### PR TITLE
feat: `cargo release` updates Hipcheck version in README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ consolidate-commits = false
 # When cargo release is run, udates the Hipcheck version number in the two 
 # instances in the READMDE where it explicitly appears in docker commands
 pre-release-replacements = [
-  {file="README.md", search="hipcheck:[a-z0-9\\.-]+", replace="hipcheck:{{version}}"},
+  {file="../README.md", search="hipcheck:[a-z0-9\\.-]+", replace="hipcheck:{{version}}"},
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,12 @@ pre-release-commit-message = "chore: Release {{crate_name}}-v{{version}}"
 # crates in a workspace.
 consolidate-commits = false
 
+# When cargo release is run, udates the Hipcheck version number in the two 
+# instances in the READMDE where it explicitly appears in docker commands
+pre-release-replacements = [
+  {file="README.md", search="hipcheck:[a-z0-9\\.-]+", replace="hipcheck:{{version}}"},
+]
+
 
 #============================================================================
 # `git-cliff` Configuration

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ cargo install --path hipcheck
 You can run Hipcheck in a container like so:
 
 ```sh
-$ docker run --env "HC_GITHUB_TOKEN=<GITHUB_TOKEN>" hipheck:3.1.0 [<HIPCHECK_ARGS>]...
+$ docker run --env "HC_GITHUB_TOKEN=<GITHUB_TOKEN>" hipcheck:3.1.0 [<HIPCHECK_ARGS>]...
 ```
 
 ### Direct Usage

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Hipcheck `Containerfile`.
 
 ```sh
 $ # Run the following from the root of the Hipcheck repository.
-$ docker build -t hipcheck:3.1.0 -f ./Containerfile
+$ docker build -t hipcheck:3.2.1 -f ./Containerfile
 ```
 
 ### Local Install
@@ -108,7 +108,7 @@ $ cargo install --path hipcheck
 You can run Hipcheck in a container like so:
 
 ```sh
-$ docker run --env "HC_GITHUB_TOKEN=<GITHUB_TOKEN>" hipcheck:3.1.0 [<HIPCHECK_ARGS>]...
+$ docker run --env "HC_GITHUB_TOKEN=<GITHUB_TOKEN>" hipcheck:3.2.1 [<HIPCHECK_ARGS>]...
 ```
 
 ### Direct Usage


### PR DESCRIPTION
When we run `cargo release` to update the Hipcheck version, it will now change the version number in the two locations it appears in Hipcheck's `README.md`.

This PR also manually updates the version number in the README to match the current version number (3.2.1).