### PR TITLE
refactor: added new types to form the basis of scoring refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "env_logger",
  "graphql_client",
  "hipcheck-macros",
+ "indexmap 2.2.6",
  "lazy_static",
  "libc",
  "log",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -63,6 +63,7 @@ url = "2.2.2"
 walkdir = "2.5.0"
 which = { version = "6.0.1", default-features = false }
 xml-rs = "0.8.20"
+indexmap = "2.2.6"
 
 # Windows-specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/hipcheck/src/analysis.rs
+++ b/hipcheck/src/analysis.rs
@@ -3,6 +3,7 @@
 #[allow(clippy::module_inception)]
 pub mod analysis;
 pub mod report_builder;
+pub mod result;
 pub mod score;
 
 pub use analysis::AnalysisProvider;

--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -1,0 +1,125 @@
+use crate::hc_error;
+use crate::report::Concern;
+use crate::Result;
+use crate::F64;
+
+/// Represents the enhanced result of a hipcheck analysis. Contains the actual outcome
+/// of the analysis, plus additional meta-information the analysis wants to provide to
+/// HipCheck core, such as raised concerns.
+struct HCAnalysisResult {
+	outcome: AnalysisOutcome,
+	concerns: Vec<Concern>,
+}
+
+/// Represents the result of a hipcheck analysis. Either the analysis encountered
+/// an error, or it completed and returned a value.
+enum AnalysisOutcome {
+	Error(HCAnalysisError),
+	Completed(HCAnalysisValue),
+}
+
+/// Enumeration of potential errors that a HipCheck analysis might return. The Generic
+/// variant enables representing errors that aren't covered by other variants.
+enum HCAnalysisError {
+	Generic(crate::error::Error),
+}
+
+/// A HipCheck analysis may return a basic or composite value. By splitting the types
+/// into two sub-enums under this one, we can eschew a recursive enum definition and
+/// ensure composite types only have a depth of one.
+enum HCAnalysisValue {
+	Basic(HCBasicValue),
+	Composite(HCCompositeValue),
+}
+
+/// Basic HipCheck analysis return types
+#[derive(Debug)]
+enum HCBasicValue {
+	Integer(i64),
+	Unsigned(u64),
+	Float(F64),
+	Bool(bool),
+	String(String),
+}
+impl From<i64> for HCBasicValue {
+	fn from(value: i64) -> Self {
+		HCBasicValue::Integer(value)
+	}
+}
+impl From<u64> for HCBasicValue {
+	fn from(value: u64) -> Self {
+		HCBasicValue::Unsigned(value)
+	}
+}
+impl From<F64> for HCBasicValue {
+	fn from(value: F64) -> Self {
+		HCBasicValue::Float(value)
+	}
+}
+impl TryFrom<f64> for HCBasicValue {
+	type Error = crate::Error;
+	fn try_from(value: f64) -> Result<HCBasicValue> {
+		let inner = F64::new(value)?;
+		Ok(HCBasicValue::Float(inner))
+	}
+}
+impl From<bool> for HCBasicValue {
+	fn from(value: bool) -> Self {
+		HCBasicValue::Bool(value)
+	}
+}
+impl From<String> for HCBasicValue {
+	fn from(value: String) -> Self {
+		HCBasicValue::String(value)
+	}
+}
+impl From<&str> for HCBasicValue {
+	fn from(value: &str) -> Self {
+		HCBasicValue::String(value.to_owned())
+	}
+}
+
+/// Composite HipCheck analysis return types
+enum HCCompositeValue {
+	List(Vec<HCBasicValue>),
+	Dict(indexmap::IndexMap<String, HCBasicValue>),
+}
+
+/// The set of possible predicates for deciding if a source passed an analysis.
+enum HCPredicate {
+	Threshold(ThresholdPredicate),
+}
+
+/// This predicate determines analysis pass/fail by whether a returned value was
+/// greater than, less than, or equal to a target value.
+struct ThresholdPredicate {
+	value: HCBasicValue,
+	threshold: HCBasicValue,
+	ordering: std::cmp::Ordering,
+}
+
+fn pass_threshold<T: PartialOrd>(a: &T, b: &T, ord: &std::cmp::Ordering) -> Result<bool> {
+	a.partial_cmp(b)
+		.ok_or(hc_error!("threshold comparison failed for unknown reason"))
+		.map(|x| x == *ord)
+}
+
+impl ThresholdPredicate {
+	// @FollowUp - would be nice for this match logic to error at compile time if a new
+	//  HCBasicValue type is added, so developer is reminded to add new variant here
+	pub fn pass(&self) -> Result<bool> {
+		use HCBasicValue::*;
+		match (&self.value, &self.threshold) {
+			(Integer(a), Integer(b)) => pass_threshold(a, b, &self.ordering),
+			(Unsigned(a), Unsigned(b)) => pass_threshold(a, b, &self.ordering),
+			(Float(a), Float(b)) => pass_threshold(a, b, &self.ordering),
+			(Bool(a), Bool(b)) => pass_threshold(a, b, &self.ordering),
+			(String(a), String(b)) => pass_threshold(a, b, &self.ordering),
+			(a, b) => Err(hc_error!(
+				"threshold and value are of different types: {:?}, {:?}",
+				a,
+				b
+			)),
+		}
+	}
+}

--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -7,14 +7,16 @@ use crate::F64;
 /// of the analysis, plus additional meta-information the analysis wants to provide to
 /// HipCheck core, such as raised concerns.
 pub struct HCAnalysisResult {
-	outcome: AnalysisOutcome,
-	concerns: Vec<Concern>,
+	pub outcome: AnalysisOutcome,
+	pub concerns: Vec<Concern>,
 }
 
+#[allow(dead_code)]
 pub type SkippableAnalysisResult = Option<HCAnalysisResult>;
 
 /// Represents the result of a hipcheck analysis. Either the analysis encountered
 /// an error, or it completed and returned a value.
+#[allow(dead_code)]
 pub enum AnalysisOutcome {
 	Error(HCAnalysisError),
 	Completed(HCAnalysisValue),
@@ -22,6 +24,7 @@ pub enum AnalysisOutcome {
 
 /// Enumeration of potential errors that a HipCheck analysis might return. The Generic
 /// variant enables representing errors that aren't covered by other variants.
+#[allow(dead_code)]
 pub enum HCAnalysisError {
 	Generic(crate::error::Error),
 }
@@ -29,6 +32,7 @@ pub enum HCAnalysisError {
 /// A HipCheck analysis may return a basic or composite value. By splitting the types
 /// into two sub-enums under this one, we can eschew a recursive enum definition and
 /// ensure composite types only have a depth of one.
+#[allow(dead_code)]
 pub enum HCAnalysisValue {
 	Basic(HCBasicValue),
 	Composite(HCCompositeValue),
@@ -82,22 +86,25 @@ impl From<&str> for HCBasicValue {
 }
 
 /// Composite HipCheck analysis return types
+#[allow(dead_code)]
 pub enum HCCompositeValue {
 	List(Vec<HCBasicValue>),
 	Dict(indexmap::IndexMap<String, HCBasicValue>),
 }
 
 /// The set of possible predicates for deciding if a source passed an analysis.
+#[allow(dead_code)]
 pub enum HCPredicate {
 	Threshold(ThresholdPredicate),
 }
 
 /// This predicate determines analysis pass/fail by whether a returned value was
 /// greater than, less than, or equal to a target value.
+#[allow(dead_code)]
 pub struct ThresholdPredicate {
-	value: HCBasicValue,
-	threshold: HCBasicValue,
-	ordering: std::cmp::Ordering,
+	pub value: HCBasicValue,
+	pub threshold: HCBasicValue,
+	pub ordering: std::cmp::Ordering,
 }
 
 fn pass_threshold<T: PartialOrd>(a: &T, b: &T, ord: &std::cmp::Ordering) -> Result<bool> {
@@ -106,6 +113,7 @@ fn pass_threshold<T: PartialOrd>(a: &T, b: &T, ord: &std::cmp::Ordering) -> Resu
 		.map(|x| x == *ord)
 }
 
+#[allow(dead_code)]
 impl ThresholdPredicate {
 	// @FollowUp - would be nice for this match logic to error at compile time if a new
 	//  HCBasicValue type is added, so developer is reminded to add new variant here

--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -6,6 +6,7 @@ use crate::F64;
 /// Represents the enhanced result of a hipcheck analysis. Contains the actual outcome
 /// of the analysis, plus additional meta-information the analysis wants to provide to
 /// HipCheck core, such as raised concerns.
+#[allow(dead_code)]
 pub struct HCAnalysisResult {
 	pub outcome: AnalysisOutcome,
 	pub concerns: Vec<Concern>,

--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -6,35 +6,37 @@ use crate::F64;
 /// Represents the enhanced result of a hipcheck analysis. Contains the actual outcome
 /// of the analysis, plus additional meta-information the analysis wants to provide to
 /// HipCheck core, such as raised concerns.
-struct HCAnalysisResult {
+pub struct HCAnalysisResult {
 	outcome: AnalysisOutcome,
 	concerns: Vec<Concern>,
 }
 
+pub type SkippableAnalysisResult = Option<HCAnalysisResult>;
+
 /// Represents the result of a hipcheck analysis. Either the analysis encountered
 /// an error, or it completed and returned a value.
-enum AnalysisOutcome {
+pub enum AnalysisOutcome {
 	Error(HCAnalysisError),
 	Completed(HCAnalysisValue),
 }
 
 /// Enumeration of potential errors that a HipCheck analysis might return. The Generic
 /// variant enables representing errors that aren't covered by other variants.
-enum HCAnalysisError {
+pub enum HCAnalysisError {
 	Generic(crate::error::Error),
 }
 
 /// A HipCheck analysis may return a basic or composite value. By splitting the types
 /// into two sub-enums under this one, we can eschew a recursive enum definition and
 /// ensure composite types only have a depth of one.
-enum HCAnalysisValue {
+pub enum HCAnalysisValue {
 	Basic(HCBasicValue),
 	Composite(HCCompositeValue),
 }
 
 /// Basic HipCheck analysis return types
 #[derive(Debug)]
-enum HCBasicValue {
+pub enum HCBasicValue {
 	Integer(i64),
 	Unsigned(u64),
 	Float(F64),
@@ -80,19 +82,19 @@ impl From<&str> for HCBasicValue {
 }
 
 /// Composite HipCheck analysis return types
-enum HCCompositeValue {
+pub enum HCCompositeValue {
 	List(Vec<HCBasicValue>),
 	Dict(indexmap::IndexMap<String, HCBasicValue>),
 }
 
 /// The set of possible predicates for deciding if a source passed an analysis.
-enum HCPredicate {
+pub enum HCPredicate {
 	Threshold(ThresholdPredicate),
 }
 
 /// This predicate determines analysis pass/fail by whether a returned value was
 /// greater than, less than, or equal to a target value.
-struct ThresholdPredicate {
+pub struct ThresholdPredicate {
 	value: HCBasicValue,
 	threshold: HCBasicValue,
 	ordering: std::cmp::Ordering,

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -103,7 +103,6 @@ impl Default for ScoreResult {
 
 //stores the score tree using petgraph
 //the tree does not need to know what sections it is scoring
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ScoreTree {
 	pub tree: Graph<ScoreTreeNode, f64>,
@@ -111,6 +110,7 @@ pub struct ScoreTree {
 
 //stores the score tree using petgraph
 //the tree does not need to know what sections it is scoring
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ScoreTreeNode {
 	pub label: String,

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -39,6 +39,7 @@ pub struct ScoringResults {
 	pub score: Score,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct AnalysisResults {
 	pub activity: Option<Result<Rc<AnalysisReport>>>,
@@ -56,6 +57,7 @@ pub struct AnalysisResults {
 	pub pr_module_contributors: Option<Result<Rc<AnalysisReport>>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct Score {
 	pub total: f64,
@@ -101,6 +103,7 @@ impl Default for ScoreResult {
 
 //stores the score tree using petgraph
 //the tree does not need to know what sections it is scoring
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ScoreTree {
 	pub tree: Graph<ScoreTreeNode, f64>,

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -2,10 +2,13 @@
 
 use crate::analysis::analysis::AnalysisOutcome;
 use crate::analysis::analysis::AnalysisReport;
+use crate::analysis::result::*;
 use crate::analysis::AnalysisProvider;
 use crate::error::Result;
 use crate::hc_error;
+use crate::report::Concern;
 use crate::shell::Phase;
+use std::cmp::Ordering;
 use std::default::Default;
 use std::rc::Rc;
 
@@ -42,7 +45,7 @@ pub struct ScoringResults {
 #[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct AnalysisResults {
-	pub activity: Option<Result<Rc<AnalysisReport>>>,
+	pub activity: Option<(Result<Rc<ThresholdPredicate>>, Vec<Concern>)>,
 	pub affiliation: Option<Result<Rc<AnalysisReport>>>,
 	pub binary: Option<Result<Rc<AnalysisReport>>>,
 	pub churn: Option<Result<Rc<AnalysisReport>>>,
@@ -125,36 +128,9 @@ pub fn phase_outcome<P: AsRef<String>>(
 	phase_name: P,
 ) -> Result<Rc<ScoreResult>> {
 	match phase_name.as_ref().as_str() {
-		ACTIVITY_PHASE => match &db.activity_analysis().unwrap().as_ref() {
-			AnalysisReport::None {
-				outcome: AnalysisOutcome::Skipped,
-			} => Ok(Rc::new(ScoreResult::default())),
-			AnalysisReport::None {
-				outcome: AnalysisOutcome::Error(msg),
-			} => Ok(Rc::new(ScoreResult {
-				count: 0,
-				score: 0,
-				outcome: AnalysisOutcome::Error(msg.clone()),
-			})),
-			AnalysisReport::Activity {
-				outcome: AnalysisOutcome::Pass(msg),
-				..
-			} => Ok(Rc::new(ScoreResult {
-				count: db.activity_weight(),
-				score: 0,
-				outcome: AnalysisOutcome::Pass(msg.to_string()),
-			})),
-			AnalysisReport::Activity {
-				outcome: AnalysisOutcome::Fail(msg),
-				..
-			} => Ok(Rc::new(ScoreResult {
-				count: db.activity_weight(),
-				score: 1,
-				outcome: AnalysisOutcome::Fail(msg.to_string()),
-			})),
-			_ => Err(hc_error!("phase name does not match analysis")),
-		},
-
+		ACTIVITY_PHASE => Err(hc_error!(
+			"activity analysis does not use this infrastructure"
+		)),
 		AFFILIATION_PHASE => match &db.affiliation_analysis().unwrap().as_ref() {
 			AnalysisReport::None {
 				outcome: AnalysisOutcome::Skipped,
@@ -593,31 +569,61 @@ pub fn score_results(phase: &mut Phase, db: &dyn ScoringProvider) -> Result<Scor
 		/*===NEW_PHASE===*/
 		update_phase(phase, ACTIVITY_PHASE)?;
 		// Check if this analysis was skipped or generated an error, then format the results accordingly for reporting.
-		let activity_analysis = db.activity_analysis()?;
-		match activity_analysis.as_ref() {
-			AnalysisReport::None {
-				outcome: AnalysisOutcome::Skipped,
-			} => results.activity = None,
-			AnalysisReport::None {
-				outcome: AnalysisOutcome::Error(err),
-			} => results.activity = Some(Err(err.clone())),
-			_ => results.activity = Some(Ok(activity_analysis)),
-		}
-
-		let score_result = db
-			.phase_outcome(Rc::new(ACTIVITY_PHASE.to_string()))
-			.unwrap();
-		score.activity = score_result.outcome.clone();
-		match add_node_and_edge_with_score(
-			score_result,
-			score_tree.clone(),
-			ACTIVITY_PHASE,
-			practices_node,
-		) {
-			Ok(score_tree_inc) => {
-				score_tree = score_tree_inc;
+		if db.activity_active() {
+			let raw_activity = db.activity_analysis();
+			let activity_res = match &raw_activity.as_ref().outcome {
+				HCAnalysisOutcome::Error(err) => Err(hc_error!("{:?}", err)),
+				HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(av)) => {
+					let raw_threshold: u64 = db.activity_week_count_threshold();
+					let threshold = HCBasicValue::from(raw_threshold);
+					let predicate = ThresholdPredicate::new(
+						av.clone(),
+						threshold,
+						Some("weeks inactivity".to_owned()),
+						Ordering::Less,
+					);
+					Ok(Rc::new(predicate))
+				}
+				HCAnalysisOutcome::Completed(HCAnalysisValue::Composite(_)) => Err(hc_error!(
+					"activity analysis should return a basic u64 type, not {:?}"
+				)),
+			};
+			// Scoring based off of predicate
+			let score_result = Rc::new(match activity_res.as_ref() {
+				Err(e) => ScoreResult {
+					count: db.activity_weight(),
+					score: 1,
+					outcome: AnalysisOutcome::Error(e.clone()),
+				},
+				Ok(pred) => {
+					// Derive score from predicate, true --> 0, false --> 1
+					let passed = pred.pass()?;
+					let msg = pred.to_string();
+					let outcome = if passed {
+						AnalysisOutcome::Pass(msg)
+					} else {
+						AnalysisOutcome::Fail(msg)
+					};
+					ScoreResult {
+						count: db.activity_weight(),
+						score: (!passed) as u64,
+						outcome,
+					}
+				}
+			});
+			results.activity = Some((activity_res, raw_activity.concerns.clone()));
+			score.activity = score_result.outcome.clone();
+			match add_node_and_edge_with_score(
+				score_result,
+				score_tree.clone(),
+				ACTIVITY_PHASE,
+				practices_node,
+			) {
+				Ok(score_tree_inc) => {
+					score_tree = score_tree_inc;
+				}
+				_ => return Err(hc_error!("failed to complete {} scoring.", ACTIVITY_PHASE)),
 			}
-			_ => return Err(hc_error!("failed to complete {} scoring.", ACTIVITY_PHASE)),
 		}
 
 		/*===REVIEW PHASE===*/

--- a/hipcheck/src/data/es_lint/data.rs
+++ b/hipcheck/src/data/es_lint/data.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 
 pub type ESLintReports = Vec<ESLintReport>;
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ESLintReport {
 	#[serde(rename = "filePath")]
@@ -29,6 +30,7 @@ pub struct ESLintReport {
 	pub source: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ESLintMessage {
 	#[serde(rename = "ruleId")]

--- a/hipcheck/src/data/modules.rs
+++ b/hipcheck/src/data/modules.rs
@@ -54,6 +54,7 @@ fn detect_npm_package_root(pkg_file: &Path) -> Result<PathBuf> {
 	}
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct RawModule {
 	pub file: String,

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -576,11 +576,11 @@ fn run_with_shell(
 
 			let scoring = match score_results(&mut phase, &session) {
 				Ok(scoring) => scoring,
-				_ => {
+				Err(x) => {
 					return (
 						session.end(),
-						Err(Error::msg("Trouble scoring and analyzing results")),
-					)
+						Err(x), // Error::msg("Trouble scoring and analyzing results")),
+					);
 				}
 			};
 

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(unused)]
 mod analysis;
 mod cli;
 mod command_util;


### PR DESCRIPTION
**Note**: Not sure why the Ubuntu `clippy` is complaining about unused fields now that it used to not have a problem with. Perhaps a change was made over the past few days that removed `Debug` from the field usage calculation?

An attempt at defining new types for overhauling the `AnalysisResult` system and Hipcheck scoring in general. `HC` prefix was added to structs/variants to disambiguate with existing structs and can/should be renamed once the old system has been removed in a subsequent PR.

The goal of this PR is to produce an `AnalysisReport` replacement with the following changes:

- Analysis implementations no longer check `db.<X>_active()` to decide themselves whether or not to run. The old `AnalysisOutcome` enum contains the `Skip` variant which is absent from the new one. Instead, we wrap the `HCAnalysisResult` in an option to represent the skipped/executed status of an analysis.
- Analyses no longer determine pass/fail themselves, they will simply return a "value". Thus, `Pass`, `Fail` language is also removed from this replacement infrastructure, and analyses won't know or return their own thresholds. 
- An infrastructure that does not require a separate enum variant of `AnalysisReport` for each analysis type as the existing system does. In this new system, analyses will return a basic/composite value type, and the config/analysis will select from a set of "predicates" that specify how that result is to be interpreted for pass/fail determination. The only one that we have right now is `ThresholdPredicate`, which allows specifying that a basic value must be above/equal/below a certain value of the same type.

I added the `indexmap` depedency for the `IndexMap` object, which is an order-preserving HashMap drop-in replacement. In the past I have found this important for JSON dict comparison. I imagine we will want to update the predicates for comparing composite types.