### PR TITLE
chore: Make `cargo-dist` releases include `config/` and `scripts/`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ targets = [
 pr-run-mode = "plan"
 # Whether to install an updater program
 install-updater = true
+# Make sure the "config/" and "scripts/" folders are in the release bundle,
+# because we'll need them for `hc setup`.
+include = ["config/", "scripts/"]
+
 
 # The profile that 'cargo dist' will build with
 [profile.dist]
@@ -89,10 +93,10 @@ pre-release-commit-message = "chore: Release {{crate_name}}-v{{version}}"
 # crates in a workspace.
 consolidate-commits = false
 
-# When cargo release is run, udates the Hipcheck version number in the two 
+# When cargo release is run, udates the Hipcheck version number in the two
 # instances in the READMDE where it explicitly appears in docker commands
 pre-release-replacements = [
-  {file="../README.md", search="hipcheck:[a-z0-9\\.-]+", replace="hipcheck:{{version}}"},
+    { file = "../README.md", search = "hipcheck:[a-z0-9\\.-]+", replace = "hipcheck:{{version}}" },
 ]
 
 


### PR DESCRIPTION
As part of changing our installation flow, we want to have an `hc setup` command which installs the required configuration and support scripts for Hipcheck. To do this, we're updating our `cargo-dist` configuration to make sure those files are bundled with the release bundles made with each Hipcheck release.