### PR TITLE
Remove dependency on lazy_static.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,6 @@ dependencies = [
  "indexmap 2.2.6",
  "indicatif",
  "indicatif-log-bridge",
- "lazy_static",
  "libc",
  "log",
  "maplit",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -31,7 +31,6 @@ duct = "0.13.5"
 env_logger = { version = "0.11.3" }
 graphql_client = "0.14.0"
 hipcheck-macros = { path = "../hipcheck-macros", version = "0.2.0" }
-lazy_static = "1.5.0"
 libc = "0.2.155"
 log = "0.4.16"
 maplit = "1.0.2"

--- a/hipcheck/src/metric/typo.rs
+++ b/hipcheck/src/metric/typo.rs
@@ -730,7 +730,6 @@ impl KeyboardLayout {
 mod test {
 	use super::NameFuzzer;
 	use super::Typo;
-	use lazy_static::lazy_static;
 
 	macro_rules! test_typos {
         ( from: $name:ident, to: $to:literal, expected: [ $( $expected:ident ),* ] ) => {
@@ -745,9 +744,7 @@ mod test {
         };
     }
 
-	lazy_static! {
-		static ref NAME: &'static str = "hello";
-	}
+	const NAME: &'static str = "hello";
 
 	#[test]
 	fn fuzz_hello_to_hallo() {


### PR DESCRIPTION
Some of our dependencies still use it so it's not entirely out of the project, but after these changes we will no longer depend on it directly.

Resolves #143