### PR TITLE
feat(CLI): CLI can infer target type from target pURL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "ordered-float",
+ "packageurl",
  "paste",
  "pathbuf",
  "petgraph",
@@ -1209,6 +1210,16 @@ checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "packageurl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd2afe7e71d621b1771201bcdede645dd1a404012cdd6673b56d10be495f2a8"
+dependencies = [
+ "percent-encoding",
+ "thiserror",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -37,6 +37,7 @@ maplit = "1.0.2"
 nom = "7.1.3"
 once_cell = "1.10.0"
 ordered-float = { version = "4.2.1", features = ["serde"] }
+packageurl = "0.4.0"
 paste = "1.0.7"
 pathbuf = "1.0.0"
 petgraph = { version = "0.6.0", features = ["serde-1"] }

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -1,5 +1,7 @@
 use clap::ValueEnum;
+use packageurl::PackageUrl;
 use serde::Serialize;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, ValueEnum, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -13,25 +15,85 @@ pub enum TargetType {
 }
 
 impl TargetType {
-	pub fn try_resolve_from_target(tgt: &str) -> Option<TargetType> {
+	/// Parses the target type if it is a pURL, GitHub repo, or SPDX file
+	/// Updates the target string with the correct formatting if the original target string was a pURL
+	pub fn try_resolve_from_target(tgt: &str) -> Option<(TargetType, String)> {
 		use TargetType::*;
-		if let Some(pkg) = tgt.strip_prefix("pkg:") {
-			if let Some((pkg_type, _)) = pkg.split_once('/') {
-				// Match on purl package type
-				match pkg_type {
-					"github" => Some(Repo),
-					"npm" => Some(Npm),
-					"maven" => Some(Maven),
-					"pypi" => Some(Pypi),
-					_ => None,
+
+		// Check if the target is a pURL and parse it if it is
+		if let Ok(purl) = PackageUrl::from_str(tgt) {
+			match purl.ty() {
+				"github" => {
+					// Construct GitHub repo URL from pURL as the updated target string
+					// For now we ignore the "version" field, which has GitHub tag information, until Hipcheck can cleanly handle things other than the main/master branch of a repo
+					let mut url = "https://github.com/".to_string();
+					// A repo must have an owner
+					match purl.namespace() {
+						Some(owner) => url.push_str(owner),
+						None => return None,
+					}
+					url.push('/');
+					let name = purl.name();
+					url.push_str(name);
+					url.push_str(".git");
+					Some((Repo, url))
 				}
-			} else {
-				None
+				"maven" => {
+					// Construct Maven package POM file URL from pURL as the updated target string
+
+					// We currently only support parsing Maven packages hosted at repo1.maven.org
+					let mut url = "https://repo1.maven.org/maven2/".to_string();
+					// A package must belong to a group
+					match purl.namespace() {
+						Some(group) => url.push_str(&group.replace('.', "/")),
+						None => return None,
+					}
+					url.push('/');
+					let name = purl.name();
+					url.push_str(name);
+					// A package version is needed to construct a URL
+					match purl.version() {
+						Some(version) => {
+							url.push('/');
+							url.push_str(version);
+							url.push('/');
+							let pom_file = format!("{}-{}.pom", name, version);
+							url.push_str(&pom_file);
+						}
+						None => return None,
+					}
+					Some((Maven, url))
+				}
+				"npm" => {
+					// Construct NPM package w/ optional version from pURL as the updated target string
+					let name = purl.name();
+					let mut package = name.to_string();
+					// Include version if provided
+					if let Some(version) = purl.version() {
+						package.push('@');
+						package.push_str(version);
+					}
+					Some((Npm, package))
+				}
+				"pypi" => {
+					// Construct PyPi package w/optional version from pURL as the updated target string
+					let name = purl.name();
+					let mut package = name.to_string();
+					// Include version if providedc
+					if let Some(version) = purl.version() {
+						package.push('@');
+						package.push_str(version);
+					}
+					Some((Pypi, package))
+				}
+				_ => None,
 			}
+		// Otherwise, check if it is a GitHub repo URL
 		} else if tgt.starts_with("https://github.com/") {
-			Some(Repo)
+			Some((Repo, tgt.to_string()))
+		// Otherwise check if it has an SPDX file extension
 		} else if tgt.ends_with(".spdx") {
-			Some(Spdx)
+			Some((Spdx, tgt.to_string()))
 		} else {
 			None
 		}


### PR DESCRIPTION
Resolves issue #184 .

`hc check` will now attempt to resolve the target type from a given target pURL. Currently we support GitHub, Maven, NPM, and PyPi pURL's. If a target type can be resolved, Hipcheck will extract the information it needs to run from the pURL.

If the user provides a target type to `hc check` with the `-t` flag, Hipcheck will error if the inferred type (whether inferred from a pURL, GitHub URL, or .spdx file extension) does not match the provided type.