### PR TITLE
Add `hc setup` installation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +99,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +157,27 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -153,6 +209,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -238,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +344,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +423,43 @@ dependencies = [
  "once_cell",
  "parking_lot_core 0.9.10",
  "rayon",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -329,6 +481,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -413,6 +576,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,12 +600,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -597,6 +792,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "spdx-rs",
+ "tar",
  "tempfile",
  "termcolor",
  "toml",
@@ -607,6 +803,8 @@ dependencies = [
  "which",
  "winapi",
  "xml-rs",
+ "xz2",
+ "zip",
 ]
 
 [[package]]
@@ -616,6 +814,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -709,6 +916,15 @@ checksum = "2963046f28a204e3e3fd7e754fd90a6235da05b5378f24707ff0ec9513725ce3"
 dependencies = [
  "indicatif",
  "log",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -829,10 +1045,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "maplit"
@@ -853,6 +1096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1113,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -985,6 +1243,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5ef818343d9b62a8391bfbc8fbd449acf2e6ddd2f1a9aede0eae4c7d91c25c"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1289,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,8 +1324,20 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
  "rand_core",
  "serde",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -1054,6 +1346,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
+ "getrandom",
  "serde",
 ]
 
@@ -1082,6 +1375,15 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1395,6 +1697,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1716,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
@@ -1510,6 +1829,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1879,25 @@ dependencies = [
  "quote",
  "syn 2.0.68",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinyvec"
@@ -1629,6 +1978,12 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -1727,6 +2082,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -2020,6 +2381,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2431,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "zip"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.2.6",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand",
+ "sha1",
+ "thiserror",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.11+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -76,6 +76,9 @@ finl_unicode = { version = "1.2.0", default-features = false, features = [
     "grapheme_clusters",
 ] }
 indicatif-log-bridge = "0.2.2"
+tar = "0.4.41"
+zip = "2.1.3"
+xz2 = "0.1.7"
 
 # Windows-specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -364,6 +364,7 @@ fn hc_env_var_value_enum<E: ValueEnum>(name: &'static str) -> Option<E> {
 pub enum FullCommands {
 	Check(CheckArgs),
 	Schema(SchemaArgs),
+	Setup,
 	Ready,
 	PrintConfig,
 	PrintData,
@@ -375,6 +376,7 @@ impl From<&Commands> for FullCommands {
 		match command {
 			Commands::Check(args) => FullCommands::Check(args.clone()),
 			Commands::Schema(args) => FullCommands::Schema(args.clone()),
+			Commands::Setup => FullCommands::Setup,
 			Commands::Ready => FullCommands::Ready,
 		}
 	}
@@ -386,6 +388,8 @@ pub enum Commands {
 	Check(CheckArgs),
 	/// Print the JSON schema for output of a specific `check` command.
 	Schema(SchemaArgs),
+	/// Initialize Hipcheck config file and script file locations.
+	Setup,
 	/// Check if Hipcheck is ready to run.
 	Ready,
 }
@@ -562,7 +566,7 @@ pub struct SchemaArgs {
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum SchemaCommand {
-	/// Print the JSONN schema for running Hipcheck against a Maven package
+	/// Print the JSON schema for running Hipcheck against a Maven package
 	Maven,
 	/// Print the JSON schema for running Hipcheck against a NPM package
 	Npm,

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -364,7 +364,7 @@ fn hc_env_var_value_enum<E: ValueEnum>(name: &'static str) -> Option<E> {
 pub enum FullCommands {
 	Check(CheckArgs),
 	Schema(SchemaArgs),
-	Setup,
+	Setup(SetupArgs),
 	Ready,
 	PrintConfig,
 	PrintData,
@@ -376,7 +376,7 @@ impl From<&Commands> for FullCommands {
 		match command {
 			Commands::Check(args) => FullCommands::Check(args.clone()),
 			Commands::Schema(args) => FullCommands::Schema(args.clone()),
-			Commands::Setup => FullCommands::Setup,
+			Commands::Setup(args) => FullCommands::Setup(args.clone()),
 			Commands::Ready => FullCommands::Ready,
 		}
 	}
@@ -389,7 +389,7 @@ pub enum Commands {
 	/// Print the JSON schema for output of a specific `check` command.
 	Schema(SchemaArgs),
 	/// Initialize Hipcheck config file and script file locations.
-	Setup,
+	Setup(SetupArgs),
 	/// Check if Hipcheck is ready to run.
 	Ready,
 }
@@ -578,6 +578,16 @@ pub enum SchemaCommand {
 	Repo,
 	/// Print the JSON schema for running Hipcheck against a pull request
 	Request,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct SetupArgs {
+	/// Setup will not attempt to pull missing files from the Hipcheck remote repository.
+	#[clap(long, short)]
+	pub offline: bool,
+	/// Path to a local Hipcheck release archive or directory from which to copy default
+	/// config and data dirs.
+	pub source: Option<PathBuf>,
 }
 
 /// A type that can copy non-`None` values from other instances of itself.

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -205,7 +205,10 @@ fn cmd_setup(args: &SetupArgs, config: &CliConfig) -> ExitCode {
 
 	// Derive the config/scripts paths from the source path
 	let (src_conf_path, src_data_path) = match &source.path {
-		SourceType::Dir(p) => (pathbuf![&p, "config"], pathbuf![&p, "scripts"]),
+		SourceType::Dir(p) => (
+			pathbuf![p.as_path(), "config"],
+			pathbuf![p.as_path(), "scripts"],
+		),
 		_ => {
 			print_error(&hc_error!("expected source to be a directory"));
 			source.cleanup();

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> ExitCode {
 	match config.subcommand() {
 		Some(FullCommands::Check(args)) => return cmd_check(&args, &config),
 		Some(FullCommands::Schema(args)) => cmd_schema(&args),
+		Some(FullCommands::Setup) => return cmd_setup(&config),
 		Some(FullCommands::Ready) => cmd_ready(&config),
 		Some(FullCommands::PrintConfig) => cmd_print_config(config.config()),
 		Some(FullCommands::PrintData) => cmd_print_data(config.data()),
@@ -155,6 +156,98 @@ fn cmd_schema(args: &SchemaArgs) {
 		SchemaCommand::Repo => print_report_schema(),
 		SchemaCommand::Request => print_request_schema(),
 	}
+}
+
+/// Copy individual files in dir instead of entire dir, to avoid users accidentally
+/// overwriting important dirs such as /usr/bin/
+fn copy_dir_contents<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
+	fn inner(from: &Path, to: &Path) -> Result<()> {
+		let src = from.to_path_buf();
+		if !src.is_dir() {
+			return Err(hc_error!("source path must be a directory"));
+		}
+		let dst: PathBuf = to.to_path_buf();
+		if !dst.is_dir() {
+			return Err(hc_error!("target path must be a directory"));
+		}
+
+		for entry in walkdir::WalkDir::new(&src) {
+			let src_f_path = entry?.path().to_path_buf();
+			if src_f_path == src {
+				continue;
+			}
+			let mut dst_f_path = dst.clone();
+			dst_f_path.push(
+				src_f_path
+					.file_name()
+					.ok_or(hc_error!("src dir entry without file name"))?,
+			);
+			// This is ok for now because we only copy files, no dirs
+			std::fs::copy(src_f_path, dst_f_path)?;
+		}
+		Ok(())
+	}
+	inner(from.as_ref(), to.as_ref())
+}
+
+fn cmd_setup(config: &CliConfig) -> ExitCode {
+	// Make config dir if not exist
+	let Some(tgt_conf_path) = config.config() else {
+		print_error(&hc_error!("target config dir not specified"));
+		return ExitCode::FAILURE;
+	};
+	if !tgt_conf_path.exists() && create_dir_all(tgt_conf_path).is_err() {
+		print_error(&hc_error!("failed to create missing target config dir"));
+	}
+	let Ok(abs_conf_path) = tgt_conf_path.canonicalize() else {
+		print_error(&hc_error!("failed to canonicalize HC_CONFIG path"));
+		return ExitCode::FAILURE;
+	};
+
+	// Make data dir if not exist
+	let Some(tgt_data_path) = config.data() else {
+		print_error(&hc_error!("target data dir not specified"));
+		return ExitCode::FAILURE;
+	};
+	if !tgt_data_path.exists() && create_dir_all(tgt_data_path).is_err() {
+		print_error(&hc_error!("failed to create missing target data dir"));
+	}
+	let Ok(abs_data_path) = tgt_data_path.canonicalize() else {
+		print_error(&hc_error!("failed to canonicalize HC_DATA path"));
+		return ExitCode::FAILURE;
+	};
+
+	// Copy local config/data dirs to target locations
+	let src_conf_path = PathBuf::from("config");
+	if let Err(e) = copy_dir_contents(src_conf_path, &abs_conf_path) {
+		print_error(&hc_error!("failed to copy config dir contents: {}", e));
+		return ExitCode::FAILURE;
+	}
+	let src_data_path = PathBuf::from("scripts");
+	if let Err(e) = copy_dir_contents(src_data_path, &abs_data_path) {
+		print_error(&hc_error!("failed to copy data dir contents: {}", e));
+		return ExitCode::FAILURE;
+	}
+
+	println!("Hipcheck setup completed successfully.");
+
+	// Recommend exportation of HC_CONFIG/HC_DATA env vars if applicable
+	let shell_profile = match std::env::var("SHELL").as_ref().map(String::as_str) {
+		Ok("/bin/zsh") | Ok("/usr/bin/zsh") => ".zshrc",
+		Ok("/bin/bash") | Ok("/usr/bin/bash") => ".bash_profile",
+		_ => ".profile",
+	};
+
+	println!(
+		"Manually add the following to your '$HOME/{}' (or similar) if you haven't already",
+		shell_profile
+	);
+	println!("\texport HC_CONFIG={:?}", abs_conf_path);
+	println!("\texport HC_DATA={:?}", abs_data_path);
+
+	println!("Run `hc help` to get started");
+
+	ExitCode::SUCCESS
 }
 
 #[derive(Debug)]

--- a/hipcheck/src/setup.rs
+++ b/hipcheck/src/setup.rs
@@ -1,0 +1,179 @@
+use crate::cli::SetupArgs;
+use crate::error::Result;
+use crate::hc_error;
+use crate::http::tls::new_agent;
+use pathbuf::pathbuf;
+use regex::Regex;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tar::Archive;
+use xz2::read::XzDecoder;
+
+static R_HC_SOURCE: OnceLock<Regex> = OnceLock::new();
+
+fn get_source_regex<'a>() -> &'a Regex {
+	R_HC_SOURCE.get_or_init(|| Regex::new("^hipcheck-[a-z0-9_]+-[a-z0-9_]+-[a-z0-9_]+").unwrap())
+}
+
+#[derive(Debug, Clone)]
+pub struct SetupSourcePath {
+	pub path: SourceType,
+	delete: bool,
+}
+impl SetupSourcePath {
+	pub fn cleanup(&self) {
+		use SourceType::*;
+		if self.delete {
+			let _res = match &self.path {
+				Dir(p) => std::fs::remove_dir_all(p),
+				Tar(p) | Zip(p) => std::fs::remove_file(p),
+			};
+		}
+	}
+	pub fn try_unpack(self) -> Result<SetupSourcePath> {
+		use SourceType::*;
+		let (new_path, delete) = match self.path.clone() {
+			Dir(p) => (p, self.delete),
+			// For tars and zips, we have to provide the decompressor with the parent dir,
+			//  which will produce a directory with the same name as the archive minus the
+			//  file extension. We return the name of that new directory.
+			Tar(p) => {
+				let new_fname: &str = p
+					.file_name()
+					.ok_or(hc_error!("malformed file name"))?
+					.to_str()
+					.ok_or(hc_error!("failed to convert tar file name to utf8"))?
+					.strip_suffix(".tar.xz")
+					.ok_or(hc_error!("tar file with improper extension"))?;
+				let tgt_p = p.with_file_name(new_fname);
+				let parent_p = PathBuf::from(tgt_p.as_path().parent().unwrap());
+				let tar_gz = File::open(p)?;
+				let mut archive = Archive::new(XzDecoder::new(tar_gz));
+				archive.unpack(parent_p.as_path())?;
+				self.cleanup();
+				(tgt_p, true)
+			}
+			Zip(p) => {
+				let new_fname: &str = p
+					.file_stem()
+					.ok_or(hc_error!("malformed .zip file name"))?
+					.to_str()
+					.ok_or(hc_error!(".zip file not utf8"))?;
+				let tgt_p = p.with_file_name(new_fname);
+				let parent_p = PathBuf::from(tgt_p.as_path().parent().unwrap());
+				let mut archive = zip::ZipArchive::new(File::open(p)?)?;
+				archive.extract(parent_p.as_path())?;
+				self.cleanup();
+				(tgt_p, true)
+			}
+		};
+		Ok(SetupSourcePath {
+			path: SourceType::Dir(new_path),
+			delete,
+		})
+	}
+}
+
+#[derive(Debug, Clone)]
+pub enum SourceType {
+	Dir(PathBuf),
+	Tar(PathBuf),
+	Zip(PathBuf),
+}
+impl TryFrom<&Path> for SourceType {
+	type Error = crate::error::Error;
+	fn try_from(value: &Path) -> Result<SourceType> {
+		use SourceType::*;
+		let source_regex = get_source_regex();
+		let file_name = value
+			.file_name()
+			.ok_or(hc_error!("path without a file name"))?
+			.to_str()
+			.ok_or(hc_error!("file name not valid utf8"))?;
+		if !source_regex.is_match(file_name) {
+			return Err(hc_error!("file does not match regex"));
+		}
+		if value.is_dir() {
+			return Ok(Dir(PathBuf::from(value)));
+		}
+		if file_name.ends_with(".tar.xz") {
+			return Ok(Tar(PathBuf::from(value)));
+		}
+		if file_name.ends_with(".zip") {
+			return Ok(Zip(PathBuf::from(value)));
+		}
+		return Err(hc_error!("unknown source type"));
+	}
+}
+
+pub fn search_dir_for_source(path: &Path) -> Option<SourceType> {
+	for r_entry in walkdir::WalkDir::new(path).max_depth(1) {
+		if let Ok(entry) = r_entry {
+			if let Ok(source) = SourceType::try_from(entry.path()) {
+				return Some(source);
+			}
+		}
+	}
+	None
+}
+
+pub fn try_get_source_path_from_path(path: &Path) -> Option<SourceType> {
+	// First treat path as a direct source dir / archive
+	if let Ok(source) = SourceType::try_from(path) {
+		Some(source)
+	}
+	// If that failed and path is a dir, see if we can find it underneath
+	else if path.is_dir() {
+		search_dir_for_source(path)
+	} else {
+		None
+	}
+}
+
+pub fn try_resolve_source_path(args: &SetupArgs) -> Result<SetupSourcePath> {
+	let try_dirs: Vec<Option<PathBuf>> = vec![
+		args.source.clone(),
+		std::env::current_dir().ok(),
+		dirs::download_dir(),
+	];
+	for opt_dir in try_dirs {
+		if let Some(try_dir) = opt_dir {
+			if let Some(bp) = try_get_source_path_from_path(try_dir.as_path()) {
+				return Ok(SetupSourcePath {
+					path: bp,
+					delete: false,
+				});
+			}
+		}
+	}
+	// If allowed by user, download from github
+	if !args.offline {
+		// Since we're just getting the conf/target dir from here, we don't
+		// technically need to grab the right version
+		let f_name: &str = "hipcheck-x86_64-unknown-linux-gnu.tar.xz";
+		let remote = format!(
+			"https://github.com/mitre/hipcheck/releases/download/hipcheck-v{}/{}",
+			env!("CARGO_PKG_VERSION"),
+			f_name
+		);
+
+		let mut out_file = File::create(f_name)?;
+		let agent = new_agent()?;
+
+		println!("Downloading Hipcheck release from remote.");
+		let resp = agent.get(remote.as_str()).call()?;
+		std::io::copy(&mut resp.into_reader(), &mut out_file)?;
+
+		return Ok(SetupSourcePath {
+			path: SourceType::Tar(std::fs::canonicalize(f_name)?),
+			delete: true,
+		});
+	}
+	Err(hc_error!("could not find suitable source file"))
+}
+
+pub fn resolve_and_transform_source(args: &SetupArgs) -> Result<SetupSourcePath> {
+	try_resolve_source_path(args)?.try_unpack()
+}


### PR DESCRIPTION
Resolves #103.

This PR adds the `hc setup` CLI command for finishing the installation of an `hc` binary. This primarily includes:
-  acquiring target locations for the `HC_CONFIG, HC_DATA` directories. 
    - creating those directories if they don't exist
- finding a suitable local copy of a `cargo-dist` release bundle for Hipcheck
  - this could be a dir, zip, or tar.xz file
  - if none is found, one will be automatically downloaded from our Hipcheck release page on github
- decompressing the source bundle if applicable, and copying the contents of the source `config/, scripts/` dirs to `HC_CONFIG, HC_DATA`, respectively.
- cleaning up any downloaded files or uncompressed directories created in service of the above operations

The cmdline is `hc setup [--offline] [SOURCE]`. If `--offline` provided, we won't try to pull the release bundle from github as a last resort when failing to find a local copy. `SOURCE` is an optional positional arg for the user to explicitly specify a directory/file that is the release bundle. 

**New Dependencies**
In order to support decompressing `.zip` and `.tar.xz` files, I added dependencies on `tar`, `zip`, and `xz2` crates. An alternative design decision could be to use `process::Command` and expect these utilities exist on the host machine, but I opted for adding libraries so we avoid OS-specific considerations.

**setup.rs::try_resolve_source_path()**
See code comments for overview. I chose to make it so this source resolution system does not take into account target triple of the release. Since we are just copying files (no executables) from dirs, I figured it shouldn't matter. When pulling from github, it does use the correct version, but otherwise it doesn't check the version of any local releases found. 

**setup.rs::SetupSourcePath**
Designed to be a representation of a file/dir that can be used for copying `config`, `scripts` dirs. `try_unpack()` is for decompressing archives into dirs so we can do the actual subdir copying. `delete: bool` allows us to track what should and should not be deleted. For instance, if we find a local `hipcheck` bundle dir already decompressed, we should use it but not touch it. However, if we need to download the release bundle from Github, we should delete both the downloaded archive and the folder that it gets decompressed into. We could consider replacing `delete()` with `impl Drop` in the future, but I thought that was maybe more fancy than useful.