### PR TITLE
Add `cargo xtask rfd` subcommand with convenience methods for interacting with RFDs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1780,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
+ "convert_case",
  "env_logger",
  "glob",
  "log",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0.133", features = ["derive"] }
 toml = "0.8.12"
 xshell = "0.2.6"
 which = "6.0.1"
+convert_case = "0.6.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> ExitCode {
 		Commands::Check => task::check::run(),
 		Commands::Ci => task::ci::run(),
 		Commands::Changelog(args) => task::changelog::run(args),
+		Commands::Rfd(args) => task::rfd::run(args),
 	};
 
 	match result {
@@ -47,19 +48,42 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Commands {
-	/// Run a variety of quality checks.
+	/// Run a variety of quality checks
 	Check,
-	/// Simulate a CI run locally.
+	/// Simulate a CI run locally
 	Ci,
 	/// Generate a draft CHANGELOG
 	Changelog(ChangelogArgs),
+	/// Interact with Hipcheck RFDs
+	Rfd(RfdArgs),
 }
 
 #[derive(Debug, clap::Args)]
-pub struct ChangelogArgs {
+struct ChangelogArgs {
 	/// Whether to bump the version, else new commits are "unreleased"
 	#[clap(short = 'b', long = "bump")]
 	bump: bool,
+}
+
+#[derive(Debug, clap::Args)]
+struct RfdArgs {
+	#[clap(subcommand)]
+	command: RfdCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum RfdCommand {
+	/// List existing RFDs
+	List,
+	/// Create a new RFD
+	New(NewRfdArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct NewRfdArgs {
+	/// The ID number to use for the RFD; inferred by default
+	#[arg(short = 'n', long = "number")]
+	number: Option<u16>,
 }
 
 #[cfg(test)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,6 +84,9 @@ struct NewRfdArgs {
 	/// The ID number to use for the RFD; inferred by default
 	#[arg(short = 'n', long = "number")]
 	number: Option<u16>,
+
+	/// The title to give the RFD
+	title: String,
 }
 
 #[cfg(test)]

--- a/xtask/src/task/mod.rs
+++ b/xtask/src/task/mod.rs
@@ -5,3 +5,4 @@
 pub mod changelog;
 pub mod check;
 pub mod ci;
+pub mod rfd;

--- a/xtask/src/task/rfd.rs
+++ b/xtask/src/task/rfd.rs
@@ -1,0 +1,54 @@
+use crate::NewRfdArgs;
+use crate::RfdArgs;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use convert_case::Case;
+use convert_case::Casing as _;
+use glob::glob;
+
+/// Run the `rfd` command.
+pub fn run(args: RfdArgs) -> Result<()> {
+	match args.command {
+		crate::RfdCommand::List => list(),
+		crate::RfdCommand::New(args) => new(args),
+	}
+}
+
+fn list() -> Result<()> {
+	let root = crate::workspace::root()?;
+	let pattern = format!("{}/docs/rfds/*.md", root.display());
+
+	for entry in glob(&pattern)? {
+		match entry {
+			Err(e) => log::warn!("{}", e),
+			Ok(path) => {
+				let file_name = path
+					.file_name()
+					.context("no file name on markdown file")?
+					.to_str()
+					.ok_or_else(|| anyhow!("invalid RFD file name"))?;
+
+				// Skip the README
+				if file_name == "README.md" {
+					continue;
+				}
+
+				let (id, name) = file_name
+					.split_once("-")
+					.ok_or_else(|| anyhow!("no numeric delimiter found"))?;
+
+				let name = name.strip_suffix(".md").unwrap_or(name);
+				let name = name.to_case(Case::Title);
+
+				log::warn!("RFD #{}: {}", id, name);
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn new(_args: NewRfdArgs) -> Result<()> {
+	todo!()
+}

--- a/xtask/src/task/rfd.rs
+++ b/xtask/src/task/rfd.rs
@@ -1,11 +1,14 @@
 use crate::NewRfdArgs;
 use crate::RfdArgs;
 use anyhow::anyhow;
-use anyhow::Context;
 use anyhow::Result;
 use convert_case::Case;
 use convert_case::Casing as _;
 use glob::glob;
+use glob::Paths;
+use pathbuf::pathbuf;
+use std::fs::File;
+use std::path::PathBuf;
 
 /// Run the `rfd` command.
 pub fn run(args: RfdArgs) -> Result<()> {
@@ -15,40 +18,169 @@ pub fn run(args: RfdArgs) -> Result<()> {
 	}
 }
 
+/// List all the RFDs checked into the repo.
 fn list() -> Result<()> {
-	let root = crate::workspace::root()?;
-	let pattern = format!("{}/docs/rfds/*.md", root.display());
-
-	for entry in glob(&pattern)? {
-		match entry {
-			Err(e) => log::warn!("{}", e),
-			Ok(path) => {
-				let file_name = path
-					.file_name()
-					.context("no file name on markdown file")?
-					.to_str()
-					.ok_or_else(|| anyhow!("invalid RFD file name"))?;
-
-				// Skip the README
-				if file_name == "README.md" {
-					continue;
-				}
-
-				let (id, name) = file_name
-					.split_once("-")
-					.ok_or_else(|| anyhow!("no numeric delimiter found"))?;
-
-				let name = name.strip_suffix(".md").unwrap_or(name);
-				let name = name.to_case(Case::Title);
-
-				log::warn!("RFD #{}: {}", id, name);
-			}
-		}
+	for rfd in rfds()? {
+		log::warn!("RFD #{}: {}", rfd.id_string, rfd.title);
 	}
 
 	Ok(())
 }
 
-fn new(_args: NewRfdArgs) -> Result<()> {
-	todo!()
+/// Create a new RFD.
+fn new(args: NewRfdArgs) -> Result<()> {
+	let root = crate::workspace::root()?;
+
+	let id = match args.number {
+		Some(id) => id,
+		None => guess_next_id()?,
+	};
+
+	let title = args.title.to_case(Case::Kebab);
+	let file_name = format!("{:04}-{}.md", id, title);
+	let path = pathbuf![&root, "docs", "rfds", &file_name];
+	let _ = File::create_new(path)?;
+	log::warn!(
+		"created draft RFD #{}: \"{}\", at '{}'",
+		id,
+		args.title,
+		pathbuf!["docs", "rfds", &file_name].display()
+	);
+	Ok(())
+}
+
+fn guess_next_id() -> Result<u16> {
+	let highest_id = rfds()?.fold(0, |highest_id, rfd| {
+		if rfd.id > highest_id {
+			rfd.id
+		} else {
+			highest_id
+		}
+	});
+
+	highest_id
+		.checked_add(1)
+		.ok_or_else(|| anyhow!("RFD IDs overflow a u16"))
+}
+
+/// Get an iterator over all RFDs.
+fn rfds() -> Result<RfdIter> {
+	RfdIter::new()
+}
+
+/// A single RFD.
+#[derive(Debug)]
+struct Rfd {
+	#[allow(unused)]
+	/// The path to the RFD file.
+	path: PathBuf,
+
+	#[allow(unused)]
+	/// The name of the RFD file.
+	file_name: String,
+
+	/// The numeric ID of the RFD.
+	id: u16,
+
+	/// The left-0 padded form of the RFD ID.
+	id_string: String,
+
+	/// The title of the RFD.
+	title: String,
+}
+
+/// An iterator over RFDs.
+#[derive(Debug)]
+struct RfdIter {
+	/// The internal glob-based iterator.
+	paths: Paths,
+}
+
+impl RfdIter {
+	/// Get a new RFD iterator.
+	fn new() -> Result<Self> {
+		let root = crate::workspace::root()?;
+		let pattern = format!("{}/docs/rfds/*.md", root.display());
+		let paths = glob(&pattern)?;
+		Ok(RfdIter { paths })
+	}
+}
+
+impl Iterator for RfdIter {
+	type Item = Rfd;
+
+	// This is a bit of a weird iterator. Basically, we log errors but don't return
+	// `None`, for them, preferring instead to call `self.next()` again, effectively
+	// behaving like a `continue` in a `for`-loop.
+	fn next(&mut self) -> Option<Self::Item> {
+		match self.paths.next() {
+			Some(Ok(path)) => {
+				// Get the possibly-not-UTF-8 file name.
+				let raw_file_name = match path.file_name() {
+					Some(file_name) => file_name,
+					None => {
+						log::warn!("path has no file name: {}", path.display());
+						return self.next();
+					}
+				};
+
+				// Get the file name as UTF-8.
+				let file_name = match raw_file_name.to_str() {
+					Some(file_name) => file_name,
+					None => {
+						log::warn!(
+							"file name is not UTF-8: {}",
+							raw_file_name.to_string_lossy()
+						);
+						return self.next();
+					}
+				};
+
+				// Skip the README
+				if file_name == "README.md" {
+					return self.next();
+				}
+
+				// Split the ID from the title portion of the file name.
+				let (id_string, name) = match file_name.split_once('-') {
+					Some(pair) => pair,
+					None => {
+						log::warn!("invalid RFD file name found: {}", file_name);
+						return self.next();
+					}
+				};
+
+				// Put the title into the correct format.
+				let title = name
+					.strip_suffix(".md")
+					.unwrap_or(name)
+					.to_case(Case::Title);
+
+				// Parse the numeric ID.
+				let id = match id_string.trim_start_matches('0').parse().ok() {
+					Some(id) => id,
+					None => {
+						log::warn!("invalid ID found: {}", id_string);
+						return self.next();
+					}
+				};
+
+				// And we're done!
+				let rfd = Rfd {
+					path: path.clone(),
+					file_name: file_name.to_owned(),
+					id,
+					id_string: id_string.to_owned(),
+					title,
+				};
+
+				Some(rfd)
+			}
+			Some(Err(e)) => {
+				log::warn!("{}", e);
+				self.next()
+			}
+			None => None,
+		}
+	}
 }


### PR DESCRIPTION
As the title says, this PR adds a new `cargo xtask rfd` command with two subcommands:

- `cargo xtask rfd list`: List all merged RFDs.
- `cargo xtask rfd new`: Create a new, draft RFD.

These are basic conveniences now, but in the future I'd love to do more to, for example, use the GitHub API to link to and open RFDs which are under consideration.