### PR TITLE
Add missing license notices.

### DIFF
--- a/hipcheck/src/data/github/authenticated_agent.rs
+++ b/hipcheck/src/data/github/authenticated_agent.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //! Defines an authenticated [`Agent`] type that adds token auth to all requests.
 
 use std::sync::Arc;

--- a/hipcheck/src/data/github/hidden.rs
+++ b/hipcheck/src/data/github/hidden.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;


### PR DESCRIPTION
This commit adds SPDX license notice comments to the top of two source files that were missing it. These were identified with the `cargo xtask validate` command.