### PR TITLE
chore: Do not run tests if changes outside code folders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'config/**'
+      - 'hipcheck/**'
+      - 'scripts/**'
+      - 'xtask/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'config/**'
+      - 'hipcheck/**'
+      - 'scripts/**'
+      - 'xtask/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Filter GitHub workflow to not run tests if changes to a push or pull-request are outside of code folders `config`, `hipcheck`, `scripts`, or `xtask`.