### PR TITLE
feat: Added `--env` flag to `xtask site serve`

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> ExitCode {
 		Commands::Changelog(args) => task::changelog::run(args),
 		Commands::Rfd(args) => task::rfd::run(args),
 		Commands::Site(args) => match args.command {
-			SiteCommand::Serve => task::site::serve::run(),
+			SiteCommand::Serve(args) => task::site::serve::run(args),
 		},
 	};
 
@@ -103,7 +103,28 @@ struct SiteArgs {
 #[derive(Debug, clap::Subcommand)]
 enum SiteCommand {
 	/// Serve the local development site.
-	Serve,
+	Serve(SiteServeArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct SiteServeArgs {
+	/// The environment to run the site for.
+	#[arg(short = 'e', long = "env")]
+	env: Option<SiteEnvironment>,
+}
+
+impl SiteServeArgs {
+	/// Get the selected environment.
+	fn env(&self) -> SiteEnvironment {
+		self.env.unwrap_or_default()
+	}
+}
+
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+enum SiteEnvironment {
+	#[default]
+	Dev,
+	Prod,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds a new `--env` flag to the `xtask site serve` subcommand that lets you specify if you're wanting to run in production or development mode. The only thing this changes at the moment is the `base_url` of the site, intended so you can locally test the production configuration of the deployment. By default, it'll use `--env dev`, which sets the `base_url` to `localhost`.