### PR TITLE
feat: shortcut cache entry size calculation with cache index file

### DIFF
--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -741,6 +741,7 @@ fn cmd_cache(args: CacheArgs, config: &CliConfig) -> ExitCode {
 			force,
 		} => cache.delete(scope, filter, force),
 	};
+	drop(cache);
 	if let Err(e) = res {
 		println!("{e}");
 		ExitCode::FAILURE


### PR DESCRIPTION
This PR introduces a filesystem backing for the `HcCache` object, stored at `$HC_CACHE/clones/index.json`. When instantiating a `HcCache` object, the constructor now looks for this file, and if it exists, will compare `last_modified` information to shortcut cache entry size calculation if the entry has not been modified since the last time a cache object was instantiated. 

Landing this will help with the potential feature described in #182 , where we may specify a cache size-reduction policy to run every time `hc check` or other subcommands are run. Without this shortcutting, re-calculating the disk size of each cache entry can add significant time overhead, impacting user experience with the tool.

Notably, the way this PR determines index entry invalidation is currently based on if the top-level dir for the repo's modified time has changed. On Linux, modifying the content of a subfolder does not propagate the `modified` information upwards, so if a cache entry `hipcheck` exists, and someone adds a file to `hipcheck/src/X`, the check will not detect that `hipcheck`'s size needs to be recomputed. Storing and checking git `ref` information would help detect one class of changes, but not others. 