### PR TITLE
Macro for simplifying threshold scoring

### DIFF
--- a/hipcheck/src/analysis/report_builder.rs
+++ b/hipcheck/src/analysis/report_builder.rs
@@ -52,35 +52,30 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 
 	// Affiliation analysis.
 
-	extract_results(
-		&mut builder,
-		&scoring.results.affiliation,
-		|builder, output| {
-			match output.as_ref() {
-				AnalysisReport::Affiliation {
-					value,
-					threshold,
-					concerns,
-					..
-				} => {
-					let analysis = Analysis::affiliation(*value, *threshold);
-					builder.add_analysis(analysis, concerns.clone())?;
-				}
-				_ => {
+	if let Some(stored) = &scoring.results.affiliation {
+		match &stored.result {
+			Ok(analysis) => {
+				let Some(pred) = analysis.as_any().downcast_ref::<ThresholdPredicate>() else {
 					return Err(hc_error!(
-						"phase name does not match {} analysis",
-						crate::analysis::score::AFFILIATION_PHASE
-					))
-				}
+						"expected threshold predicate for affiliation analysis"
+					));
+				};
+				let HCBasicValue::Unsigned(value) = pred.value else {
+					return Err(hc_error!("affiliation analysis has a non-u64 value"));
+				};
+				let HCBasicValue::Unsigned(thresh) = pred.threshold else {
+					return Err(hc_error!("affiliation analysis has a non-u64 value"));
+				};
+				builder.add_analysis(
+					Analysis::affiliation(value, thresh),
+					stored.concerns.clone(),
+				)?;
 			}
-
-			Ok(())
-		},
-		|builder, error| {
-			builder.add_errored_analysis(AnalysisIdent::Affiliation, error);
-			Ok(())
-		},
-	)?;
+			Err(error) => {
+				builder.add_errored_analysis(AnalysisIdent::Affiliation, error);
+			}
+		}
+	};
 
 	// Binary Analysis
 

--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -117,6 +117,12 @@ pub trait HCPredicate: Display + std::fmt::Debug + std::any::Any + 'static {
 	fn as_any(&self) -> &dyn std::any::Any;
 }
 
+pub struct ThresholdSpec {
+	pub threshold: HCBasicValue,
+	pub units: Option<String>,
+	pub ordering: Ordering,
+}
+
 /// This predicate determines analysis pass/fail by whether a returned value was
 /// greater than, less than, or equal to a target value.
 #[derive(Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
This macro is dependent on #130 getting merged into `main`.

Continuation of effort on #28 .

This adds `affiliation` to the set of analyses using the new scoring/storage system, but the main contribution of this PR is the `run_and_score_threshold_analysis` macro defined in `score.rs`. If approved, this will make converting the rest of the analyses much simpler and reduce lines of (committed) code. The macro is a bit in-elegant but we expect churn in this area of Hipcheck in the next few months anyway, I doubt this will remain for very long.

It might also be worthwhile to add a similar macro for analyses on the new system in `analysis/report_builder.rs`.