### PR TITLE
fix mishandling of `HC_CONFIG` with new CLI

### DIFF
--- a/hipcheck/src/analysis/session/mod.rs
+++ b/hipcheck/src/analysis/session/mod.rs
@@ -258,12 +258,6 @@ fn load_config_and_data(
 	let valid_config_path = config_path
 	   .ok_or_else(|| hc_error!("Failed to load configuration. Please make sure the path set by the hc_config env variable exists."))?;
 
-	// Get the directory the config file is in.
-	let config_dir = valid_config_path
-		.parent()
-		.map(ToOwned::to_owned)
-		.ok_or_else(|| hc_error!("can't identify directory of config file"))?;
-
 	// Load the configuration file.
 	let config = Config::load_from(valid_config_path)
 		.context("Failed to load configuration. Please make sure the config files are in the config directory.")?;
@@ -278,7 +272,12 @@ fn load_config_and_data(
 
 	phase.finish()?;
 
-	Ok((config, config_dir, data_dir, hc_github_token))
+	Ok((
+		config,
+		valid_config_path.to_path_buf(),
+		data_dir,
+		hc_github_token,
+	))
 }
 
 fn load_source(

--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -28,8 +28,7 @@ impl Config {
 				"Hipcheck config path must be a directory, not a file."
 			));
 		}
-		let mut config_file = PathBuf::from(config_path);
-		config_file.push("Hipcheck.toml");
+		let config_file = pathbuf![config_path, "Hipcheck.toml"];
 		file::exists(&config_file)?;
 		let config = file::read_toml(config_file).context("can't parse config file")?;
 

--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -4,6 +4,7 @@
 
 use crate::context::Context;
 use crate::error::Result;
+use crate::hc_error;
 use crate::util::fs as file;
 use crate::BINARY_CONFIG_FILE;
 use crate::F64;
@@ -22,8 +23,15 @@ use std::rc::Rc;
 impl Config {
 	/// Load configuration from the given directory.
 	pub fn load_from(config_path: &Path) -> Result<Config> {
-		file::exists(config_path)?;
-		let config = file::read_toml(config_path).context("can't parse config file")?;
+		if config_path.is_file() {
+			return Err(hc_error!(
+				"Hipcheck config path must be a directory, not a file."
+			));
+		}
+		let mut config_file = PathBuf::from(config_path);
+		config_file.push("Hipcheck.toml");
+		file::exists(&config_file)?;
+		let config = file::read_toml(config_file).context("can't parse config file")?;
 
 		Ok(config)
 	}


### PR DESCRIPTION
Resolves #108 .

Function `resolve_config()` is no longer called in `load_config_and_data()`, and used to return a path with `Hipcheck.toml` at the end, necessitating a call to `.parent()` to get the conf dir to pass to `Config::load_from()`. With the new CLI, the path doesn't have `Hipcheck.toml` on the end, but the `.parent()` call was left accidentally.

This fix removes the unneeded call, and adds a check to `Config::load_from()` that the passed path is not a regular file to provide users with a clearer error message if they accidentally set `HC_CONFIG` to point to `Hipcheck.toml`.