### PR TITLE
feat: added types for new target repo spec and resolution

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -427,7 +427,7 @@ pub struct CheckArgs {
 		help = "The target package, URL, commit, etc. for Hipcheck to analyze. If ambiguous, the -t flag must be set"
 	)]
 	pub target: Option<String>,
-	#[arg(trailing_var_arg(true), hide = true)]
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	pub trailing_args: Vec<String>,
 }
 
@@ -563,6 +563,9 @@ pub struct CheckPypiArgs {
 pub struct CheckRepoArgs {
 	/// Repository to analyze; can be a local path or a URI
 	pub source: String,
+    /// The ref of the repo to analyze
+    #[clap(long = "ref")]
+    pub ref_: Option<String>
 }
 
 #[derive(Debug, Clone, clap::Args)]

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -1,3 +1,7 @@
+#[allow(unused)]
+
+pub mod types;
+
 use clap::ValueEnum;
 use packageurl::PackageUrl;
 use serde::Serialize;

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+use url::Url;
+
+pub struct Target {
+    /// The original specifier provided by the user.
+    specifier: String,
+
+    /// The path to the local repository.
+    local: LocalGitRepo,
+
+    /// The url of the remote repository, if any.
+    remote: Option<RemoteGitRepo>,
+
+    /// The package associated with the target, if any.
+    package: Option<Package>,
+}
+
+pub struct RemoteGitRepo {
+    url: Url,
+    known_remote: Option<KnownRemote>,
+}
+
+pub enum KnownRemote {
+    GitHub { owner: String, repo: String }
+}
+
+pub struct LocalGitRepo {
+    /// The path to the repo.
+    path: PathBuf,
+
+    /// The Git ref we're referring to.
+    git_ref: String,
+}
+
+pub struct Package {
+    /// A package url for the package.
+    purl: String,
+
+    /// The package name
+    name: String,
+
+    /// The package version
+    version: String,
+
+    /// What host the package is from.
+    host: PackageHost,
+}
+
+pub enum PackageHost {
+    Npm,
+    Maven,
+    PyPi
+}


### PR DESCRIPTION
Adds new types, including `Target` which is designed to replace `Source` going forward. Future work will integrate this type into the Hipcheck analysis, and derive `Target` from `CheckArgs`

Additionally adds the optional `ref_` arg to `CheckRepoArgs` and fixes `trailing_args` to also consume flag arguments. Without this, `--ref` can't be passed when not using deprecated `hc check repo/maven/etc <TARGET>` format.