### PR TITLE
feat(cli): hc check and schema will print help msg when no subcommand

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -390,7 +390,7 @@ pub enum Commands {
 #[derive(Debug, Clone, clap::Args)]
 pub struct CheckArgs {
 	#[clap(subcommand)]
-	pub command: Option<CheckCommand>,
+	pub command: CheckCommand,
 }
 
 #[derive(Debug, Clone, clap::Subcommand)]
@@ -493,7 +493,7 @@ pub struct CheckSpdxArgs {
 #[derive(Debug, Clone, clap::Args)]
 pub struct SchemaArgs {
 	#[clap(subcommand)]
-	pub command: Option<SchemaCommand>,
+	pub command: SchemaCommand,
 }
 
 #[derive(Debug, Clone, clap::Subcommand)]

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -81,13 +81,7 @@ fn main() -> ExitCode {
 
 /// Run the `check` command.
 fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
-	let check = match &args.command {
-		Some(command) => command.as_check(),
-		None => {
-			print_error(&hc_error!("unknown check type"));
-			return ExitCode::FAILURE;
-		}
-	};
+	let check = args.command.as_check();
 
 	if check.kind.target_kind().is_checkable().not() {
 		print_missing();
@@ -132,15 +126,12 @@ fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
 /// Run the `schema` command.
 fn cmd_schema(args: &SchemaArgs) {
 	match args.command {
-		Some(SchemaCommand::Maven) => print_maven_schema(),
-		Some(SchemaCommand::Npm) => print_npm_schema(),
-		Some(SchemaCommand::Patch) => print_patch_schema(),
-		Some(SchemaCommand::Pypi) => print_pypi_schema(),
-		Some(SchemaCommand::Repo) => print_report_schema(),
-		Some(SchemaCommand::Request) => print_request_schema(),
-		None => {
-			print_error(&hc_error!("unknown schema type"));
-		}
+		SchemaCommand::Maven => print_maven_schema(),
+		SchemaCommand::Npm => print_npm_schema(),
+		SchemaCommand::Patch => print_patch_schema(),
+		SchemaCommand::Pypi => print_pypi_schema(),
+		SchemaCommand::Repo => print_report_schema(),
+		SchemaCommand::Request => print_request_schema(),
 	}
 }
 


### PR DESCRIPTION
This MR resolves #105  and #106 issues pertaining to the replacement of unhelpful error msgs that Hipcheck emits when either `check` or `schema` subcommands are invoked without any arguments. 

This is addressed simply by updating the type of the `command` field in the `CheckArgs` and `SchemaArgs` structs from an `Option` to just the underlying type. This conveys to `clap` that **some** subcommand must be parsed from the remaining arguments for things to move forward - if this does not happen, it will print the `-h` help msg. 

The `match` statements associated with these `command` fields in `main.rs` are updated in accordance with this change.