### PR TITLE
Add `hc setup` subcommand to finish Hipcheck installation

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -361,6 +361,7 @@ fn hc_env_var_value_enum<E: ValueEnum>(name: &'static str) -> Option<E> {
 pub enum FullCommands {
 	Check(CheckArgs),
 	Schema(SchemaArgs),
+	Setup,
 	Ready,
 	PrintConfig,
 	PrintData,
@@ -372,6 +373,7 @@ impl From<&Commands> for FullCommands {
 		match command {
 			Commands::Check(args) => FullCommands::Check(args.clone()),
 			Commands::Schema(args) => FullCommands::Schema(args.clone()),
+			Commands::Setup => FullCommands::Setup,
 			Commands::Ready => FullCommands::Ready,
 		}
 	}
@@ -383,6 +385,8 @@ pub enum Commands {
 	Check(CheckArgs),
 	/// Print the JSON schema for output of a specific `check` command.
 	Schema(SchemaArgs),
+	/// Initialize Hipcheck config file and script file locations.
+	Setup,
 	/// Check if Hipcheck is ready to run.
 	Ready,
 }
@@ -498,7 +502,7 @@ pub struct SchemaArgs {
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum SchemaCommand {
-	/// Print the JSONN schema for running Hipcheck against a Maven package
+	/// Print the JSON schema for running Hipcheck against a Maven package
 	Maven,
 	/// Print the JSON schema for running Hipcheck against a NPM package
 	Npm,

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -181,10 +181,8 @@ fn cmd_setup(config: &CliConfig) -> ExitCode {
 		print_error(&hc_error!("target config dir not specified"));
 		return ExitCode::FAILURE;
 	};
-	if !tgt_conf_path.exists() {
-		if !create_dir_all(&tgt_conf_path).is_ok() {
-			print_error(&hc_error!("failed to create missing target config dir"));
-		};
+	if !tgt_conf_path.exists() && create_dir_all(tgt_conf_path).is_err() {
+		print_error(&hc_error!("failed to create missing target config dir"));
 	}
 	let Ok(abs_conf_path) = tgt_conf_path.canonicalize() else {
 		print_error(&hc_error!("failed to canonicalize HC_CONFIG path"));
@@ -196,10 +194,8 @@ fn cmd_setup(config: &CliConfig) -> ExitCode {
 		print_error(&hc_error!("target data dir not specified"));
 		return ExitCode::FAILURE;
 	};
-	if !tgt_data_path.exists() {
-		if !create_dir_all(&tgt_data_path).is_ok() {
-			print_error(&hc_error!("failed to create missing target data dir"));
-		};
+	if !tgt_data_path.exists() && create_dir_all(tgt_data_path).is_err() {
+		print_error(&hc_error!("failed to create missing target data dir"));
 	}
 	let Ok(abs_data_path) = tgt_data_path.canonicalize() else {
 		print_error(&hc_error!("failed to canonicalize HC_DATA path"));
@@ -217,10 +213,8 @@ fn cmd_setup(config: &CliConfig) -> ExitCode {
 			print_error(&hc_error!("could not find appropriate bin dir for `hc`"));
 			return ExitCode::FAILURE;
 		};
-		if !tgt_bin_path.exists() {
-			if !create_dir_all(&tgt_bin_path).is_ok() {
-				print_error(&hc_error!("failed to create missing HC_BIN dir"));
-			};
+		if !tgt_bin_path.exists() && create_dir_all(&tgt_bin_path).is_err() {
+			print_error(&hc_error!("failed to create missing HC_BIN dir"));
 		}
 		tgt_bin_path.push("hc");
 		if let Err(e) = std::fs::copy(std::env::current_exe().unwrap(), &tgt_bin_path) {
@@ -244,12 +238,12 @@ fn cmd_setup(config: &CliConfig) -> ExitCode {
 
 	// Copy local config/data dirs to target locations
 	let src_conf_path = PathBuf::from("config");
-	if let Err(e) = copy_dir_contents(&src_conf_path, &abs_conf_path) {
+	if let Err(e) = copy_dir_contents(src_conf_path, &abs_conf_path) {
 		print_error(&hc_error!("failed to copy config dir contents: {}", e));
 		return ExitCode::FAILURE;
 	}
 	let src_data_path = PathBuf::from("scripts");
-	if let Err(e) = copy_dir_contents(&src_data_path, &abs_data_path) {
+	if let Err(e) = copy_dir_contents(src_data_path, &abs_data_path) {
 		print_error(&hc_error!("failed to copy data dir contents: {}", e));
 		return ExitCode::FAILURE;
 	}
@@ -267,8 +261,8 @@ fn cmd_setup(config: &CliConfig) -> ExitCode {
 		"Manually add the following to your '$HOME/{}' (or similar) if you haven't already",
 		shell_profile
 	);
-	println!("{}", format!("  export HC_CONFIG={:?}", abs_conf_path));
-	println!("{}", format!("  export HC_DATA={:?}", abs_data_path));
+	println!("\texport HC_CONFIG={:?}", abs_conf_path);
+	println!("\texport HC_DATA={:?}", abs_data_path);
 
 	println!("Run `hc help` to get started");
 


### PR DESCRIPTION
Resolves #103.

- Uses `CliConfig` to get definitions for `HC_DATA` and `HC_CONFIG` from user in same precedence order as main `hc` commands. Difference is we may create these dirs if they do not exist
- `HC_BIN` - if `hc` is not already in path, this is the target location for `hc` to be copied to. First tries `HC_BIN` env var, then uses `dirs::executable_dir()`. 

Steps:
1. Resolve and create (if necessary) `HC_DATA` and `HC_CONFIG` dirs
2. Check if `hc` on path. If not, determine `HC_BIN` val and copy `hc` exe to that location. If in new location `hc` still not on sys path, warn user.
3. Copy config from `./config` to `HC_CONFIG` and data from `./scripts` to `HC_DATA`. **this expects `hc setup` to be run from repo base as we don't have `cargo-dist` built packages yet**. This copies the file contents, not the directories wholesale to minimize chance of user accidentally trying to overwrite important system dirs with bad `HC_CONFIG` value, etc.
4. Emit suggestions for `HC_CONFIG`, `HC_DATA` values as `install.sh` did

Things `install.sh` does that this does not:
- Check for `cargo` and `curl`
- Download and build Hipcheck

Design Discussions:
1. Handling of src dirs for `HC_CONFIG` and `HC_DATA` in Step 3 ok for now?
2. Anything added that should be moved out of `main.rs`?
3. Maybe make `cmd_setup` more sheepish about overwriting existing files (e.g. someone calls `hc setup` which would overwrite a customized `Hipcheck.toml` file in target dir) and add a `--force` flag?