### PR TITLE
chore: Replace log bridge dependency with bespoke implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,6 @@ dependencies = [
  "indexmap 2.2.6",
  "indextree",
  "indicatif",
- "indicatif-log-bridge",
  "log",
  "maplit",
  "nom",
@@ -954,16 +953,6 @@ dependencies = [
  "portable-atomic",
  "rayon",
  "unicode-width",
-]
-
-[[package]]
-name = "indicatif-log-bridge"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2963046f28a204e3e3fd7e754fd90a6235da05b5378f24707ff0ec9513725ce3"
-dependencies = [
- "indicatif",
- "log",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -73,7 +73,6 @@ indicatif = { version = "0.17.8", features = ["rayon"] }
 finl_unicode = { version = "1.2.0", default-features = false, features = [
     "grapheme_clusters",
 ] }
-indicatif-log-bridge = "0.2.2"
 tar = "0.4.41"
 zip = "2.1.5"
 xz2 = "0.1.7"

--- a/hipcheck/src/log_bridge.rs
+++ b/hipcheck/src/log_bridge.rs
@@ -1,0 +1,38 @@
+//! The `indicatif-log-bridge` crate discards filtering information when using env_logger, so I'm writting my own.
+
+use env_logger::Logger;
+use log::SetLoggerError;
+
+use crate::shell::Shell;
+
+pub struct LogWrapper(pub Logger);
+
+impl log::Log for LogWrapper {
+	fn enabled(&self, metadata: &log::Metadata) -> bool {
+		self.0.enabled(metadata)
+	}
+
+	fn log(&self, record: &log::Record) {
+		Shell::in_suspend(|| self.0.log(record))
+	}
+
+	fn flush(&self) {
+		Shell::in_suspend(|| self.0.flush())
+	}
+}
+
+impl LogWrapper {
+	pub fn try_init(self) -> Result<(), SetLoggerError> {
+		if !Shell::is_init() {
+			panic!("Initialize the global shell before initializing this logger");
+		}
+
+		let max_filter_level = self.0.filter();
+
+		log::set_boxed_logger(Box::new(self))?;
+
+		log::set_max_level(max_filter_level);
+
+		Ok(())
+	}
+}

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -11,6 +11,7 @@ mod error;
 mod git2_log_shim;
 mod git2_rustls_transport;
 mod http;
+mod log_bridge;
 mod metric;
 mod report;
 mod session;
@@ -54,11 +55,9 @@ use command_util::DependentProgram;
 use config::WeightTreeNode;
 use config::WeightTreeProvider;
 use core::fmt;
-use env_logger::Builder as EnvLoggerBuilder;
 use env_logger::Env;
 use indextree::Arena;
 use indextree::NodeId;
-use indicatif_log_bridge::LogWrapper;
 use ordered_float::NotNan;
 use pathbuf::pathbuf;
 use rustls::crypto::ring;
@@ -81,10 +80,11 @@ use util::fs::create_dir_all;
 use which::which;
 
 fn init_logging() -> std::result::Result<(), log::SetLoggerError> {
-	let logger =
-		EnvLoggerBuilder::from_env(Env::new().filter("HC_LOG").write_style("HC_LOG_STYLE")).build();
+	let env = Env::new().filter("HC_LOG").write_style("HC_LOG_STYLE");
 
-	LogWrapper::new(Shell::progress_bars(), logger).try_init()
+	let logger = env_logger::Builder::from_env(env).build();
+
+	log_bridge::LogWrapper(logger).try_init()
 }
 
 /// Entry point for Hipcheck.

--- a/hipcheck/src/shell.rs
+++ b/hipcheck/src/shell.rs
@@ -76,6 +76,11 @@ impl Shell {
 		});
 	}
 
+	/// Check if the global shell is initialized.
+	pub fn is_init() -> bool {
+		Shell::try_get().is_some()
+	}
+
 	/// Get the global shell if it's initialized or return [None].
 	#[inline]
 	pub fn try_get() -> Option<&'static Self> {


### PR DESCRIPTION
`indicatif-log-bridge` was improperly filtering log messages in some instances, and was pretty easy to replace.