### PR TITLE
feat: add weight tree and replace old scoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,12 +769,14 @@ dependencies = [
  "graphql_client",
  "hipcheck-macros",
  "indexmap 2.2.6",
+ "indextree",
  "indicatif",
  "indicatif-log-bridge",
  "libc",
  "log",
  "maplit",
  "nom",
+ "num-traits",
  "once_cell",
  "ordered-float",
  "paste",
@@ -893,6 +895,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "indextree"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6f7e29c1619ec492f411b021ac9f30649d5f522ca6f287f2467ee48c8dfe10"
 
 [[package]]
 name = "indicatif"

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -79,6 +79,8 @@ indicatif-log-bridge = "0.2.2"
 tar = "0.4.41"
 zip = "2.1.3"
 xz2 = "0.1.7"
+indextree = "4.6.1"
+num-traits = "0.2.19"
 
 # Windows-specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/hipcheck/src/analysis/report_builder.rs
+++ b/hipcheck/src/analysis/report_builder.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::analysis::analysis::AnalysisReport;
 use crate::analysis::result::{HCBasicValue, HCPredicate, Predicate};
 use crate::analysis::score::*;
 use crate::config::RiskConfigQuery;

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::analysis::analysis::AnalysisOutcome;
-use crate::analysis::analysis::AnalysisReport;
 use crate::analysis::result::*;
 use crate::analysis::AnalysisProvider;
 use crate::config::{visit_leaves, WeightTree, WeightTreeProvider};
@@ -9,17 +8,13 @@ use crate::error::Result;
 use crate::hc_error;
 use crate::report::Concern;
 use crate::shell::Phase;
-use crate::F64;
+use num_traits::identities::Zero;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::default::Default;
 use std::sync::Arc;
 
-use indextree::{Arena, NodeEdge, NodeId};
-use petgraph::graph::node_index as n;
-use petgraph::graph::NodeIndex;
-use petgraph::prelude::Graph;
-use petgraph::EdgeDirection::Outgoing;
+use indextree::{Arena, NodeId};
 
 pub const RISK_PHASE: &str = "risk";
 
@@ -136,12 +131,49 @@ impl Default for ScoreResult {
 	}
 }
 
+fn normalize_st_internal(node: NodeId, tree: &mut Arena<ScoreTreeNode>) -> f64 {
+	let children: Vec<NodeId> = node.children(tree).collect();
+	let weight_sum: f64 = children
+		.iter()
+		.map(|n| normalize_st_internal(*n, tree))
+		.sum();
+	if !weight_sum.is_zero() {
+		for c in children {
+			let child = tree.get_mut(c).unwrap().get_mut();
+			child.weight /= weight_sum;
+		}
+	}
+	tree.get(node).unwrap().get().weight
+}
+
 #[derive(Debug, Clone)]
 pub struct AltScoreTree {
 	pub tree: Arena<ScoreTreeNode>,
 	pub root: NodeId,
 }
 impl AltScoreTree {
+	pub fn new(root_label: &str) -> Self {
+		let mut tree = Arena::<ScoreTreeNode>::new();
+		let root = tree.new_node(ScoreTreeNode {
+			label: root_label.to_owned(),
+			score: -1.0,
+			weight: 1.0,
+		});
+		AltScoreTree { tree, root }
+	}
+	pub fn add_child(&mut self, under: NodeId, label: &str, score: f64, weight: f64) -> NodeId {
+		let child = self.tree.new_node(ScoreTreeNode {
+			label: label.to_owned(),
+			score,
+			weight,
+		});
+		under.append(child, &mut self.tree);
+		child
+	}
+	pub fn normalize(mut self) -> Self {
+		let _ = normalize_st_internal(self.root, &mut self.tree);
+		self
+	}
 	// Given a weight tree and set of analysis results, produce an AltScoreTree by creating
 	// ScoreTreeNode objects for each analysis that was not skipped, and composing them into
 	// a tree structure matching that of the WeightTree
@@ -190,22 +222,16 @@ impl AltScoreTree {
 	// As our scope, we track the weight of each node. Once we get to a leaf node, we multiply all
 	// the weights (already normalized) by the score (0/1) then sum each value
 	pub fn score(&self) -> f64 {
-		visit_leaves(
+		let raw_score = visit_leaves(
 			self.root,
 			&self.tree,
 			|n| n.weight,
 			|a, n| a.iter().product::<f64>() * n.score,
 		)
 		.into_iter()
-		.sum()
+		.sum();
+		decimal_truncate(raw_score)
 	}
-}
-
-//stores the score tree using petgraph
-//the tree does not need to know what sections it is scoring
-#[derive(Debug, Clone)]
-pub struct ScoreTree {
-	pub tree: Graph<ScoreTreeNode, f64>,
 }
 
 //stores the score tree using petgraph
@@ -221,7 +247,7 @@ pub struct ScoreTreeNode {
 // returns score result for each phase based on phase name
 // pass (a score of 0) or fail (a score of 1)
 pub fn phase_outcome<P: AsRef<String>>(
-	db: &dyn ScoringProvider,
+	_db: &dyn ScoringProvider,
 	phase_name: P,
 ) -> Result<Arc<ScoreResult>> {
 	match phase_name.as_ref().as_str() {
@@ -260,63 +286,13 @@ pub fn update_phase(phase: &mut Phase, phase_name: &str) -> Result<()> {
 	}
 }
 
-//Scores phase and adds nodes and edges to tree
-pub fn add_node_and_edge_with_score(
-	score_result: impl AsRef<ScoreResult>,
-	mut score_tree: ScoreTree,
-	phase: &str,
-	parent_node: NodeIndex<u32>,
-) -> Result<ScoreTree> {
-	let weight = score_result.as_ref().count as f64;
-	let score_increment = score_result.as_ref().score as i64;
-
-	//adding nodes/edges to the score tree
-	let (child_node, score_tree_updated) =
-		match add_tree_node(score_tree.clone(), phase, score_increment, weight) {
-			Ok(results) => results,
-			_ => {
-				return Err(hc_error!(
-					"failed to add score tree node for {} scoring.",
-					phase
-				))
-			}
-		};
-
-	score_tree = add_tree_edge(score_tree_updated, child_node, parent_node);
-
-	Ok(score_tree)
-}
-
-pub fn add_tree_node(
-	mut score_tree: ScoreTree,
-	phase: &str,
-	score_increment: i64,
-	weight: f64,
-) -> Result<(NodeIndex, ScoreTree)> {
-	let score_node = score_tree.tree.add_node(ScoreTreeNode {
-		label: phase.to_string(),
-		score: score_increment as f64,
-		weight,
-	});
-	Ok((score_node, score_tree))
-}
-
-pub fn add_tree_edge(
-	mut score_tree: ScoreTree,
-	child_node: NodeIndex,
-	parent_node: NodeIndex,
-) -> ScoreTree {
-	score_tree.tree.add_edge(parent_node, child_node, 0.0);
-	score_tree
-}
-
 macro_rules! run_and_score_threshold_analysis {
 	($res:ident, $p:ident, $phase:ident, $a:expr, $spec:ident) => {{
 		update_phase($p, $phase)?;
 		let analysis_result =
 			ThresholdPredicate::from_analysis(&$a, $spec.threshold, $spec.units, $spec.ordering);
 		$res.table.insert($phase.to_owned(), analysis_result);
-		let (an_score, outcome) = $res.table.get($phase).unwrap().score();
+		let (_an_score, outcome) = $res.table.get($phase).unwrap().score();
 		outcome
 	}};
 }
@@ -495,33 +471,6 @@ pub fn score_results(phase: &mut Phase, db: &dyn ScoringProvider) -> Result<Scor
 	Ok(ScoringResults { results, score })
 }
 
-fn score_nodes(node: NodeIndex, gr: Graph<ScoreTreeNode, f64>) -> f64 {
-	//get all children to get full weight for node/branch level
-	let mut children = gr.neighbors_directed(node, Outgoing).detach();
-
-	let mut child_weight_sums = 0.0;
-	let sums = gr.clone();
-	let mut weights = children.clone();
-	//add child weights together so we can get weight later
-	while let Some(child) = weights.next_node(&sums) {
-		child_weight_sums += sums[child].weight;
-	}
-
-	if child_weight_sums == 0.0 {
-		//if node has no children return the node score
-		return gr[node].score;
-	}
-
-	let mut score = 0.0;
-	while let Some(child) = children.next_node(&gr) {
-		let child_weight = gr[child].weight / child_weight_sums;
-
-		//using recursion to get children node scores, this takes us to last node first in the end
-		score += score_nodes(child, gr.clone()) * child_weight;
-	}
-	decimal_truncate(score)
-}
-
 fn decimal_truncate(score: f64) -> f64 {
 	(score * 100.0).round() / 100.0
 }
@@ -529,7 +478,6 @@ fn decimal_truncate(score: f64) -> f64 {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use petgraph::Graph;
 
 	//We use -1.0 values for parent nodes basically that get scored through recursion based on child nodes that have a score set and weight
 
@@ -549,81 +497,22 @@ mod test {
 	#[test]
 	#[ignore = "test of tree scoring"]
 	fn test_graph1() {
-		let mut score_tree = ScoreTree { tree: Graph::new() };
-		let core = score_tree.tree.add_node(ScoreTreeNode {
-			label: "risk".to_string(),
-			score: -1.0,
-			weight: -1.0,
-		});
-		let practices = score_tree.tree.add_node(ScoreTreeNode {
-			label: PRACTICES_PHASE.to_string(),
-			score: -1.0,
-			weight: 10.0,
-		});
-		let review = score_tree.tree.add_node(ScoreTreeNode {
-			label: REVIEW_PHASE.to_string(),
-			score: 1.0,
-			weight: 5.0,
-		});
-		let activity = score_tree.tree.add_node(ScoreTreeNode {
-			label: ACTIVITY_PHASE.to_string(),
-			score: 0.0,
-			weight: 4.0,
-		});
-		let attacks = score_tree.tree.add_node(ScoreTreeNode {
-			label: ATTACKS_PHASE.to_string(),
-			score: -1.0,
-			weight: 20.0,
-		});
-		let commits = score_tree.tree.add_node(ScoreTreeNode {
-			label: COMMITS_PHASE.to_string(),
-			score: -1.0,
-			weight: 5.0,
-		});
-		let trust = score_tree.tree.add_node(ScoreTreeNode {
-			label: "trust".to_string(),
-			score: 1.0,
-			weight: 4.0,
-		});
-		let code_review = score_tree.tree.add_node(ScoreTreeNode {
-			label: "code review".to_string(),
-			score: 0.0,
-			weight: 3.0,
-		});
-		let entropy = score_tree.tree.add_node(ScoreTreeNode {
-			label: ENTROPY_PHASE.to_string(),
-			score: 0.0,
-			weight: 2.0,
-		});
-		let churn = score_tree.tree.add_node(ScoreTreeNode {
-			label: CHURN_PHASE.to_string(),
-			score: 1.0,
-			weight: 10.0,
-		});
-		let typo = score_tree.tree.add_node(ScoreTreeNode {
-			label: TYPO_PHASE.to_string(),
-			score: 1.0,
-			weight: 5.0,
-		});
-		//edge weights are not used
-		score_tree.tree.add_edge(core, practices, 0.0);
-		score_tree.tree.add_edge(core, attacks, 0.0);
-
-		score_tree.tree.add_edge(practices, review, 0.0);
-		score_tree.tree.add_edge(practices, activity, 0.0);
-
-		score_tree.tree.add_edge(attacks, commits, 0.0);
-		score_tree.tree.add_edge(attacks, typo, 0.0);
-
-		score_tree.tree.add_edge(commits, trust, 0.0);
-		score_tree.tree.add_edge(commits, code_review, 0.0);
-		score_tree.tree.add_edge(commits, entropy, 0.0);
-		score_tree.tree.add_edge(commits, churn, 0.0);
-
-		let final_score = score_nodes(core, score_tree.tree);
+		let mut score_tree = AltScoreTree::new("risk");
+		let core = score_tree.root;
+		let practices = score_tree.add_child(core, PRACTICES_PHASE, -1.0, 10.0);
+		let review = score_tree.add_child(practices, REVIEW_PHASE, 1.0, 5.0);
+		let activity = score_tree.add_child(practices, ACTIVITY_PHASE, 0.0, 4.0);
+		let attacks = score_tree.add_child(core, ATTACKS_PHASE, -1.0, 20.0);
+		let commits = score_tree.add_child(attacks, COMMITS_PHASE, -1.0, 5.0);
+		let trust = score_tree.add_child(commits, "trust", 1.0, 4.0);
+		let code_review = score_tree.add_child(commits, "code_review", 0.0, 3.0);
+		let entropy = score_tree.add_child(commits, ENTROPY_PHASE, 0.0, 2.0);
+		let churn = score_tree.add_child(commits, CHURN_PHASE, 1.0, 10.0);
+		let typo = score_tree.add_child(attacks, TYPO_PHASE, 1.0, 5.0);
+		let final_score = score_tree.normalize().score();
 		println!("final score {}", final_score);
 
-		assert_eq!(0.77, final_score);
+		assert_eq!(0.76, final_score);
 	}
 
 	/*
@@ -638,53 +527,15 @@ mod test {
 	#[test]
 	#[ignore = "test2 of tree scoring"]
 	fn test_graph2() {
-		let mut score_tree = ScoreTree { tree: Graph::new() };
-		let core = score_tree.tree.add_node(ScoreTreeNode {
-			label: "risk".to_string(),
-			score: -1.0,
-			weight: -1.0,
-		});
-		let practices = score_tree.tree.add_node(ScoreTreeNode {
-			label: PRACTICES_PHASE.to_string(),
-			score: -1.0,
-			weight: 10.0,
-		});
-		let review = score_tree.tree.add_node(ScoreTreeNode {
-			label: REVIEW_PHASE.to_string(),
-			score: 1.0,
-			weight: 4.0,
-		});
-		let activity = score_tree.tree.add_node(ScoreTreeNode {
-			label: ACTIVITY_PHASE.to_string(),
-			score: 1.0,
-			weight: 5.0,
-		});
-		let attacks = score_tree.tree.add_node(ScoreTreeNode {
-			label: ATTACKS_PHASE.to_string(),
-			score: -1.0,
-			weight: 15.0,
-		});
-		let code_review = score_tree.tree.add_node(ScoreTreeNode {
-			label: "code review".to_string(),
-			score: 0.0,
-			weight: 6.0,
-		});
-		let entropy = score_tree.tree.add_node(ScoreTreeNode {
-			label: ENTROPY_PHASE.to_string(),
-			score: 0.0,
-			weight: 7.0,
-		});
-		//edge weights are not used
-		score_tree.tree.add_edge(core, practices, 0.0);
-		score_tree.tree.add_edge(core, attacks, 0.0);
-
-		score_tree.tree.add_edge(practices, review, 0.0);
-		score_tree.tree.add_edge(practices, activity, 0.0);
-
-		score_tree.tree.add_edge(attacks, code_review, 0.0);
-		score_tree.tree.add_edge(attacks, entropy, 0.0);
-
-		let final_score = score_nodes(core, score_tree.tree);
+		let mut score_tree = AltScoreTree::new("risk");
+		let core = score_tree.root;
+		let practices = score_tree.add_child(core, PRACTICES_PHASE, -1.0, 10.0);
+		let review = score_tree.add_child(practices, REVIEW_PHASE, 1.0, 4.0);
+		let activity = score_tree.add_child(practices, ACTIVITY_PHASE, 1.0, 5.0);
+		let attacks = score_tree.add_child(core, ATTACKS_PHASE, -1.0, 15.0);
+		let code_review = score_tree.add_child(attacks, "code_review", 0.0, 6.0);
+		let entropy = score_tree.add_child(attacks, ENTROPY_PHASE, 0.0, 7.0);
+		let final_score = score_tree.normalize().score();
 		println!("final score {}", final_score);
 
 		assert_eq!(0.4, final_score);
@@ -702,53 +553,15 @@ mod test {
 	#[test]
 	#[ignore = "test3 of tree scoring"]
 	fn test_graph3() {
-		let mut score_tree = ScoreTree { tree: Graph::new() };
-		let core = score_tree.tree.add_node(ScoreTreeNode {
-			label: "risk".to_string(),
-			score: -1.0,
-			weight: -1.0,
-		});
-		let practices = score_tree.tree.add_node(ScoreTreeNode {
-			label: PRACTICES_PHASE.to_string(),
-			score: -1.0,
-			weight: 33.0,
-		});
-		let review = score_tree.tree.add_node(ScoreTreeNode {
-			label: REVIEW_PHASE.to_string(),
-			score: 1.0,
-			weight: 10.0,
-		});
-		let activity = score_tree.tree.add_node(ScoreTreeNode {
-			label: ACTIVITY_PHASE.to_string(),
-			score: 1.0,
-			weight: 5.0,
-		});
-		let attacks = score_tree.tree.add_node(ScoreTreeNode {
-			label: ATTACKS_PHASE.to_string(),
-			score: -1.0,
-			weight: 15.0,
-		});
-		let code_review = score_tree.tree.add_node(ScoreTreeNode {
-			label: "code review".to_string(),
-			score: 1.0,
-			weight: 6.0,
-		});
-		let entropy = score_tree.tree.add_node(ScoreTreeNode {
-			label: ENTROPY_PHASE.to_string(),
-			score: 1.0,
-			weight: 15.0,
-		});
-		//edge weights are not used
-		score_tree.tree.add_edge(core, practices, 0.0);
-		score_tree.tree.add_edge(core, attacks, 0.0);
-
-		score_tree.tree.add_edge(practices, review, 0.0);
-		score_tree.tree.add_edge(practices, activity, 0.0);
-
-		score_tree.tree.add_edge(attacks, code_review, 0.0);
-		score_tree.tree.add_edge(attacks, entropy, 0.0);
-
-		let final_score = score_nodes(core, score_tree.tree);
+		let mut score_tree = AltScoreTree::new("risk");
+		let core = score_tree.root;
+		let practices = score_tree.add_child(core, PRACTICES_PHASE, -1.0, 33.0);
+		let review = score_tree.add_child(practices, REVIEW_PHASE, 1.0, 10.0);
+		let activity = score_tree.add_child(practices, ACTIVITY_PHASE, 1.0, 5.0);
+		let attacks = score_tree.add_child(core, ATTACKS_PHASE, -1.0, 15.0);
+		let code_review = score_tree.add_child(attacks, "code_review", 1.0, 6.0);
+		let entropy = score_tree.add_child(attacks, ENTROPY_PHASE, 1.0, 15.0);
+		let final_score = score_tree.normalize().score();
 		println!("final score {}", final_score);
 
 		assert_eq!(1.0, final_score);
@@ -767,53 +580,15 @@ mod test {
 	#[test]
 	#[ignore = "test4 of tree scoring"]
 	fn test_graph4() {
-		let mut score_tree = ScoreTree { tree: Graph::new() };
-		let core = score_tree.tree.add_node(ScoreTreeNode {
-			label: "risk".to_string(),
-			score: -1.0,
-			weight: -1.0,
-		});
-		let practices = score_tree.tree.add_node(ScoreTreeNode {
-			label: PRACTICES_PHASE.to_string(),
-			score: -1.0,
-			weight: 40.0,
-		});
-		let review = score_tree.tree.add_node(ScoreTreeNode {
-			label: REVIEW_PHASE.to_string(),
-			score: 0.0,
-			weight: 12.0,
-		});
-		let activity = score_tree.tree.add_node(ScoreTreeNode {
-			label: ACTIVITY_PHASE.to_string(),
-			score: 1.0,
-			weight: 6.0,
-		});
-		let attacks = score_tree.tree.add_node(ScoreTreeNode {
-			label: ATTACKS_PHASE.to_string(),
-			score: -1.0,
-			weight: 15.0,
-		});
-		let code_review = score_tree.tree.add_node(ScoreTreeNode {
-			label: "code review".to_string(),
-			score: 0.0,
-			weight: 9.0,
-		});
-		let entropy = score_tree.tree.add_node(ScoreTreeNode {
-			label: ENTROPY_PHASE.to_string(),
-			score: 1.0,
-			weight: 13.0,
-		});
-		//edge weights are not used
-		score_tree.tree.add_edge(core, practices, 0.0);
-		score_tree.tree.add_edge(core, attacks, 0.0);
-
-		score_tree.tree.add_edge(practices, review, 0.0);
-		score_tree.tree.add_edge(practices, activity, 0.0);
-
-		score_tree.tree.add_edge(attacks, code_review, 0.0);
-		score_tree.tree.add_edge(attacks, entropy, 0.0);
-
-		let final_score = score_nodes(core, score_tree.tree);
+		let mut score_tree = AltScoreTree::new("risk");
+		let core = score_tree.root;
+		let practices = score_tree.add_child(core, PRACTICES_PHASE, -1.0, 40.0);
+		let review = score_tree.add_child(practices, REVIEW_PHASE, 0.0, 12.0);
+		let activity = score_tree.add_child(practices, ACTIVITY_PHASE, 1.0, 6.0);
+		let attacks = score_tree.add_child(core, ATTACKS_PHASE, -1.0, 15.0);
+		let code_review = score_tree.add_child(attacks, "code_review", 0.0, 9.0);
+		let entropy = score_tree.add_child(attacks, ENTROPY_PHASE, 1.0, 13.0);
+		let final_score = score_tree.normalize().score();
 		println!("final score {}", final_score);
 
 		assert_eq!(0.40, final_score);

--- a/hipcheck/src/session/session.rs
+++ b/hipcheck/src/session/session.rs
@@ -15,6 +15,7 @@ use crate::config::FuzzConfigQueryStorage;
 use crate::config::LanguagesConfigQueryStorage;
 use crate::config::PracticesConfigQueryStorage;
 use crate::config::RiskConfigQueryStorage;
+use crate::config::WeightTreeQueryStorage;
 use crate::context::Context as _;
 use crate::data::git::get_git_version;
 use crate::data::git::GitProviderStorage;
@@ -80,7 +81,8 @@ use std::sync::Arc;
 	RiskConfigQueryStorage,
 	ScoringProviderStorage,
 	SourceQueryStorage,
-	VersionQueryStorage
+	VersionQueryStorage,
+	WeightTreeQueryStorage
 )]
 pub struct Session {
 	/// The shell interface, for outputting progress.


### PR DESCRIPTION
Continuation of effort on #28 .

This PR introduces the "weight tree" - a tree structure containing the normalized weights of each analysis according to the config. Presently, the structure of the weight tree (i.e. which analyses fall under which parent nodes) is hard-coded to match the existing analysis hierarchy, but in the future plugin system the abstraction of getting a weight tree from salsa can allow us to produce differently-shaped trees.

The weight tree can be combined with the hashmap-style `AnalysisResults` objects that previous PR #159 made the de facto storage location for analysis results. This function `synthesize()` produces an `AltScoreTree` (to be renamed upon becoming the de facto scoring tool). As the code walks the `WeightTree`, it uses the analysis label to index the `AnalysisResults` object, call `score()` on it, and produce an instance of the existing `ScoreTreeNode` struct (to reduce duplication, but likely after this some fields of that struct can get pared down).

Once we have an `AltScoreTree`, we simply call the `score()` function on it. This uses the generic `visit_leaves()` function, which allows tracking of some scope, and then aggregates the results of calling a user-provided function on each leaf node. In this way, we multiply the score of the leaf node (0/1) with the product of all the weights from it to the root node, and then sum the resulting float of each leaf node to get the "score". Because it does not truncate floats prematurely, the score generated by this system may be +/- 1% of the previous score for the same repo analysis.

Since the `AltScoreTree` now does scoring, there is no need for the old `ScoreTree`, and the creation and tracking of it in `score_results()` has been removed. As a result, the `run_and_score_threshold_analysis` macro could also be greatly simplified.

Finally, I have replace the behavior of the tests in `score.rs` and deleted the now-obsolete ScoreTree helper functions.