### PR TITLE
chore: refactor affiliation analysis, experiment with macro

### DIFF
--- a/hipcheck/src/analysis/result.rs
+++ b/hipcheck/src/analysis/result.rs
@@ -112,8 +112,14 @@ pub enum HCCompositeValue {
 }
 
 /// The set of possible predicates for deciding if a source passed an analysis.
-pub trait HCPredicate: Display + std::fmt::Debug + std::any::Any + 'static {
+pub trait HCPredicate: Display + std::fmt::Debug {
 	fn pass(&self) -> Result<bool>;
+}
+
+pub struct ThresholdSpec {
+	pub threshold: HCBasicValue,
+	pub units: Option<String>,
+	pub ordering: Ordering,
 }
 
 /// This predicate determines analysis pass/fail by whether a returned value was


### PR DESCRIPTION
(new copy of PR #132 rebased off of main)

Continuation of effort on #28.

This adds affiliation to the set of analyses using the new scoring/storage system, but the main contribution of this PR is the run_and_score_threshold_analysis macro defined in score.rs. If approved, this will make converting the rest of the analyses much simpler and reduce lines of (committed) code. The macro is a bit in-elegant but we expect churn in this area of Hipcheck in the next few months anyway, I doubt this will remain for very long.

It might also be worthwhile to add a similar macro for analyses on the new system in analysis/report_builder.rs.