### PR TITLE
Removed dead code.

### DIFF
--- a/hipcheck/src/data.rs
+++ b/hipcheck/src/data.rs
@@ -212,11 +212,9 @@ pub fn get_single_pull_request_review_from_github(
 
 // Module structs/enums
 
-#[allow(unused)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize)]
 pub enum Relationship {
 	Child,
-	Import,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]

--- a/hipcheck/src/data/es_lint/mod.rs
+++ b/hipcheck/src/data/es_lint/mod.rs
@@ -7,23 +7,9 @@ use crate::context::Context as _;
 use crate::error::Result;
 use command::ESLintCommand;
 use data::ESLintReports;
-use semver::Version;
 
 pub mod command;
 pub mod data;
-
-#[allow(unused)]
-pub fn get_eslint_version() -> Result<String> {
-	ESLintCommand::internal([OsStr::new("--version")])?.output()
-}
-
-#[allow(unused)]
-pub fn parse_eslint_version(version: &str) -> Result<Version> {
-	// semver's parser will not accept the leading 'v' or trailing newline
-	let version = version.strip_prefix('v').unwrap_or(version);
-	let version = version.trim_end();
-	Ok(Version::parse(version)?)
-}
 
 // rustfmt insists on splitting the args into separate lines,
 // reducing readability
@@ -51,15 +37,7 @@ mod test {
 	use crate::command_util::DependentProgram;
 	use std::fs::File;
 	use std::io::Write;
-
 	use tempfile::tempdir;
-
-	#[test]
-	#[ignore = "can't guarantee availability of ESLint"]
-	fn parse_version() {
-		let version = get_eslint_version().unwrap();
-		DependentProgram::EsLint.check_version(&version).unwrap();
-	}
 
 	#[test]
 	#[ignore = "can't guarantee availability of ESLint"]

--- a/hipcheck/src/data/git/mod.rs
+++ b/hipcheck/src/data/git/mod.rs
@@ -10,7 +10,6 @@ pub use query::*;
 
 use crate::context::Context as _;
 pub use crate::data::git_command::*;
-use crate::error::Error;
 use crate::error::Result;
 use std::path::Path;
 
@@ -58,17 +57,6 @@ pub fn get_commits_from_date(repo: &Path, date: &str) -> Result<Vec<RawCommit>> 
 	.context(msg)?;
 
 	git_log(&raw_output)
-}
-
-#[allow(unused)]
-pub fn get_last_commit(repo: &Path) -> Result<RawCommit> {
-	let mut raw_commits = get_commits(repo)?;
-
-	if raw_commits.is_empty() {
-		Err(Error::msg("no commits"))
-	} else {
-		Ok(raw_commits.remove(0))
-	}
 }
 
 pub fn get_diffs(repo: &Path) -> Result<Vec<Diff>> {

--- a/hipcheck/src/data/query/mod.rs
+++ b/hipcheck/src/data/query/mod.rs
@@ -10,8 +10,6 @@ mod github;
 mod module;
 mod pr_review;
 
-#[allow(unused)]
-pub use code_quality::CodeQualityProvider;
 pub use code_quality::CodeQualityProviderStorage;
 pub use dependencies::DependenciesProvider;
 pub use dependencies::DependenciesProviderStorage;

--- a/hipcheck/src/error.rs
+++ b/hipcheck/src/error.rs
@@ -76,26 +76,6 @@ impl Error {
 		}
 	}
 
-	#[allow(unused)]
-	/// Get the next error in the chain.
-	pub fn source(&self) -> Option<&(dyn StdError + 'static)> {
-		self.head.source()
-	}
-
-	#[allow(unused)]
-	/// Get the root error of the chain.
-	pub fn root_cause(&self) -> Error {
-		let mut current = &self.head;
-
-		while let Some(next) = &current.next {
-			current = next;
-		}
-
-		Error {
-			head: Rc::clone(current),
-		}
-	}
-
 	/// Get an iterator over the errors in a chain.
 	pub fn chain(&self) -> Chain {
 		Chain::new(self)

--- a/hipcheck/src/filesystem.rs
+++ b/hipcheck/src/filesystem.rs
@@ -4,7 +4,6 @@ use crate::context::Context as _;
 use crate::error::Result;
 use crate::hc_error;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::fs;
 use std::fs::File;
 use std::ops::Not;
@@ -53,27 +52,6 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()>
 	}
 
 	inner(path.as_ref(), contents.as_ref())
-}
-
-/// Write JSON to a file.
-#[allow(unused)]
-pub fn write_json<P: AsRef<Path>, T: ?Sized + Serialize>(path: P, value: &T) -> Result<()> {
-	// The non-generic inner function (NGIF) trick is useless here, since T would still be generic,
-	// so instead we do this conversion up-front to avoid borrowing issues with the `with_context`
-	// closure taking ownership of `path`.
-	let path = path.as_ref();
-	let mut file = create(path)?;
-	serde_json::to_writer_pretty(&mut file, value)
-		.with_context(|| format!("failed to write JSON '{}'", path.display()))
-}
-
-/// Create a new file.
-pub fn create<P: AsRef<Path>>(path: P) -> Result<File> {
-	fn inner(path: &Path) -> Result<File> {
-		File::create(path).with_context(|| format!("failed to create file '{}'", path.display()))
-	}
-
-	inner(path.as_ref())
 }
 
 /// Open an existing file.

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -10,6 +10,7 @@ mod filesystem;
 mod pathbuf;
 mod report;
 mod shell;
+#[cfg(test)]
 mod test_util;
 #[cfg(test)]
 mod tests;
@@ -777,10 +778,6 @@ const HIPCHECK_TOML_FILE: &str = "Hipcheck.toml";
 // Constants for exiting with error codes.
 /// Indicates the program failed.
 const EXIT_FAILURE: i32 = 1;
-
-#[allow(unused)]
-/// Indicates the program succeeded.
-const EXIT_SUCCESS: i32 = 0;
 
 //used in hc_session::pm and main.rs, global variables for hc check CheckKindHere node-ipc@9.2.1
 enum CheckKind {

--- a/hipcheck/src/report.rs
+++ b/hipcheck/src/report.rs
@@ -1036,8 +1036,6 @@ macro_rules! pr_count_constructor {
 	};
 }
 
-// Unused for now
-#[allow(unused_macros)]
 macro_rules! pr_percent_constructor {
 	( $name:tt ) => {
 		pr_constructor!($name(f64), Percent);

--- a/hipcheck/src/test_util.rs
+++ b/hipcheck/src/test_util.rs
@@ -20,7 +20,6 @@ lazy_static! {
 /// before unwinding the panic.
 ///
 /// Credit: Fabian Braun at https://stackoverflow.com/a/67433684
-#[allow(unused)]
 pub fn with_env_vars<F>(kvs: Vec<(&str, Option<&str>)>, closure: F)
 where
 	F: Fn() + UnwindSafe + RefUnwindSafe,


### PR DESCRIPTION
This commit removes all "#[allow(unused)]` annotations and all the dead code that removal of those annotations revealed. This is code that isn't used today and which we don't expect to use in the future, though of course it exists in the project history so we can get it back if we really need to.