### PR TITLE
add `xtask changelog` command.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-xtask = "run --package xtask --bin xtask --"
+xtask = "run --package xtask --bin xtask --quiet --"
 
 [build]
 target-dir = ".target"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # dotenv env configuration file
 .env
+
+# We generate a file with this name when prepping each release, and don't
+# want it to be checked in.
+CHANGELOG-NEXT.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,13 +1750,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
+name = "xshell"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db0ab86eae739efd1b054a8d3d16041914030ac4e01cd1dca0cf252fd8b6437"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d422e8e38ec76e2f06ee439ccc765e9c6a9638b9e7c9f2e8255e4d41e8bd852"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
- "duct",
  "env_logger",
  "glob",
  "log",
@@ -1764,4 +1778,5 @@ dependencies = [
  "serde",
  "toml",
  "which",
+ "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,12 +106,15 @@ consolidate-commits = false
 
 [workspace.metadata.git-cliff.changelog]
 
-body = """
+header = """
 # Hipcheck Changelog
 
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning].
 
+"""
+
+body = """
 {% if version -%}
     ## [{{ version | split(pat="-") | last | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
@@ -145,9 +148,31 @@ project adheres to [Semantic Versioning].
 
 {% if version %}
     {% if previous.version %}
-    **Full Changelog**: <{{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}>
+    __Full Changelog__: <{{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}>
     {% endif %}
 {% endif %}
+
+{% if version -%}
+    {% if previous.version -%}
+        [{{ version | split(pat="-") | last | trim_start_matches(pat="v") }}]: \
+            https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                /compare/{{ previous.version }}..{{ version }}
+    {% else -%}
+        {% set first_commit = "4372390" %}
+        [{{ version | split(pat="-") | last | trim_start_matches(pat="v") }}]: \
+            https://github.com/{{ remote.github.owner }}/{{remote.github.repo}}\
+                /compare/{{ first_commit }}..HEAD
+    {% endif -%}
+{% else -%}
+    {% if previous.version -%}
+        [Unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+            /compare/{{ previous.version }}..HEAD
+    {% else -%}
+        {% set first_commit = "4372390" %}
+        [Unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+            /compare/{{ first_commit }}..HEAD
+    {% endif -%}
+{% endif -%}
 
 {%- macro remote_url() -%}
   https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
@@ -159,31 +184,6 @@ project adheres to [Semantic Versioning].
 """
 
 footer = """
-{% for release in releases -%}
-    {% if release.version -%}
-        {% if release.previous -%}
-            {% if release.previous.version -%}
-                [{{ release.version | split(pat="-") | last | trim_start_matches(pat="v") }}]: \
-                    https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
-                        /compare/{{ release.previous.version }}..{{ release.version }}
-            {% endif -%}
-        {% else -%}
-            {% set first_commit = "4372390" %}
-            [{{ release.version }}]: https://github.com/{{ remote.github.owner }}/{{remote.github.repo}}\
-                /compare/{{ first_commit }}..HEAD
-        {% endif -%}
-    {% else -%}
-        {% if release.previous.version -%}
-            [Unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
-                /compare/{{ release.previous.version }}..HEAD
-        {% else -%}
-            {% set first_commit = "4372390" %}
-            [Unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
-                /compare/{{ first_commit }}..HEAD
-        {% endif -%}
-    {% endif -%}
-{% endfor -%}
-
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 """
 
@@ -232,6 +232,9 @@ filter_commits = true
 
 # Regex for matching git tags
 tag_pattern = "v[0-9].*"
+
+[workspace.metadata.git-cliff.bump]
+features_always_bump_minor = false
 
 # Configures GitHub integration, which lets `git-cliff` augments the
 # generated `CHANGELOG.md` with additional GitHub info.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 anyhow = "1.0.83"
 clap = { version = "4.5.4", features = ["cargo", "derive"] }
 clap-verbosity-flag = "2.2.0"
-duct = "0.13.5"
 env_logger = "0.11.3"
 log = "0.4.21"
 glob = "0.3.0"
 pathbuf = "1.0.0"
 serde = { version = "1.0.133", features = ["derive"] }
 toml = "0.8.12"
+xshell = "0.2.6"
 which = "6.0.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,9 @@
 mod task;
 mod workspace;
 
-use clap::Parser;
+use clap::Parser as _;
+use clap_verbosity_flag::Verbosity;
+use clap_verbosity_flag::WarnLevel;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -11,20 +13,33 @@ fn main() -> ExitCode {
 
 	env_logger::Builder::new()
 		.filter_level(args.verbose.log_level_filter())
+		.format_timestamp(None)
+		.format_module_path(false)
+		.format_target(false)
+		.format_indent(Some(8))
 		.init();
 
-	match args.command {
-		Commands::Validate => task::validate::run(),
+	let result = match args.command {
+		Commands::Check => task::check::run(),
 		Commands::Ci => task::ci::run(),
+		Commands::Changelog(args) => task::changelog::run(args),
+	};
+
+	match result {
+		Ok(_) => ExitCode::SUCCESS,
+		Err(e) => {
+			log::error!("{}", e);
+			ExitCode::FAILURE
+		}
 	}
 }
 
 /// Hipcheck development task runner.
 #[derive(Debug, clap::Parser)]
-#[clap(about, version)]
+#[clap(about, version, long_about = None, propagate_version = true)]
 struct Args {
 	#[clap(flatten)]
-	verbose: clap_verbosity_flag::Verbosity,
+	verbose: Verbosity<WarnLevel>,
 
 	#[clap(subcommand)]
 	command: Commands,
@@ -33,7 +48,27 @@ struct Args {
 #[derive(Debug, clap::Subcommand)]
 enum Commands {
 	/// Run a variety of quality checks.
-	Validate,
+	Check,
 	/// Simulate a CI run locally.
 	Ci,
+	/// Generate a draft CHANGELOG
+	Changelog(ChangelogArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ChangelogArgs {
+	/// Whether to bump the version, else new commits are "unreleased"
+	#[clap(short = 'b', long = "bump")]
+	bump: bool,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Args;
+	use clap::CommandFactory;
+
+	#[test]
+	fn verify_cli() {
+		Args::command().debug_assert()
+	}
 }

--- a/xtask/src/task/changelog.rs
+++ b/xtask/src/task/changelog.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ChangelogArgs;
+use anyhow::Result;
+use log::LevelFilter;
+use xshell::cmd;
+use xshell::Shell;
+
+/// Execute the changelog task.
+pub fn run(args: ChangelogArgs) -> Result<()> {
+	let sh = Shell::new()?;
+
+	// Get the root of the workspace, and make sure the shell is in it.
+	// `git-cliff` expects to be run from the root of the workspace.
+	let root = crate::workspace::root()?;
+	sh.change_dir(root);
+
+	// Warn the user about what version we're bumping to.
+	//
+	// Avoid running the extra external command if we won't see the result.
+	if log::max_level() >= LevelFilter::Warn {
+		let new_version = {
+			let full = cmd!(sh, "git cliff --bumped-version").read()?;
+			full.strip_prefix("hipcheck-").unwrap_or(&full).to_owned()
+		};
+
+		log::warn!(
+			"bumping to {}; this may not be the version you want",
+			new_version
+		);
+	}
+
+	// We don't overwrite the CHANGELOG.md file, and instead by default
+	// write to a different output file.
+	let output = "CHANGELOG-NEXT.md";
+
+	// Only include the bump flag if requested by the user.
+	let bump = args.bump.then_some("--bump");
+	cmd!(sh, "git cliff {bump...} -o {output}")
+		.quiet()
+		.ignore_stdout()
+		.ignore_stderr()
+		.run()?;
+
+	log::warn!("finished; check {} to proceed", output);
+	Ok(())
+}

--- a/xtask/src/task/check.rs
+++ b/xtask/src/task/check.rs
@@ -22,19 +22,9 @@ use std::io::BufReader;
 use std::ops::Not as _;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::ExitCode;
 
 /// Print list of validation failures for crates in the workspace.
-pub fn run() -> ExitCode {
-	if let Err(e) = inner() {
-		log::error!("{}", e);
-		return ExitCode::FAILURE;
-	}
-
-	ExitCode::SUCCESS
-}
-
-fn inner() -> Result<()> {
+pub fn run() -> Result<()> {
 	log::info!("beginning validation");
 
 	let workspace = Workspace::resolve()?;

--- a/xtask/src/task/mod.rs
+++ b/xtask/src/task/mod.rs
@@ -2,5 +2,6 @@
 
 //! Commands supported by 'xtask'
 
+pub mod changelog;
+pub mod check;
 pub mod ci;
-pub mod validate;

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use std::path::Path;
 use std::path::PathBuf;
 
+/// Get the root directory of the workspace.
 pub fn root() -> Result<PathBuf> {
 	Path::new(&env!("CARGO_MANIFEST_DIR"))
 		.ancestors()


### PR DESCRIPTION
This commit introduces a new `xtask changelog` command to `cargo xtask`, to help produce automated changelogs which can be the basis for updating `CHANGELOG.md`. This new command _does not_ overwrite `CHANGELOG.md`, but instead writes its auto-generated changelog to `CHANGELOG-NEXT.md`, which is also marked in `.gitignore` so it doesn't get checked in. The goal here is that this automation will _help_ write changelogs for each new version, but doesn't turn the changelog into a fully-automated system, as we still want to be able to have human-written release notes.