### PR TITLE
fix: Remove 'atty' dep for GHSA-g98v-hv3f-hcfr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,17 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,7 +785,6 @@ dependencies = [
 name = "hc_shell"
 version = "0.1.0"
 dependencies = [
- "atty",
  "duct",
  "hc_common",
  "hc_report",
@@ -834,15 +822,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -954,7 +933,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]

--- a/libs/hc_shell/Cargo.toml
+++ b/libs/hc_shell/Cargo.toml
@@ -6,7 +6,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-atty = "0.2.14"
 duct = "0.13.5"
 hc_common = { path = "../hc_common" }
 hc_report = { path = "../hc_report" }

--- a/libs/hc_shell/src/lib.rs
+++ b/libs/hc_shell/src/lib.rs
@@ -84,7 +84,6 @@
 
 #![deny(missing_docs)]
 
-use atty::is as is_atty;
 use hc_common::{
 	error::{Error, Result},
 	hc_error, log, serde_json,
@@ -92,6 +91,9 @@ use hc_common::{
 use hc_report::{Format, PrReport, RecommendationKind, Report};
 use std::cell::Cell;
 use std::fmt::{self, Debug, Formatter};
+use std::io::stderr;
+use std::io::stdout;
+use std::io::IsTerminal as _;
 use std::io::Write;
 use std::ops::Not as _;
 use std::str::FromStr;
@@ -800,7 +802,7 @@ pub struct Output {
 impl Output {
 	/// Create a new Output wrapping stdout.
 	pub fn stdout(color_choice: ColorChoice) -> Output {
-		let is_atty = is_atty(atty::Stream::Stdout);
+		let is_atty = stdout().is_terminal();
 		let color_choice = color_choice.to_termcolor(is_atty);
 		Output {
 			out: Box::new(StandardStream::stdout(color_choice)),
@@ -810,7 +812,7 @@ impl Output {
 
 	/// Create a new Output wrapping stderr.
 	pub fn stderr(color_choice: ColorChoice) -> Output {
-		let is_atty = is_atty(atty::Stream::Stderr);
+		let is_atty = stderr().is_terminal();
 		let color_choice = color_choice.to_termcolor(is_atty);
 		Output {
 			out: Box::new(StandardStream::stderr(color_choice)),


### PR DESCRIPTION
This commit removes `atty` as a dependency. The Rust standard library
provides the same functionality built in now, and `atty` has a known
low-severity vulnerability and is unmaintained.

Signed-off-by: Andrew Lilley Brinker <abrinker@mitre.org>