### PR TITLE
Publish tagged HC releases on Dockerhub in MITRE namespace

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -1,0 +1,43 @@
+name: Push Hipcheck image to Docker Hub on every tagged release
+
+on:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Run string replace
+        uses: frabert/replace-string-action@v2
+        id: format-tag
+        with:
+          pattern: 'v'
+          string: "${{ github.event.release.tag_name || github.event.inputs.version }}"
+          replace-with: ''
+          flags: 'g'
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Checkout the Hipcheck Repository
+        uses: actions/checkout@v4
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: "linux/amd64,linux/arm64"
+          tags: mitre/hipcheck:release-latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}

--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -3,12 +3,7 @@ name: Push Hipcheck image to Docker Hub on every tagged release
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version'
-        required: true
+      - 'hipcheck-v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   docker:
@@ -22,7 +17,7 @@ jobs:
         uses: frabert/replace-string-action@v2
         id: format-tag
         with:
-          pattern: 'v'
+          pattern: 'hipcheck-v'
           string: "${{ github.event.release.tag_name || github.event.inputs.version }}"
           replace-with: ''
           flags: 'g'
@@ -41,4 +36,4 @@ jobs:
           file: Containerfile
           push: true
           platforms: "linux/amd64,linux/arm64"
-          tags: mitre/hipcheck:release-latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}
+          tags: mitre/hipcheck:latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}

--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Containerfile
           push: true
           platforms: "linux/amd64,linux/arm64"
           tags: mitre/hipcheck:release-latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}


### PR DESCRIPTION
Resolves #22.

Repo has been updated with secrets for `DOCKER_USERNAME` and `DOCKER_TOKEN`.

Being a github action, this is difficult to test without publishing a new release or manually triggering by modifying the `on` field of the action's `.yml` file. 

In theory we should be able to manually trigger from GitHub once this is merged into `main`