### PR TITLE
feat(CLI): CLI can infer target from VCS URL

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -985,6 +985,39 @@ mod tests {
 	}
 
 	#[test]
+	fn test_deductive_check_repo_vcs_https() {
+		let url = "https://github.com/mitre/hipcheck.git".to_string();
+		let cmd = get_check_cmd_from_cli(vec!["hc", "check", "git+https://github.com/mitre/hipcheck.git"]);
+		assert!(matches!(cmd, Ok(CheckCommand::Repo(..))));
+		if let Ok(chk_cmd) = cmd {
+			let target = get_target_from_cmd(chk_cmd);
+			assert_eq!(target, url);
+		}
+	}
+
+	#[test]
+	fn test_deductive_check_repo_vcs_ssh() {
+		let url = "ssh://git@github.com/mitre/hipcheck.git".to_string();
+		let cmd = get_check_cmd_from_cli(vec!["hc", "check", "git+ssh://git@github.com/mitre/hipcheck.git"]);
+		assert!(matches!(cmd, Ok(CheckCommand::Repo(..))));
+		if let Ok(chk_cmd) = cmd {
+			let target = get_target_from_cmd(chk_cmd);
+			assert_eq!(target, url);
+		}
+	}
+
+	#[test]
+	fn test_deductive_check_repo_filepath() {
+		let path = "/home/me/projects/hipcheck".to_string();
+		let cmd = get_check_cmd_from_cli(vec!["hc", "check", "git+file:///home/me/projects/hipcheck"]);
+		assert!(matches!(cmd, Ok(CheckCommand::Repo(..))));
+		if let Ok(chk_cmd) = cmd {
+			let target = get_target_from_cmd(chk_cmd);
+			assert_eq!(target, path);
+		}
+	}
+
+	#[test]
 	fn test_check_with_target_flag() {
 		let cmd = get_check_cmd_from_cli(vec![
 			"hc",

--- a/hipcheck/src/source/source.rs
+++ b/hipcheck/src/source/source.rs
@@ -101,7 +101,7 @@ impl SourceRepo {
 		raw: &str,
 		src: PathBuf,
 	) -> Result<SourceRepo> {
-        let local = clone_local_repo_to_cache(src.as_path(), root)?;
+		let local = clone_local_repo_to_cache(src.as_path(), root)?;
 		let head = get_head_commit(&local).context("can't get head commit for local source")?;
 		let remote = match SourceRepo::try_resolve_remote_for_local(&local) {
 			Ok(remote) => Some(remote),
@@ -621,23 +621,23 @@ fn build_unknown_remote_clone_dir(url: &Url) -> Result<String> {
 }
 
 fn clone_local_repo_to_cache(src: &Path, root: &Path) -> Result<PathBuf> {
-    let src = src.canonicalize()?;
+	let src = src.canonicalize()?;
 	let hc_data_root = pathbuf![root, "clones"];
 	// If src dir is already in HC_CACHE/clones, leave it be. else clone from local fs
 	if src.starts_with(&hc_data_root) {
 		return Ok(src);
 	}
 	let dest = pathbuf![&hc_data_root, "local", src.file_name().unwrap()];
-    if dest.exists() {
-        std::fs::remove_dir_all(&dest)?;
-    }
-    let src_str = src.to_str().ok_or_else(|| hc_error!("source isn't UTF-8 encoded '{}'", src.display()))?;
-    let dest_str = dest.to_str().ok_or_else(|| hc_error!("destination isn't UTF-8 encoded '{}'", dest.display()))?;
-    let _output = GitCommand::new_repo([
-        "clone",
-        src_str,
-        dest_str
-    ])?.output()?;
+	if dest.exists() {
+		std::fs::remove_dir_all(&dest)?;
+	}
+	let src_str = src
+		.to_str()
+		.ok_or_else(|| hc_error!("source isn't UTF-8 encoded '{}'", src.display()))?;
+	let dest_str = dest
+		.to_str()
+		.ok_or_else(|| hc_error!("destination isn't UTF-8 encoded '{}'", dest.display()))?;
+	let _output = GitCommand::new_repo(["clone", src_str, dest_str])?.output()?;
 	Ok(dest)
 }
 


### PR DESCRIPTION
Resolves issue #185 

`hc check` will now attempt to resolve the target repo from a given target VCS URL (see [here](https://pip.pypa.io/en/stable/topics/vcs-support/). Currently we support remote Git repo URLs and local Git repo filepaths. If a target type can be resolved, Hipcheck will extract the information it needs to run from the VCS URL.

We currently ignore any additional Git ref information that may be provided with the VCS URL. We assume that if such a ref is given, it follows the VCS URL convention of `git+https://github.com/owner/repo.git@ref`, with the "`.git`" suffix provided before the "@".