### PR TITLE
chore (cli): Changes hc CLI to use compile-time "derive" syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,17 @@ on:
   push:
     branches: [main]
     paths:
-      - 'config/**'
-      - 'hipcheck/**'
-      - 'scripts/**'
-      - 'xtask/**'
+      - "config/**"
+      - "hipcheck/**"
+      - "scripts/**"
+      - "xtask/**"
   pull_request:
     branches: [main]
     paths:
-      - 'config/**'
-      - 'hipcheck/**'
-      - 'scripts/**'
-      - 'xtask/**'
+      - "config/**"
+      - "hipcheck/**"
+      - "scripts/**"
+      - "xtask/**"
 
 permissions:
   contents: read
@@ -34,10 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Dependency Tree
+        run: cargo tree
       - name: Build
         run: cargo build --verbose --workspace
       - name: Test
         run: cargo test --verbose --workspace
       - name: Lint
         run: cargo clippy --verbose --workspace
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "content_inspector",
  "dirs",
  "dotenv",
@@ -946,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -1054,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -191,7 +191,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -245,9 +245,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "dirs"
@@ -296,9 +296,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "env_filter"
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -796,9 +796,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -1018,7 +1018,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1190,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1222,22 +1222,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1449,7 +1449,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -1471,7 +1471,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -19,10 +19,8 @@ path = "src/main.rs"
 content_inspector = "0.2.4"
 dotenv = "0.15.0"
 chrono = { version = "0.4.19", features = ["serde"] }
-clap = { version = "4.5.4", default-features = false, features = [
-    "string",
-    "std",
-] }
+clap = { version = "4.5.4", default-features = false, features = ["string", "std", "derive"] }
+clap-verbosity-flag = "2.2.0"
 dirs = "5.0.1"
 duct = "0.13.5"
 env_logger = { version = "0.11.3" }

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Data structures for Hipcheck's main CLI.
+
+use clap::Parser as _;
+
+/// Automatically assess and score git repositories for risk
+#[derive(Debug, clap::Parser)]
+#[command(about, disable_help_flag=true, disable_version_flag=true, long_about=None)]
+pub struct Args {
+	/// print help text
+	#[arg(short = 'h', long = "help")]
+	pub extra_help: bool,
+
+	/// print version information
+	#[arg(short = 'V', long, global = true)]
+	pub version: bool,
+
+	/// print the home directory for Hipcheck
+	#[arg(long = "print-home", global = true)]
+	pub print_home: bool,
+
+	/// print the config file path for Hipcheck
+	#[arg(long = "print-config", global = true)]
+	pub print_config: bool,
+
+	/// print the data folder path for Hipcheck
+	#[arg(long = "print-data", global = true)]
+	pub print_data: bool,
+
+	/// silences progress reporting
+	#[arg(short = 'q', long = "quiet", global = true)]
+	pub verbosity: bool,
+
+	/// set output coloring ('always', 'never', or 'auto')
+	#[arg(
+		short = 'k',
+		long,
+		default_value = "auto",
+		value_name = "COLOR",
+		global = true
+	)]
+	pub color: Option<String>,
+
+	/// path to the configuration file
+	#[arg(short, long, value_name = "FILE", global = true)]
+	pub config: Option<String>,
+
+	/// path to the data folder
+	#[arg(short, long, value_name = "FILE", global = true)]
+	pub data: Option<String>,
+
+	/// path to the hipcheck home
+	#[arg(short = 'H', long, value_name = "FILE", global = true)]
+	pub home: Option<String>,
+
+	/// output results in JSON format
+	#[arg(short, long, global = true)]
+	pub json: bool,
+
+	#[command(subcommand)]
+	pub command: Commands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum Commands {
+	/// Analyzes a repository or pull/merge request
+	#[command(disable_help_subcommand = true)]
+	Check(CheckArgs),
+	/// Print help information, optionally for a given subcommand
+	Help(HelpArgs),
+	/// Print the schema for JSON-format output for a specified subtarget
+	#[command(disable_help_subcommand = true)]
+	Schema(SchemaArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckArgs {
+	/// print help text
+	#[arg(short = 'h', long = "help", global = true)]
+	pub extra_help: bool,
+
+	#[clap(subcommand)]
+	pub command: CheckCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum CheckCommand {
+	/// Analyze a maven package git repo via package URI
+	Maven(CheckMavenArgs),
+	/// Analyze an npm package git repo via package URI or with format <package name>[@<optional version>]
+	Npm(CheckNpmArgs),
+	/// Analyze 'git' patches for projects that use a patch-based workflow (not yet implemented)
+	Patch(CheckPatchArgs),
+	/// Analyze a PyPI package git repo via package URI or with format <package name>[@<optional version>]
+	Pypi(CheckPypiArgs),
+	/// Analyze a repository and output an overall risk assessment
+	Repo(CheckRepoArgs),
+	/// Analyze pull/merge request for potential risks
+	Request(CheckRequestArgs),
+	/// Analyze packages specified in an SPDX document
+	Spdx(CheckSpdxArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckMavenArgs {
+	/// Maven package URI to analyze
+	#[arg(value_name = "PACKAGE", index = 1)]
+	pub package: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckNpmArgs {
+	/// NPM package URI or package[@<optional version>] to analyze
+	#[arg(value_name = "PACKAGE", index = 1)]
+	pub package: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckPatchArgs {
+	/// URI of git patch to analyze
+	#[arg(value_name = "PATCH FILE URI", index = 1)]
+	pub patch_file_uri: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckPypiArgs {
+	/// PyPI package URI or package[@<optional version>] to analyze"
+	#[arg(value_name = "PACKAGE", index = 1)]
+	pub package: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckRepoArgs {
+	/// Repository to analyze; can be a local path or a URI
+	#[arg(value_name = "SOURCE", index = 1)]
+	pub source: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckRequestArgs {
+	/// URI of pull/merge request to analyze
+	#[arg(value_name = "PR/MR URI", index = 1)]
+	pub pr_mr_uri: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckSpdxArgs {
+	/// SPDX document to analyze
+	#[arg(value_name = "FILEPATH", index = 1)]
+	pub filepath: String,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct HelpArgs {
+	#[clap(subcommand)]
+	pub command: Option<HelpCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum HelpCommand {
+	/// Print help information for the check subcommand
+	Check,
+	/// Print help information for the schema subcommand
+	Schema,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct SchemaArgs {
+	/// print help text
+	#[arg(short = 'h', long = "help", global = true)]
+	pub extra_help: bool,
+
+	#[clap(subcommand)]
+	pub command: SchemaCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SchemaCommand {
+	/// Print the schema for JSON-format output for running Hipcheck against a Maven package
+	Maven,
+	/// Print the schema for JSON-format output for running Hipcheck against a NPM package
+	Npm,
+	/// Print the schema for JSON-format output for running Hipcheck against a patch
+	Patch,
+	/// Print the schema for JSON-format output for running Hipcheck against a PyPI package
+	Pypi,
+	/// Print the schema for JSON-format output for running Hipcheck against a repository
+	Repo,
+	/// Print the schema for JSON-format output for running Hipcheck against a pull/merge request
+	Request,
+	/// Print the schema for JSON-format output for running Hipcheck against an SPDX document
+	Spdx,
+}

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -72,6 +72,7 @@ pub enum Commands {
 	#[command(disable_help_subcommand = true)]
 	Check(CheckArgs),
 	/// Print help information, optionally for a given subcommand
+	#[command(disable_help_subcommand = true)]
 	Help(HelpArgs),
 	/// Print the schema for JSON-format output for a specified subtarget
 	#[command(disable_help_subcommand = true)]
@@ -91,18 +92,25 @@ pub struct CheckArgs {
 #[derive(Debug, clap::Subcommand)]
 pub enum CheckCommand {
 	/// Analyze a maven package git repo via package URI
+	#[command(disable_help_subcommand = true)]
 	Maven(CheckMavenArgs),
 	/// Analyze an npm package git repo via package URI or with format <package name>[@<optional version>]
+	#[command(disable_help_subcommand = true)]
 	Npm(CheckNpmArgs),
 	/// Analyze 'git' patches for projects that use a patch-based workflow (not yet implemented)
+	#[command(disable_help_subcommand = true)]
 	Patch(CheckPatchArgs),
 	/// Analyze a PyPI package git repo via package URI or with format <package name>[@<optional version>]
+	#[command(disable_help_subcommand = true)]
 	Pypi(CheckPypiArgs),
 	/// Analyze a repository and output an overall risk assessment
+	#[command(disable_help_subcommand = true)]
 	Repo(CheckRepoArgs),
 	/// Analyze pull/merge request for potential risks
+	#[command(disable_help_subcommand = true)]
 	Request(CheckRequestArgs),
 	/// Analyze packages specified in an SPDX document
+	#[command(disable_help_subcommand = true)]
 	Spdx(CheckSpdxArgs),
 }
 
@@ -164,8 +172,10 @@ pub struct HelpArgs {
 #[derive(Debug, clap::Subcommand)]
 pub enum HelpCommand {
 	/// Print help information for the check subcommand
+	#[command(disable_help_subcommand = true)]
 	Check,
 	/// Print help information for the schema subcommand
+	#[command(disable_help_subcommand = true)]
 	Schema,
 }
 
@@ -182,16 +192,22 @@ pub struct SchemaArgs {
 #[derive(Debug, clap::Subcommand)]
 pub enum SchemaCommand {
 	/// Print the schema for JSON-format output for running Hipcheck against a Maven package
+	#[command(disable_help_subcommand = true)]
 	Maven,
 	/// Print the schema for JSON-format output for running Hipcheck against a NPM package
+	#[command(disable_help_subcommand = true)]
 	Npm,
 	/// Print the schema for JSON-format output for running Hipcheck against a patch
+	#[command(disable_help_subcommand = true)]
 	Patch,
 	/// Print the schema for JSON-format output for running Hipcheck against a PyPI package
+	#[command(disable_help_subcommand = true)]
 	Pypi,
 	/// Print the schema for JSON-format output for running Hipcheck against a repository
+	#[command(disable_help_subcommand = true)]
 	Repo,
 	/// Print the schema for JSON-format output for running Hipcheck against a pull/merge request
+	#[command(disable_help_subcommand = true)]
 	Request,
 }
 

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -7,7 +7,7 @@
 #[command(about, disable_help_flag=true, disable_version_flag=true, long_about=None)]
 pub struct Args {
 	/// print help text
-	#[arg(short = 'h', long = "help")]
+	#[arg(name="extra-help", short = 'h', long = "help")]
 	pub extra_help: bool,
 
 	/// print version information

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -2,8 +2,6 @@
 
 //! Data structures for Hipcheck's main CLI.
 
-use clap::Parser as _;
-
 /// Automatically assess and score git repositories for risk
 #[derive(Debug, clap::Parser)]
 #[command(about, disable_help_flag=true, disable_version_flag=true, long_about=None)]

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -194,3 +194,15 @@ pub enum SchemaCommand {
 	/// Print the schema for JSON-format output for running Hipcheck against a pull/merge request
 	Request,
 }
+
+/// Test CLI commands
+#[cfg(test)]
+mod tests {
+	use super::Args;
+	use clap::CommandFactory;
+
+	#[test]
+	fn verify_cli() {
+		Args::command().debug_assert()
+	}
+}

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -59,7 +59,7 @@ pub struct Args {
 	pub json: bool,
 
 	#[command(subcommand)]
-	pub command: Commands,
+	pub command: Option<Commands>,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -81,7 +81,7 @@ pub struct CheckArgs {
 	pub extra_help: bool,
 
 	#[clap(subcommand)]
-	pub command: CheckCommand,
+	pub command: Option<CheckCommand>,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -172,7 +172,7 @@ pub struct SchemaArgs {
 	pub extra_help: bool,
 
 	#[clap(subcommand)]
-	pub command: SchemaCommand,
+	pub command: Option<SchemaCommand>,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -189,6 +189,4 @@ pub enum SchemaCommand {
 	Repo,
 	/// Print the schema for JSON-format output for running Hipcheck against a pull/merge request
 	Request,
-	/// Print the schema for JSON-format output for running Hipcheck against an SPDX document
-	Spdx,
 }

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -78,12 +78,6 @@ pub enum Commands {
 	Schema(SchemaArgs),
 }
 
-impl Default for Commands {
-	fn default() -> Commands {
-		Commands::Help(HelpArgs { command: None })
-	}
-}
-
 #[derive(Debug, clap::Args)]
 pub struct CheckArgs {
 	/// print help text

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -62,6 +62,12 @@ pub struct Args {
 	pub command: Option<Commands>,
 }
 
+// impl Default for Args {
+// 	fn default() -> Self {
+// 		command::None
+// 	}
+// }
+
 #[derive(Debug, clap::Subcommand)]
 pub enum Commands {
 	/// Analyzes a repository or pull/merge request
@@ -72,6 +78,12 @@ pub enum Commands {
 	/// Print the schema for JSON-format output for a specified subtarget
 	#[command(disable_help_subcommand = true)]
 	Schema(SchemaArgs),
+}
+
+impl Default for Commands {
+	fn default() -> Commands {
+		Commands::Help(HelpArgs { command: None })
+	}
 }
 
 #[derive(Debug, clap::Args)]

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -228,52 +228,52 @@ impl CliArgs {
 							check_value: OsString::from(args.package),
 							parent_command_value: MAVEN.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Npm(args)) => {
 						check = Check {
 							check_type: CheckType::PackageVersion,
 							check_value: OsString::from(args.package),
 							parent_command_value: NPM.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Patch(args)) => {
 						check = Check {
 							check_type: CheckType::PatchUri,
 							check_value: OsString::from(args.patch_file_uri),
 							parent_command_value: PATCH.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Pypi(args)) => {
 						check = Check {
 							check_type: CheckType::PackageVersion,
 							check_value: OsString::from(args.package),
 							parent_command_value: PYPI.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Repo(args)) => {
 						check = Check {
 							check_type: CheckType::RepoSource,
 							check_value: OsString::from(args.source),
 							parent_command_value: REPO.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Request(args)) => {
 						check = Check {
 							check_type: CheckType::PrUri,
 							check_value: OsString::from(args.pr_mr_uri),
 							parent_command_value: REQUEST.to_string(),
 						}
-					},
+					}
 					Some(CheckCommand::Spdx(args)) => {
 						check = Check {
 							check_type: CheckType::SpdxDocument,
 							check_value: OsString::from(args.filepath),
 							parent_command_value: SPDX.to_string(),
 						}
-					},
+					}
 					None => print_check_help(),
 				}
-			},
+			}
 			Some(Commands::Schema(args)) => {
 				if args.extra_help {
 					print_schema_help();
@@ -287,7 +287,7 @@ impl CliArgs {
 					Some(SchemaCommand::Request) => print_request_schema(),
 					None => print_schema_help(),
 				}
-			},
+			}
 			None => print_help(),
 		}
 
@@ -398,7 +398,7 @@ SUBTASKS:
     pypi    <PACKAGE>     analyze a pypi package git repo via package uri or with format <package name>[@<optional version>]
     repo    <SOURCE>      analyze a repository and output an overall risk assessment
     request <PR/MR URI>   analyze pull/merge request for potential risks
-    spdx    <FILEPATH>    analyze packages specified in an SPDX document
+    spdx    <FILEPATH>    analyze packages specified in an SPDX document (not yet implemented)
 
 {}",
 		env!("CARGO_PKG_NAME"),
@@ -423,19 +423,6 @@ fn print_version() -> ! {
 	println!("{}", version_text);
 	exit(Outcome::Err.exit_code());
 }
-
-// /// Get the current version of Hipcheck as a String.
-// fn get_version() -> String {
-// 	let raw_version = env!("CARGO_PKG_VERSION", "can't find Hipcheck package version");
-
-// 	let version_text = format!(
-// 		"{} {}",
-// 		env!("CARGO_PKG_NAME"),
-// 		version::get_version(raw_version).unwrap()
-// 	);
-
-// 	version_text
-// }
 
 /// Print the JSON schema of the report.
 fn print_report_schema() -> ! {


### PR DESCRIPTION
This changes the CLI for the `hc` command to use `clap`'s "derive" syntax over the previous "build" syntax. This makes the CLI run at compile-time, which will save time when Hipcheck is run on different data sources without recompilation in between (as we expect) with typical use.

As a bonus feature, the CLI no longer panics if no command argument is provided. Instead it displays the appropriate help text, as expected.