### PR TITLE
fix: Fix broken website links in production.

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -16,12 +16,12 @@ highlight_code = true
 
 # Define the site navigation.
 nav = [
-    { name = "Documentation", url = "/docs" },
-    { name = "Contribute", url = "/contribute" },
-    { name = "Blog", url = "/blog" },
+    { name = "Documentation", url = "@/docs/_index.md" },
+    { name = "Contribute", url = "@/contribute/_index.md" },
+    { name = "Blog", url = "@/blog/_index.md" },
     { sep = true },
     { name = "Get Help", url = "https://github.com/mitre/hipcheck/discussions", icon = "life-buoy", external = true },
-    { name = "Install", url = "/install", highlight = true, icon = "arrow-down" },
+    { name = "Install", url = "@/install/_index.md", highlight = true, icon = "arrow-down" },
     { sep = true },
     { url = "https://github.com/mitre/hipcheck", icon = "github", icononly = true },
     { url = "#", icon = "sun", icononly = true, id = "toggle-darkmode" },
@@ -31,18 +31,18 @@ nav = [
 footer = [
     [
         { name = "Documentation", title = true },
-        { name = "Quickstart", url = "/docs/quickstart" },
-        { name = "Complete Guide", url = "/docs/guide" },
-        { name = "Requests for Discussion", url = "/rfds" },
-        { name = "Development Blog", url = "/blog" },
+        { name = "Quickstart", url = "@/docs/quickstart/_index.md" },
+        { name = "Complete Guide", url = "@/docs/guide/_index.md" },
+        { name = "Requests for Discussion", url = "@/rfds/_index.md" },
+        { name = "Development Blog", url = "@/blog/_index.md" },
         { name = "Project", title = true },
-        { name = "Hipcheck Values", url = "/rfds/0002" },
+        { name = "Hipcheck Values", url = "@/rfds/0002-hipchecks-values.md" },
         { name = "Open Source License", url = "https://github.com/mitre/hipcheck/blob/main/LICENSE", external = true },
         { name = "Code of Conduct", url = "https://github.com/mitre/hipcheck/blob/main/CODE_OF_CONDUCT.md", external = true },
     ],
     [
         { name = "Install", title = true },
-        { name = "Installer", url = "/install" },
+        { name = "Installer", url = "@/install/_index.md" },
         { name = "Container Image", url = "https://hub.docker.com/r/mitre/hipcheck", external = true },
         { name = "Release Notes", url = "https://github.com/mitre/hipcheck/releases", external = true },
         { name = "Changelog", url = "https://github.com/mitre/hipcheck/blob/main/CHANGELOG.md", external = true },

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -36,7 +36,7 @@
         rounded-lg
         mr-4 mt-8
         top-[-1px]
-    " href="{{ get_url(path="/docs") }}">{{ ic::icon(name="book-open", classes="mt-[-2px] ml-[-4px] mr-1") }}  Read the Docs</a>
+    " href="{{ get_url(path="@/docs/_index.md") }}">{{ ic::icon(name="book-open", classes="mt-[-2px] ml-[-4px] mr-1") }}  Read the Docs</a>
 
     <a class="
         relative z-20
@@ -47,11 +47,11 @@
         bg-blue-600 hover:bg-green-500 hover:from-green-100
         text-blue-50 hover:text-green-50
         rounded-lg
-    " href="{{ get_url(path="/install") }}">Try Hipcheck! {{ ic::icon(name="arrow-down", classes="mt-[-2px] mr-[-4px] mr-1") }} </a>
+    " href="{{ get_url(path="@/install/_index.md") }}">Try Hipcheck! {{ ic::icon(name="arrow-down", classes="mt-[-2px] mr-[-4px] mr-1") }} </a>
 {% endblock %}
 
 {% block sidebar %}
-    <img class="block rounded-md p-4 bg-[#eff1f5] z-10 -mt-2 -ml-[5.333rem] absolute w-[28rem]" src="{{ get_url(path="/images/homepage-bg.png") }}">
+    <img class="block rounded-md p-4 bg-[#eff1f5] z-10 -mt-2 -ml-[5.333rem] absolute w-[28rem]" src="{{ get_url(path="images/homepage-bg.png") }}">
 {% endblock %}
 
 {% block extra %}
@@ -67,7 +67,7 @@
                     <div class="flex-1 dark:text-gray-200">
                         <h3 class="mb-4 font-semibold">Identify High Risk Dependencies</h3>
                         <p class="text-sm">Audit a project&rsquo;s development practices, like code review, fuzz testing, and active maintenance, automatically!</p>
-                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_page(path="docs/guide/analyses.md") }}">Learn about Hipcheck&rsquo;s analyses &rarr;</a ></p>
+                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_url(path="@/docs/guide/analyses.md") }}">Learn about Hipcheck&rsquo;s analyses &rarr;</a ></p>
                     </div>
                 </div>
             </div>
@@ -79,7 +79,7 @@
                     <div class="flex-1 dark:text-gray-200">
                         <h3 class="mb-4 font-semibold">Configure Analyses You Care About</h3>
                         <p class="text-sm">Keep only the analyses that matter to you, change how they contribute to scoring, and how much risk you&rsquo;re willing to tolerate.</p>
-                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_page(path="docs/guide/configuration.md") }}">Learn about configuring Hipcheck &rarr;</a ></p>
+                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_url(path="@/docs/guide/configuration.md") }}">Learn about configuring Hipcheck &rarr;</a ></p>
                     </div>
                 </div>
             </div>
@@ -91,7 +91,7 @@
                     <div class="flex-1 dark:text-gray-200">
                         <h3 class="mb-4 font-semibold">Make Dependencies Manageable</h3 >
                         <p class="text-sm">Many software projects use hundreds of open source dependencies! Filter that list to something manageable with Hipcheck</p>
-                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_page(path="docs/guide/how-to-use.md") }}">Learn about using Hipcheck &rarr;</a ></p>
+                        <p class="mt-4 text-sm"><a class="font-semibold text-blue-500 hover:text-blue-700" href="{{ get_url(path="@/docs/guide/how-to-use.md") }}">Learn about using Hipcheck &rarr;</a ></p>
                     </div>
                 </div>
             </div>

--- a/site/templates/partials/footer.tera.html
+++ b/site/templates/partials/footer.tera.html
@@ -1,11 +1,9 @@
 
-{% set root = config.base_url | replace(from="https://mitre.github.io/", to="") %}
-
 <div class="max-w-6xl mx-auto mt-32">
     <div class="pb-16">
         <div class="flex gap-8 dark:text-zinc-400">
             <div class="basis-1/4 text-lg">
-                <a class="hover:text-green-600 font-semibold" href="{{ root }}/">Hipcheck <span class="leading-none font-extrabold text-green-600 text-2xl">✓</span></a>
+                <a class="hover:text-green-600 font-semibold" href="{{ get_url(path="@/_index.md") }}">Hipcheck <span class="leading-none font-extrabold text-green-600 text-2xl">✓</span></a>
                 <p class="text-sm text-zinc-500 mt-3 leading-6">Automated supply chain risk assessment for software packages.</p>
             </div>
             {% for list in config.extra.footer %}
@@ -16,7 +14,13 @@
                                 {% if item.title %}
                                     <span class="font-semibold mb-4 mt-8 block">{{ item.name }}</span>
                                 {% else %}
-                                    <a class="block mb-2 hover:text-blue-500" href="{{ root }}{{ item.url }}">
+                                    {% if item.url is starting_with("http") %}
+                                        {% set url = item.url %}
+                                    {% else %}
+                                        {% set url = get_url(path=item.url) %}
+                                    {% endif %}
+
+                                    <a class="block mb-2 hover:text-blue-500" href="{{ url }}">
                                         {{ item.name }}
                                         {% if item.external %}
                                             <span class="text-xs text-zinc-500">↗</span>

--- a/site/templates/partials/nav.tera.html
+++ b/site/templates/partials/nav.tera.html
@@ -1,8 +1,6 @@
 
 {% import "macros/icon.tera.html" as ic %}
 
-{% set root = config.base_url | replace(from="https://mitre.github.io/", to="") %}
-
 <nav class="
         text-sm
         py-4 px-8
@@ -12,7 +10,7 @@
             mx-4
             ">
         <li class="block md:flex md:flex-1 items-stretch">
-	    <a href="{{ root }}/" class="
+	    <a href="{{ get_url(path="@/_index.md") }}" class="
                 items-stretch content-center
                 text-black dark:text-zinc-200 hover:text-green-600
                 text-xl
@@ -20,7 +18,7 @@
                 ">Hipcheck&nbsp;<span class="leading-none font-extrabold text-green-600 text-2xl">✓</span></a>
 
             {% if config.extra.announce %}
-	        <a href="{{ root }}{{ config.extra.announce.url }}"
+                <a href="{{ config.extra.announce.url }}"
                     class="
                         rounded-3xl
                         bg-sky-100 dark:bg-sky-900 hover:bg-sky-200 dark:hover:bg-sky-800
@@ -43,6 +41,12 @@
                     {% endif %}
                     ">
                 {% if not item.sep %}
+                    {% if item.url is starting_with("http") %}
+                        {% set url = item.url %}
+                    {% else %}
+                        {% set url = get_url(path=item.url) %}
+                    {% endif %}
+
                     <a class="
                         items-stretch
                         text-black dark:text-zinc-200 hover:text-blue-500
@@ -57,7 +61,7 @@
                         {% else %}
                             p-0
                         {% endif %}
-			" href="{{ root }}{{ item.url }}" {% if item.id %}id="{{ item.id }}"{% endif %}>
+			" href="{{ url }}" {% if item.id %}id="{{ item.id }}"{% endif %}>
                     {% if item.icon %}
                         {% set name = item.icon %}
                         {{ ic::icon(name=name, classes="mt-[-2px] ml-[-4px] mr-1") }}


### PR DESCRIPTION
Previously, by hardcoding a number of links, we were breaking in production because the production site is served under a sub-path of the `https://mitre.github.io` host: `hipcheck/`. This commit fixes many of these broken links, including those on the homepage and in the navigation and footer, as I now better understand Zola's mechanism for linking to pages within the site in a way that always ensures proper handling of the site's `base_url`.