### PR TITLE
build: Use rust-cache in GitHub CI to speed up builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
       - name: Dependency Tree
         run: cargo tree
       - name: Build


### PR DESCRIPTION
Relates to #139

The `rust-cache` action will preserve the CARGO_HOME and target directories between builds. These contain the downloaded dependency crates (in source code) and the compiled dependency crates, respectively.

Key the cache on the OS target to keep the caches separate between OS builds.

Docs:
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
https://github.com/Swatinem/rust-cache
https://github.com/axodotdev/cargo-dist/issues/907