### PR TITLE
feat: Adds hc ready command

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -71,6 +71,9 @@ pub enum Commands {
 	/// Analyzes a repository or pull/merge request
 	#[command(disable_help_subcommand = true)]
 	Check(CheckArgs),
+	/// Check if Hipcheck is ready to execute and reports status to user
+	#[command(disable_help_subcommand = true)]
+	Doctor,
 	/// Print help information, optionally for a given subcommand
 	#[command(disable_help_subcommand = true)]
 	Help(HelpArgs),

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -7,24 +7,12 @@
 #[command(about, disable_help_flag=true, disable_version_flag=true, long_about=None)]
 pub struct Args {
 	/// print help text
-	#[arg(name="extra-help", short = 'h', long = "help")]
+	#[arg(name = "extra-help", short = 'h', long = "help")]
 	pub extra_help: bool,
 
 	/// print version information
 	#[arg(short = 'V', long, global = true)]
 	pub version: bool,
-
-	/// print the home directory for Hipcheck
-	#[arg(long = "print-home", global = true)]
-	pub print_home: bool,
-
-	/// print the config file path for Hipcheck
-	#[arg(long = "print-config", global = true)]
-	pub print_config: bool,
-
-	/// print the data folder path for Hipcheck
-	#[arg(long = "print-data", global = true)]
-	pub print_data: bool,
 
 	/// silences progress reporting
 	#[arg(short = 'q', long = "quiet", global = true)]
@@ -73,7 +61,7 @@ pub enum Commands {
 	Check(CheckArgs),
 	/// Check if Hipcheck is ready to execute and reports status to user
 	#[command(disable_help_subcommand = true)]
-	Doctor,
+	Ready,
 	/// Print help information, optionally for a given subcommand
 	#[command(disable_help_subcommand = true)]
 	Help(HelpArgs),

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -79,6 +79,12 @@ pub enum Commands {
 	Schema(SchemaArgs),
 }
 
+impl Default for Commands {
+	fn default() -> Commands {
+		Commands::Help(HelpArgs { command: None })
+	}
+}
+
 #[derive(Debug, clap::Args)]
 pub struct CheckArgs {
 	/// print help text

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -523,7 +523,7 @@ fn print_readiness(
 	// Check that the Hipcheck config TOML exists in the designated location
 	let hipcheck_config = resolve_config(config_path);
 	match hipcheck_config {
-		Ok(path_buffer) => println!("Hipcheck config directory: {}", path_buffer.display()),
+		Ok(path_buffer) => println!("Hipcheck config file: {}", path_buffer.display()),
 		Err(err) => {
 			failed = true;
 			print_error(&err);

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -330,7 +330,7 @@ USAGE:
 
 TASKS:
     check <SUBTASK>       analyzes a repository or pull/merge request
-    ready                 print a report of whether or not Hipcheck is ready to run
+    ready                 print a report of whether or not Hipcheck is ready to run (experimental)
     schema <SUBTASK>      print the schema for JSON-format output for a specified subtarget
     help [<SUBTASK>]      print help information, optionally for a given subcommand
 
@@ -473,7 +473,7 @@ fn print_readiness(
 		version::get_version(raw_version).unwrap()
 	);
 	println!("{}", version_text);
-	
+
 	// Check that git is installed and that its version is up to date
 	// Print the version number either way
 	let git_check = data::git::get_git_version();

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -788,3 +788,14 @@ impl Outcome {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::Args;
+	use clap::CommandFactory;
+
+	#[test]
+	fn verify_cli() {
+		Args::command().debug_assert()
+	}
+}

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -217,6 +217,13 @@ impl CliArgs {
 				Some(HelpCommand::Check) => print_check_help(),
 				Some(HelpCommand::Schema) => print_schema_help(),
 			},
+			Some(Commands::Doctor) => {
+				print_readiness(
+					home_dir.as_deref(),
+					config_path.as_deref(),
+					data_path.as_deref(),
+				);
+			}
 			Some(Commands::Check(args)) => {
 				if args.extra_help {
 					print_check_help();
@@ -460,6 +467,35 @@ fn print_pypi_schema() -> ! {
 	print_missing()
 }
 
+fn print_readiness(
+	home_dir: Option<&Path>,
+	config_path: Option<&Path>,
+	data_path: Option<&Path>,
+) -> ! {
+	let hipcheck_home = resolve_home(home_dir);
+
+	let hipcheck_config = resolve_config(config_path);
+
+	let hipcheck_data = resolve_data(data_path);
+
+	let exit_code = match (hipcheck_home, hipcheck_config, hipcheck_data) {
+		(Ok(home_path), Ok(config_path), Ok(data_path)) => {
+			println!(
+				"{}, {}, {}",
+				home_path.display(),
+				config_path.display(),
+				data_path.display()
+			);
+			Outcome::Ok.exit_code()
+		}
+		_ => {
+			//print_error(&err);
+			Outcome::Err.exit_code()
+		}
+	};
+
+	exit(exit_code);
+}
 /// Print the current home directory for Hipcheck.
 ///
 /// Exits `Ok` if home directory is specified, `Err` otherwise.

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -464,6 +464,16 @@ fn print_readiness(
 ) -> ! {
 	let mut failed = false;
 
+	// Print Hipcheck version
+	let raw_version = env!("CARGO_PKG_VERSION", "can't find Hipcheck package version");
+
+	let version_text = format!(
+		"{} {}",
+		env!("CARGO_PKG_NAME"),
+		version::get_version(raw_version).unwrap()
+	);
+	println!("{}", version_text);
+	
 	// Check that git is installed and that its version is up to date
 	// Print the version number either way
 	let git_check = data::git::get_git_version();


### PR DESCRIPTION
Adds the `hc ready` command. This checks that:

- git and NPM are installed and sufficiently up to date, and if installed prints their versions
- The home directory, config file, and data directory can all be found, and if set prints their respective locations
- The HC_GITHUB_TOKEN environment variable is set (but it does not check that the token is valid)

If git and NPM are up to date and home, config, and data are all found, the command reports that Hipcheck is ready to run. Otherwise it reports that Hipcheck is not ready.