### PR TITLE
Fix double-version command in `xtask`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,6 @@
 [alias]
-xtask = "run --package xtask --bin xtask --quiet --"
+xtask = "run --package xtask --bin xtask --"
 
 [build]
 target-dir = ".target"
 incremental = true
-
-[profile.dev]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0
-

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
 	let matches = Command::new("xtask")
 		.about("Hipcheck development task runner.")
 		.version(crate_version!())
+		.disable_version_flag(true)
 		.arg(
 			Arg::new("help")
 				.short('h')


### PR DESCRIPTION
This commit fixes a runtime error that was stopping `cargo xtask` from running at all. Basically, we define a custom `--version` command, which was conflicting with the one automatically generated by `clap`, resulting in a runtime failure.

This command just adds a line telling `clap` not to generate its own `version` flag, resolving the error and allowing `xtask` to run as expected.