### PR TITLE
feat: add more robust 'target resolution' system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,13 +187,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -214,7 +213,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -229,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -249,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
 dependencies = [
  "anstream",
  "anstyle",
@@ -552,9 +551,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "c6dc8c8ff84895b051f07a0e65f975cf225131742531338752abfb324e4449ff"
 dependencies = [
  "log",
  "regex",
@@ -562,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "06676b12debf7bba6903559720abca942d3a66b8acb88815fd2c7c6537e9ade1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -998,9 +997,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1212,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -1293,9 +1292,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1352,9 +1351,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -1458,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1541,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
  "once_cell",
@@ -1585,9 +1584,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1687,9 +1686,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -1700,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1938,18 +1937,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2145,9 +2144,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -2298,7 +2297,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2316,7 +2315,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2336,18 +2335,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2358,9 +2357,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2370,9 +2369,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2382,15 +2381,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2400,9 +2399,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2412,9 +2411,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2424,9 +2423,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2436,15 +2435,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0"
 dependencies = [
  "memchr",
 ]

--- a/hipcheck/src/source.rs
+++ b/hipcheck/src/source.rs
@@ -2,4 +2,5 @@
 
 pub mod query;
 #[allow(clippy::module_inception)]
+#[allow(unused)]
 pub mod source;

--- a/hipcheck/src/source/source.rs
+++ b/hipcheck/src/source/source.rs
@@ -9,6 +9,7 @@ use crate::shell::progress_phase::ProgressPhase;
 use crate::shell::spinner_phase::SpinnerPhase;
 use crate::shell::Shell;
 pub use crate::source::query::*;
+use crate::target::{KnownRemote, LocalGitRepo, RemoteGitRepo, Target};
 use console::Term;
 use git2::build::CheckoutBuilder;
 use git2::build::RepoBuilder;
@@ -22,16 +23,234 @@ use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::fs;
 use std::io::Write;
+use std::ops::Rem;
 use std::path::Path;
 use std::path::PathBuf;
+use url::Host;
 use url::Url;
 
-// Right now our only subject of analysis is a repository, represented by the
-// `Source` type. It may optionally include a `Remote` component, in which
-// case analyses which require that remote may work! Now, we're faced with the
-// question of how to handle supporting more subjects of analysis, namely
-// pull requests, but also possibly to include individual commits or patches.
+/// Resolving is how we ensure we have a valid, ready-to-go source of Git data
+/// for the rest of Hipcheck's analysis. The below functions handle the resolution
+/// of local or remote repos.
+///
+/// If the repo is local, the resolve function will work with the local repository
+/// without cloning (all operationsare write-only, so this won't harm the repo at
+/// all).
+///
+/// If it's a remote source, Hipcheck will clone the source so it can work with a
+/// local copy, putting the clone in '<root>/clones'. It also notes whether a
+/// remote repo is from a known or unknown host, because some forms of analysis
+/// rely on accessing the API's of certain known hosts (currently just GitHub).
+///
+/// In either case, it also gets the commit head of the HEAD commit, so we can
+/// make sure future operations are all done relative to the HEAD, and that any
+/// cached data records what the HEAD was at the time of caching, to enable
+/// cache invalidation.
+
+/// Resolves a specified local git repo into a Target for analysis by Hipcheck
+pub fn resolve_local_repo(
+	phase: &SpinnerPhase,
+	root: &Path,
+	local_repo: LocalGitRepo,
+) -> Result<Target> {
+	let src = local_repo.path.clone();
+
+	let specifier = src
+		.to_str()
+		.ok_or(hc_error!(
+			"Path to local repo contained one or more invalid characters"
+		))?
+		.to_string();
+
+	let local = clone_local_repo_to_cache(src.as_path(), root)?;
+	// TODO - use git2 to set the local repo to the correct ref
+	let head = get_head_commit(&local).context("can't get head commit for local source")?;
+	let remote = match try_resolve_remote_for_local(&local) {
+		Ok(remote) => Some(remote),
+		Err(err) => {
+			log::debug!("failed to get remote [err='{}']", err);
+			None
+		}
+	};
+
+	Ok(Target {
+		specifier,
+		local: local_repo,
+		remote,
+		package: None,
+	})
+}
+
+/// Creates a RemoteGitRepo struct from a given git URL by idenfitying if it is from a known host (currently only GitHub) or not
+pub fn get_remote_repo_from_url(url: Url) -> Result<RemoteGitRepo> {
+	match url.host() {
+		Some(Host::Domain("github.com")) => {
+			let (owner, repo) = get_github_owner_and_repo(&url)?;
+			Ok(RemoteGitRepo {
+				url,
+				known_remote: Some(KnownRemote::GitHub { owner, repo }),
+			})
+		}
+		Some(_) => Ok(RemoteGitRepo {
+			url,
+			known_remote: None,
+		}),
+		None => Err(hc_error!("Target repo URL is missing a host")),
+	}
+}
+
+/// Resolves a remote git repo originally specified by its remote location into a Target for analysis by Hipcheck
+pub fn resolve_remote_repo(
+	phase: &SpinnerPhase,
+	root: &Path,
+	remote_repo: RemoteGitRepo,
+) -> Result<Target> {
+	// For remote repos originally specified by their URL, the specifier is just that URL
+	let specifier = remote_repo.url.to_string();
+
+	match remote_repo.known_remote {
+		Some(KnownRemote::GitHub {
+			ref owner,
+			ref repo,
+		}) => resolve_github_remote_repo(phase, root, remote_repo.clone(), owner, repo, specifier),
+		_ => resolve_unknown_remote_repo(phase, root, remote_repo.clone(), specifier),
+	}
+}
+
+/// Resolves a remote git repo derived from a source other than its remote location (e.g. a package or SPDX file) into a Target for analysis by Hipcheck
+pub fn resolve_remote_package_repo(
+	phase: &SpinnerPhase,
+	root: &Path,
+	remote_repo: RemoteGitRepo,
+	specifier: String,
+) -> Result<Target> {
+	match remote_repo.known_remote {
+		Some(KnownRemote::GitHub {
+			ref owner,
+			ref repo,
+		}) => resolve_github_remote_repo(phase, root, remote_repo.clone(), owner, repo, specifier),
+		_ => resolve_unknown_remote_repo(phase, root, remote_repo.clone(), specifier),
+	}
+}
+
+fn resolve_github_remote_repo(
+	phase: &SpinnerPhase,
+	root: &Path,
+	remote_repo: RemoteGitRepo,
+	owner: &str,
+	repo: &str,
+	specifier: String,
+) -> Result<Target> {
+	let url = &remote_repo.url;
+
+	let path = pathbuf![root, "clones", "github", owner, repo];
+
+	clone_or_update_remote(phase, url, &path)?;
+
+	let head = get_head_commit(&path)?;
+
+	let local = LocalGitRepo {
+		path,
+		git_ref: head,
+	};
+
+	Ok(Target {
+		specifier,
+		local,
+		remote: Some(remote_repo),
+		package: None,
+	})
+}
+
+fn resolve_unknown_remote_repo(
+	phase: &SpinnerPhase,
+	root: &Path,
+	remote_repo: RemoteGitRepo,
+	specifier: String,
+) -> Result<Target> {
+	let url = &remote_repo.url;
+
+	let clone_dir =
+		build_unknown_remote_clone_dir(url).context("failed to prepare local clone directory")?;
+	let path = pathbuf![root, "clones", "unknown", &clone_dir];
+
+	clone_or_update_remote(phase, url, &path)?;
+
+	let head = get_head_commit(&path)?;
+
+	let local = LocalGitRepo {
+		path,
+		git_ref: head,
+	};
+
+	Ok(Target {
+		specifier,
+		local,
+		remote: Some(remote_repo),
+		package: None,
+	})
+}
+
+fn try_resolve_remote_for_local(local: &Path) -> Result<RemoteGitRepo> {
+	let url = {
+		let symbolic_ref = get_symbolic_ref(local)?;
+
+		log::trace!("local source has symbolic ref [ref='{:?}']", symbolic_ref);
+
+		if symbolic_ref.is_empty() {
+			return Err(Error::msg("no symbolic ref found"));
+		}
+
+		let upstream = get_upstream_for_ref(local, &symbolic_ref)?;
+
+		log::trace!("local source has upstream [upstream='{:?}']", upstream);
+
+		if upstream.is_empty() {
+			return Err(Error::msg("no upstream found"));
+		}
+
+		let remote = get_remote_from_upstream(&upstream)
+			.ok_or_else(|| hc_error!("failed to get remote name from upstream '{}'", upstream))?;
+
+		log::trace!("local source has remote [remote='{:?}']", remote);
+
+		if remote.is_empty() {
+			return Err(Error::msg("no remote found"));
+		}
+
+		let raw = get_url_for_remote(local, remote)?;
+
+		log::trace!("local source remote has url [url='{}']", raw);
+
+		if raw.is_empty() {
+			return Err(Error::msg("no URL found for remote"));
+		}
+
+		Url::parse(&raw)?
+	};
+
+	let host = url
+		.host_str()
+		.ok_or_else(|| hc_error!("no host name in '{}'", url))?;
+
+	match host {
+		"github.com" => {
+			let (owner, repo) = get_github_owner_and_repo(&url)?;
+			Ok(RemoteGitRepo {
+				url,
+				known_remote: Some(KnownRemote::GitHub { owner, repo }),
+			})
+		}
+		_ => Ok(RemoteGitRepo {
+			url,
+			known_remote: None,
+		}),
+	}
+}
+
+// TODO: Remove reliance on SourceRepo in Hipcheck so we can delete this struct in favor of exclusively useing Target and related types
 
 /// Represents the Git repository to be analyzed.
 #[derive(Debug, PartialEq, Eq)]
@@ -47,45 +266,6 @@ pub struct SourceRepo {
 }
 
 impl SourceRepo {
-	/// Resolving is how we ensure we have a valid, ready-to-go source of Git data
-	/// for the rest of Hipcheck's analysis.
-	///
-	/// This function works by identifying if we have a local or remote source. If it's
-	/// local, it'll just work with the local repository without cloning (all operations
-	/// are write-only, so this won't harm the repo at all). If it's a remote source,
-	/// Hipcheck will clone the source so it can work with a local copy, putting the
-	/// clone in '<root>/clones'. It also notes whether a remote repo is from
-	/// a known or unknown host, because some forms of analysis rely on accessing the
-	/// API's of certain known hosts (currently just GitHub).
-	///
-	/// In either case, it also gets the commit head of the HEAD commit, so we can
-	/// make sure future operations are all done relative to the HEAD, and that any
-	/// cached data records what the HEAD was at the time of caching, to enable
-	/// cache invalidation.
-	pub fn resolve_repo(phase: &SpinnerPhase, root: &Path, raw: &str) -> Result<SourceRepo> {
-		let local = PathBuf::from(raw);
-
-		let source = match (local.exists(), local.is_dir()) {
-			// It's a local file, not a dir.
-			(true, false) => Err(hc_error!(
-				"source path is not a directory '{}'",
-				local.display()
-			)),
-			// It's a local dir.
-			(true, true) => SourceRepo::resolve_local_repo(root, raw, local),
-			// It's possibly a remote URL.
-			(false, _) => SourceRepo::resolve_remote_repo(phase, root, raw),
-		};
-
-		if source.is_ok() {
-			log::debug!("resolved source [source={:?}]", source);
-		} else {
-			log::error!("could not resolve source: {:?}", source);
-		}
-
-		source
-	}
-
 	/// Get the path to the location of the repository on the local disk.
 	pub fn local(&self) -> &Path {
 		&self.local
@@ -107,135 +287,6 @@ impl SourceRepo {
 		// but we call it 'name' here because it's nicer.
 		&self.raw
 	}
-
-	fn resolve_local_repo(root: &Path, raw: &str, src: PathBuf) -> Result<SourceRepo> {
-		let local = clone_local_repo_to_cache(src.as_path(), root)?;
-		let head = get_head_commit(&local).context("can't get head commit for local source")?;
-		let remote = match SourceRepo::try_resolve_remote_for_local(&local) {
-			Ok(remote) => Some(remote),
-			Err(err) => {
-				log::debug!("failed to get remote [err='{}']", err);
-				None
-			}
-		};
-
-		Ok(SourceRepo {
-			raw: raw.to_string(),
-			local,
-			remote,
-			head,
-		})
-	}
-
-	fn resolve_remote_repo(phase: &SpinnerPhase, root: &Path, raw: &str) -> Result<SourceRepo> {
-		let url = Url::parse(raw)?;
-		let host = url
-			.host_str()
-			.ok_or_else(|| hc_error!("source URL is missing a host '{}'", raw))?;
-
-		match host {
-			// It's a GitHub URL.
-			"github.com" => SourceRepo::resolve_github_remote_repo(phase, root, raw, url),
-			// It's another host.
-			_ => SourceRepo::resolve_unknown_remote_repo(phase, root, raw, url),
-		}
-	}
-
-	fn resolve_github_remote_repo(
-		phase: &SpinnerPhase,
-		root: &Path,
-		raw: &str,
-		url: Url,
-	) -> Result<SourceRepo> {
-		let (owner, repo) = get_github_owner_and_repo(&url)
-			.context("can't identify GitHub repository and owner")?;
-		let dest = pathbuf![root, "clones", "github", &owner, &repo];
-
-		clone_or_update_remote(phase, &url, &dest)?;
-
-		let head = get_head_commit(&dest)?;
-
-		Ok(SourceRepo {
-			raw: raw.to_string(),
-			local: dest,
-			remote: Some(Remote::GitHub { owner, repo, url }),
-			head,
-		})
-	}
-
-	fn resolve_unknown_remote_repo(
-		phase: &SpinnerPhase,
-		root: &Path,
-		raw: &str,
-		url: Url,
-	) -> Result<SourceRepo> {
-		let clone_dir = build_unknown_remote_clone_dir(&url)
-			.context("failed to prepare local clone directory")?;
-		let dest = pathbuf![root, "clones", "unknown", &clone_dir];
-
-		clone_or_update_remote(phase, &url, &dest)?;
-
-		let head = get_head_commit(&dest)?;
-
-		Ok(SourceRepo {
-			raw: raw.to_string(),
-			local: dest,
-			remote: Some(Remote::Unknown(url)),
-			head,
-		})
-	}
-
-	fn try_resolve_remote_for_local(local: &Path) -> Result<Remote> {
-		let url = {
-			let symbolic_ref = get_symbolic_ref(local)?;
-
-			log::trace!("local source has symbolic ref [ref='{:?}']", symbolic_ref);
-
-			if symbolic_ref.is_empty() {
-				return Err(Error::msg("no symbolic ref found"));
-			}
-
-			let upstream = get_upstream_for_ref(local, &symbolic_ref)?;
-
-			log::trace!("local source has upstream [upstream='{:?}']", upstream);
-
-			if upstream.is_empty() {
-				return Err(Error::msg("no upstream found"));
-			}
-
-			let remote = get_remote_from_upstream(&upstream).ok_or_else(|| {
-				hc_error!("failed to get remote name from upstream '{}'", upstream)
-			})?;
-
-			log::trace!("local source has remote [remote='{:?}']", remote);
-
-			if remote.is_empty() {
-				return Err(Error::msg("no remote found"));
-			}
-
-			let raw = get_url_for_remote(local, remote)?;
-
-			log::trace!("local source remote has url [url='{}']", raw);
-
-			if raw.is_empty() {
-				return Err(Error::msg("no URL found for remote"));
-			}
-
-			Url::parse(&raw)?
-		};
-
-		let host = url
-			.host_str()
-			.ok_or_else(|| hc_error!("no host name in '{}'", url))?;
-
-		match host {
-			"github.com" => {
-				let (owner, repo) = get_github_owner_and_repo(&url)?;
-				Ok(Remote::GitHub { owner, repo, url })
-			}
-			_ => Ok(Remote::Unknown(url)),
-		}
-	}
 }
 
 impl Display for SourceRepo {
@@ -244,6 +295,7 @@ impl Display for SourceRepo {
 	}
 }
 
+// TODO: Delete unused code related to analyzing targets other than repos
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub struct SourceChangeRequest {
@@ -550,7 +602,7 @@ fn get_remote_from_upstream(upstream: &str) -> Option<&str> {
 	upstream.split('/').next()
 }
 
-fn get_github_owner_and_repo(url: &Url) -> Result<(String, String)> {
+pub fn get_github_owner_and_repo(url: &Url) -> Result<(String, String)> {
 	let mut segments = url
 		.path_segments()
 		.ok_or_else(|| Error::msg("GitHub URL missing path for owner and repository"))?;
@@ -624,7 +676,7 @@ fn build_unknown_remote_clone_dir(url: &Url) -> Result<String> {
 	Ok(dir)
 }
 
-fn clone_local_repo_to_cache(src: &Path, root: &Path) -> Result<PathBuf> {
+pub fn clone_local_repo_to_cache(src: &Path, root: &Path) -> Result<PathBuf> {
 	let src = src.canonicalize()?;
 	let hc_data_root = pathbuf![root, "clones"];
 	// If src dir is already in HC_CACHE/clones, leave it be. else clone from local fs
@@ -645,7 +697,7 @@ fn clone_local_repo_to_cache(src: &Path, root: &Path) -> Result<PathBuf> {
 	Ok(dest)
 }
 
-fn clone_or_update_remote(phase: &SpinnerPhase, url: &Url, dest: &Path) -> Result<()> {
+pub fn clone_or_update_remote(phase: &SpinnerPhase, url: &Url, dest: &Path) -> Result<()> {
 	if dest.exists() {
 		phase.update_status("pulling");
 		update_remote(dest).context("failed to update remote repository")
@@ -788,4 +840,38 @@ pub(crate) fn get_head_commit(path: &Path) -> Result<String> {
 	let output = GitCommand::for_repo(path, ["rev-parse", "--short", "HEAD"])?.output()?;
 
 	Ok(output.trim().to_owned())
+}
+
+impl From<RemoteGitRepo> for Remote {
+	fn from(value: RemoteGitRepo) -> Self {
+		let mut o = "".to_owned();
+		let mut r = "".to_owned();
+		if let Some(KnownRemote::GitHub { owner, repo }) = value.known_remote {
+			o = owner;
+			r = repo;
+		};
+		Remote::GitHub {
+			owner: o,
+			repo: r,
+			url: value.url,
+		}
+	}
+}
+
+impl TryFrom<Target> for Source {
+	type Error = crate::error::Error;
+	fn try_from(value: Target) -> Result<Self> {
+		let raw = value.specifier;
+		let local = value.local.path;
+		let remote = value.remote.map(Remote::from);
+		let head = get_head_commit(&local).context("can't get head commit for local source")?;
+		Ok(Source {
+			kind: SourceKind::Repo(SourceRepo {
+				raw,
+				local,
+				remote,
+				head,
+			}),
+		})
+	}
 }

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -1,5 +1,6 @@
 #[allow(unused)]
 pub mod types;
+pub use types::*;
 
 use clap::ValueEnum;
 use packageurl::PackageUrl;
@@ -80,7 +81,7 @@ impl TargetType {
 					Some((Npm, package))
 				}
 				"pypi" => {
-					// Construct PyPi package w/optional version from pURL as the updated target string
+					// Construct PyPI package w/optional version from pURL as the updated target string
 					let name = purl.name();
 					let mut package = name.to_string();
 					// Include version if providedc

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -1,53 +1,112 @@
+use crate::error::Error;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::path::PathBuf;
 use url::Url;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Target {
 	/// The original specifier provided by the user.
-	specifier: String,
+	pub specifier: String,
 
 	/// The path to the local repository.
-	local: LocalGitRepo,
+	pub local: LocalGitRepo,
 
 	/// The url of the remote repository, if any.
-	remote: Option<RemoteGitRepo>,
+	pub remote: Option<RemoteGitRepo>,
 
 	/// The package associated with the target, if any.
-	package: Option<Package>,
+	pub package: Option<Package>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteGitRepo {
-	url: Url,
-	known_remote: Option<KnownRemote>,
+	pub url: Url,
+	pub known_remote: Option<KnownRemote>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KnownRemote {
 	GitHub { owner: String, repo: String },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalGitRepo {
 	/// The path to the repo.
-	path: PathBuf,
+	pub path: PathBuf,
 
 	/// The Git ref we're referring to.
-	git_ref: String,
+	pub git_ref: String,
 }
-
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Package {
 	/// A package url for the package.
-	purl: String,
+	pub purl: Url,
 
 	/// The package name
-	name: String,
+	pub name: String,
 
 	/// The package version
-	version: String,
+	pub version: String,
 
 	/// What host the package is from.
-	host: PackageHost,
+	pub host: PackageHost,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MavenPackage {
+	/// The Maven url
+	pub url: Url,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+// Maven as a possible host is ommitted because a MavenPackage is currently its own struct without a host field
 pub enum PackageHost {
 	Npm,
-	Maven,
-	PyPi,
+	PyPI,
+}
+
+impl Display for PackageHost {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self {
+			PackageHost::Npm => write!(f, "Npm"),
+			PackageHost::PyPI => write!(f, "PyPI"),
+		}
+	}
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TargetSeed {
+	LocalRepo(LocalGitRepo),
+	RemoteRepo(RemoteGitRepo),
+	Package(Package),
+	MavenPackage(MavenPackage),
+	Spdx(PathBuf),
+}
+
+impl Display for TargetSeed {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self {
+			TargetSeed::LocalRepo(repo) => write!(f, "local repo at {}", repo.path.display()),
+			TargetSeed::RemoteRepo(remote_repo) => match &remote_repo.known_remote {
+				Some(KnownRemote::GitHub { owner, repo }) => {
+					write!(f, "GitHub repo {}/{} from {}", owner, repo, remote_repo.url)
+				}
+				_ => write!(f, "remote repo at {}", remote_repo.url.as_str()),
+			},
+			TargetSeed::Package(package) => write!(
+				f,
+				"{} package {}@{}",
+				package.host, package.name, package.version
+			),
+			TargetSeed::MavenPackage(package) => {
+				write!(f, "Maven package {}", package.url.as_str())
+			}
+			TargetSeed::Spdx(path) => write!(f, "SPDX file at {}", path.display()),
+		}
+	}
+}
+
+pub trait ToTargetSeed {
+	fn to_target_seed(&self) -> Result<TargetSeed, Error>;
 }


### PR DESCRIPTION
The need for the refactor represented by this PR was determined from discussions around tackling #183 .

This PR was a collaborative effort between myself and @mchernicoff .

This PR uses the types defined in `target/types.rs` for representing the "target" of a HipCheck analysis. Although information can be specified on the cmdline by users in a variety of ways (variants of `TargetSeed`), we eventually need to arrive at a local clone of a git repository that may or may not have an associated remote repo / package information. This is all encapsulated by the `Target` struct.

This PR provides glue code for converting `cli.rs` structures to `TargetSeed` instances using the `ToTargetSeed` trait. The `resolve_target()` function does the work of `TargetSeed` to `Result<Target>` translation. 

In order to limit the LOC changed by this PR, the generated `Target` is then translated to the existing `Source` object in `source/query.rs`. In a future PR we will do the work of removing the `Source` ecosystem and fully replacing it with `Target`.