### PR TITLE
chore: Add license and description to rfd.rs

### DIFF
--- a/xtask/src/task/rfd.rs
+++ b/xtask/src/task/rfd.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tasks to list or create RFDs
+
 use crate::NewRfdArgs;
 use crate::RfdArgs;
 use anyhow::anyhow;


### PR DESCRIPTION
Resolves issue #87   Adds the missing license and description to the file xtask/src/task/rfd.rs