### PR TITLE
fix: Fix broken `cargo-dist` build.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.14.1/cargo-dist-installer.sh | sh"
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.
@@ -167,7 +167,7 @@ jobs:
           submodules: recursive
       - name: Install cargo-dist
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.14.1/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@v4
@@ -212,7 +212,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.14.1/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
         uses: actions/download-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,40 +19,53 @@ members = ["hipcheck", "xtask"]
 # See `.cargo/config.toml` for how this is done.
 default-members = ["hipcheck"]
 
-
-#============================================================================
-# `cargo-dist` Configuration
-#
-# We use `cargo-dist` to automate building and publishing prebuilt binaries
-# for Hipcheck releases. It runs in CI on GitHub Actions and is triggered
-# by pushing new release tags with `cargo-release`.
-#----------------------------------------------------------------------------
-
+# Config for 'cargo dist'
 [workspace.metadata.dist]
-
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.13.3"
-
+cargo-dist-version = "0.14.1"
 # CI backends to support
-ci = ["github"]
-
+ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
-
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
+    #------------------------------------------------------------------------
+    # macOS Targets
+
+    # Arm64 macOS
     "aarch64-apple-darwin",
+    # x64 macOS
     "x86_64-apple-darwin",
+
+    #------------------------------------------------------------------------
+    # Linux Targets
+
+    # x64 Linux (glibc)
     "x86_64-unknown-linux-gnu",
+    # Arm64 Linux (glibc)
+    "aarch64-unknown-linux-gnu",
+    # x64 Linux (musl libc)
     "x86_64-unknown-linux-musl",
+    # Arm64 Linux (musl libc)
+    "aarch64-unknown-linux-musl",
+
+    #------------------------------------------------------------------------
+    # Windows Targets
+
+    # x64 Windows with the MSVC toolchain
     "x86_64-pc-windows-msvc",
 ]
-
 # Publish jobs to run in CI
 pr-run-mode = "plan"
-
 # Whether to install an updater program
 install-updater = true
+
+[workspace.metadata.dist.dependencies.apt]
+# Just grab the latest version of OpenSSL for Ubuntu.
+# This is required for `musl` builds, which want to statically link to
+# OpenSSL. Note that even for `musl` builds `cargo-dist` is using
+# Ubuntu and not Alpine or something else.
+libssl-dev = "*"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
This commit does three things:

- Updates to the latest version of `cargo-dist`
- Expands the set of targets we build for.
- (Should) fix building for `musl` targets by making sure we have OpenSSL dev files installed to support static linking.