### PR TITLE
fix: Removes missing /libs folder from Container file

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,11 +13,9 @@ WORKDIR /build
 #
 # 1) Our Cargo configuration.
 # 2) The main Hipcheck crate.
-# 3) Hipcheck's internal libraries.
-# 4) The current Crate manifest and lockfile.
+# 3) The current Crate manifest and lockfile.
 COPY .cargo/ .cargo/
 COPY hipcheck/ hipcheck/
-COPY libs/ libs/
 COPY Cargo.toml Cargo.lock ./
 
 # Prep the system.


### PR DESCRIPTION
When we combined all of Hipcheck's crates into a single binary crate, we did away with the need for a `/libs` folder. The `Container` file was never updated to no longer try to copy the contents of this folder during the Docker installation procedure. This removes that unnecessary and `docker build` breaking copy from the `Container` file.