### PR TITLE
chore: Make a dummy change to main() to trigger a compile, to test rust cache

### DIFF
--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hipcheck"
-description = "Automatically assess and score software repositories for supply chain risk"
+description = "Automatically assess and score software repositories for supply chain risk, and break caches 1"
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -82,6 +82,9 @@ fn init_logging() {
 fn main() -> ExitCode {
 	init_logging();
 
+	println!("Testing a code change to use the rust cache.");
+	println!("This is test 1.");
+
 	// Install a process-wide default crypto provider.
 	CryptoProvider::install_default(ring::default_provider())
 		.expect("installed process-wide default crypto provider");

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> ExitCode {
 	init_logging();
 
 	println!("Testing a code change to use the rust cache.");
-	println!("This is test 1.");
+	println!("This is test 2.");
 
 	// Install a process-wide default crypto provider.
 	CryptoProvider::install_default(ring::default_provider())


### PR DESCRIPTION
Please don't actually merge this change.

I'll add commits to this to check whether and to what extent `rust-cache` successfully caches the built dependencies.

Without changing `Cargo.toml` or `Cargo.lock`, there should be an "exact match" for the cache key.
If I do change one of those, I want to see whether `rust-cache` preserves anything about the cache.

In any case, caches created for this Pull Request should not end up being usable on the main branch due to GitHub Actions isolation rules for caches.
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache