### PR TITLE
feat: add ability to manually exec push-to-dockerhub action

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'hipcheck-v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
 
 jobs:
   docker:


### PR DESCRIPTION
As discussed in HC weekly meeting, add ability to manually trigger `push-to-docker.yml` job, particularly useful in case there are bugs in the script that get discovered the first time a new version gets cut.