### PR TITLE
fix: install git-cliff dependency through build script

### DIFF
--- a/hipcheck/build.rs
+++ b/hipcheck/build.rs
@@ -80,24 +80,24 @@ impl GitCommand {
 }
 
 fn install_git_cliff_if_not_found() -> Result<()> {
-
-    if which("git-cliff").is_err() {
-        // Install git cliff with `cargo install`
+	if which("git-cliff").is_err() {
+		// Install git cliff with `cargo install`
 		let cargo_path = which("cargo").context("can't find cargo")?;
 		let output = Command::new(cargo_path)
 			.args(vec!["install", "git-cliff"])
 			.output()?;
 
-        if !output.status.success() {
-            return match String::from_utf8(output.stderr) {
-                Ok(msg) if msg.is_empty().not() => Err(anyhow!(
-                    "cargo install failed with message '{}' [status: {}]",
-                    msg.trim(),output.status
-                )),
-                _ => Err(anyhow!("cargo install failed [status: {}]", output.status)),
-            };
-        }
-    }
+		if !output.status.success() {
+			return match String::from_utf8(output.stderr) {
+				Ok(msg) if msg.is_empty().not() => Err(anyhow!(
+					"cargo install failed with message '{}' [status: {}]",
+					msg.trim(),
+					output.status
+				)),
+				_ => Err(anyhow!("cargo install failed [status: {}]", output.status)),
+			};
+		}
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/hipcheck/build.rs
+++ b/hipcheck/build.rs
@@ -99,5 +99,5 @@ fn install_git_cliff_if_not_found() -> Result<()> {
         }
     }
 
-	Ok(())
+    Ok(())
 }

--- a/hipcheck/build.rs
+++ b/hipcheck/build.rs
@@ -88,17 +88,16 @@ fn install_git_cliff_if_not_found() -> Result<()> {
 			.args(vec!["install", "git-cliff"])
 			.output()?;
 
-		if !output.status.success() {
-			return match String::from_utf8(output.stderr) {
-				Ok(msg) if msg.is_empty().not() => Err(anyhow!(
-					"cargo install failed with message '{}' [status: {}]",
-					msg.trim(),
-					output.status
-				)),
-				_ => Err(anyhow!("cargo install failed [status: {}]", output.status)),
-			};
-		}
-	}
+        if !output.status.success() {
+            return match String::from_utf8(output.stderr) {
+                Ok(msg) if msg.is_empty().not() => Err(anyhow!(
+                    "cargo install failed with message '{}' [status: {}]",
+                    msg.trim(),output.status
+                )),
+                _ => Err(anyhow!("cargo install failed [status: {}]", output.status)),
+            };
+        }
+    }
 
 	Ok(())
 }


### PR DESCRIPTION
This update will cause `build.rs` to look for and conditionally install `git-cliff` using `cargo` when run. 

This will allow git-cliff to be installed for the user if necessary, no matter if the user installs through `install.sh`, `cargo build`, or as a docker container. 

This will not help ensure users of pre-built Hipcheck binaries will have `git-cliff` installed. Not sure if that is a relevant consideration since they may not have access to the `xtask` subcommand in the first place.

Note additionally that this can cause the build process to take multiple minutes longer than it previously did.