### PR TITLE
chore: Removes patch type as option

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -458,9 +458,6 @@ pub enum CheckCommand {
 	/// Analyze an npm package git repo via package URI or with format <package name>[@<optional version>]
 	#[command(hide = true)]
 	Npm(CheckNpmArgs),
-	/// Analyze 'git' patches for projects that use a patch-based workflow (not yet implemented)
-	#[command(hide = true)]
-	Patch(CheckPatchArgs),
 	/// Analyze a PyPI package git repo via package URI or with format <package name>[@<optional version>]
 	#[command(hide = true)]
 	Pypi(CheckPypiArgs),
@@ -485,10 +482,6 @@ impl CheckCommand {
 			CheckCommand::Npm(args) => Check {
 				target: args.package.clone(),
 				kind: CheckKind::Npm,
-			},
-			CheckCommand::Patch(args) => Check {
-				target: args.patch_file_uri.clone(),
-				kind: CheckKind::Patch,
 			},
 			CheckCommand::Pypi(args) => Check {
 				target: args.package.clone(),
@@ -520,13 +513,6 @@ pub struct CheckMavenArgs {
 pub struct CheckNpmArgs {
 	/// NPM package URI or package[@<optional version>] to analyze
 	pub package: String,
-}
-
-#[derive(Debug, Clone, clap::Args)]
-pub struct CheckPatchArgs {
-	/// Path to Git patch file to analyze
-	#[arg(value_name = "PATCH FILE URI")]
-	pub patch_file_uri: String,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -566,8 +552,6 @@ pub enum SchemaCommand {
 	Maven,
 	/// Print the JSON schema for running Hipcheck against a NPM package
 	Npm,
-	/// Print the JSON schema for running Hipcheck against a Git patchfile
-	Patch,
 	/// Print the JSON schema for running Hipcheck against a PyPI package
 	Pypi,
 	/// Print the JSON schema for running Hipcheck against a source repository

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -150,7 +150,6 @@ fn cmd_schema(args: &SchemaArgs) {
 	match args.command {
 		SchemaCommand::Maven => print_maven_schema(),
 		SchemaCommand::Npm => print_npm_schema(),
-		SchemaCommand::Patch => print_patch_schema(),
 		SchemaCommand::Pypi => print_pypi_schema(),
 		SchemaCommand::Repo => print_report_schema(),
 		SchemaCommand::Request => print_request_schema(),
@@ -460,11 +459,6 @@ fn print_npm_schema() {
 	print_missing()
 }
 
-/// Print the JSON schema of the patch.
-fn print_patch_schema() {
-	print_missing()
-}
-
 /// Print the JSON schema of the pypi package
 fn print_pypi_schema() {
 	print_missing()
@@ -493,7 +487,6 @@ const EXIT_FAILURE: i32 = 1;
 enum CheckKind {
 	Repo,
 	Request,
-	Patch,
 	Maven,
 	Npm,
 	Pypi,
@@ -506,7 +499,6 @@ impl CheckKind {
 		match self {
 			CheckKind::Repo => "repo",
 			CheckKind::Request => "request",
-			CheckKind::Patch => "patch",
 			CheckKind::Maven => "maven",
 			CheckKind::Npm => "npm",
 			CheckKind::Pypi => "pypi",
@@ -519,7 +511,6 @@ impl CheckKind {
 		match self {
 			CheckKind::Repo => TargetKind::RepoSource,
 			CheckKind::Request => TargetKind::PrUri,
-			CheckKind::Patch => TargetKind::PatchUri,
 			CheckKind::Maven => TargetKind::PackageVersion,
 			CheckKind::Npm => TargetKind::PackageVersion,
 			CheckKind::Pypi => TargetKind::PackageVersion,
@@ -680,12 +671,6 @@ fn run_with_shell(
 
 			(session.end(), Ok(AnyReport::PrReport(pr_report)))
 		}
-		_ => (
-			session.end(),
-			Err(Error::msg(
-				"Hipcheck attempted to analyze an unsupported type",
-			)),
-		),
 	}
 }
 

--- a/hipcheck/src/session/session.rs
+++ b/hipcheck/src/session/session.rs
@@ -295,7 +295,6 @@ fn load_source(
 		TargetKind::PrUri => "resolving git pull request source",
 		TargetKind::PackageVersion => "resolving package source",
 		TargetKind::SpdxDocument => "parsing SPDX document",
-		_ => return Err(hc_error!("source specified was not a valid source")),
 	};
 
 	let mut phase = shell.phase(phase_desc)?;
@@ -354,7 +353,6 @@ fn resolve_source(
 				kind: SourceKind::Repo(repo),
 			})
 		}
-		_ => Err(Error::msg("source specified was not a valid source")),
 	}
 }
 
@@ -367,7 +365,6 @@ pub struct Check {
 pub enum TargetKind {
 	RepoSource,
 	PrUri,
-	PatchUri,
 	PackageVersion,
 	SpdxDocument,
 }
@@ -378,7 +375,6 @@ impl TargetKind {
 
 		match self {
 			RepoSource | PrUri | PackageVersion | SpdxDocument => true,
-			PatchUri => false,
 		}
 	}
 }

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -6,7 +6,6 @@ use serde::Serialize;
 pub enum TargetType {
 	Maven,
 	Npm,
-	Patch,
 	Pypi,
 	Repo,
 	Request,


### PR DESCRIPTION
Resolves issue #95 

Removes all code that  "patch" as an option for `hc check` and `hc schema`, as Hipcheck currently does not support patches as a type to check.

Also removes the "unsupported type" and "not a valid type" error options for target types in the places they appear, as those would now be unreachable code blocks.