### PR TITLE
feat: Hipcheck can process SBOMs using CycloneDX JSONs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,9 +135,30 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -423,6 +458,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyclonedx-bom"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a114dd99ed051f1481d8d35acd455f77469f026b783fe08074763fdf1701506"
+dependencies = [
+ "base64 0.21.7",
+ "cyclonedx-bom-macros",
+ "fluent-uri",
+ "indexmap 2.2.6",
+ "jsonschema",
+ "once_cell",
+ "ordered-float",
+ "packageurl 0.3.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "spdx",
+ "strum 0.26.3",
+ "thiserror",
+ "time",
+ "uuid",
+ "xml-rs",
+]
+
+[[package]]
+name = "cyclonedx-bom-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +737,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -672,8 +772,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -793,11 +895,12 @@ name = "hipcheck"
 version = "3.4.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "console",
  "content_inspector",
+ "cyclonedx-bom",
  "dashmap",
  "dialoguer",
  "dirs",
@@ -819,7 +922,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "ordered-float",
- "packageurl",
+ "packageurl 0.4.0",
  "paste",
  "pathbuf",
  "petgraph",
@@ -993,6 +1096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1126,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1165,10 +1305,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1254,6 +1464,16 @@ dependencies = [
 
 [[package]]
 name = "packageurl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c53362339d1c48910f1b0c35e2ae96e2d32e442c7dc3ac5f622908ec87221f08"
+dependencies = [
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "packageurl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd2afe7e71d621b1771201bcdede645dd1a404012cdd6673b56d10be495f2a8"
@@ -1282,6 +1502,16 @@ dependencies = [
  "instant",
  "lock_api",
  "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -1610,7 +1840,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -1654,7 +1884,7 @@ dependencies = [
  "lock_api",
  "log",
  "oorandom",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rustc-hash",
  "salsa-macros",
  "smallvec",
@@ -1854,6 +2084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spdx-expression"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,8 +2115,8 @@ dependencies = [
  "nom",
  "serde",
  "spdx-expression",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "thiserror",
  "uuid",
 ]
@@ -1901,6 +2140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2159,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2025,10 +2286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2036,6 +2299,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -2177,7 +2450,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "log",
  "once_cell",
  "rustls",
@@ -2574,6 +2847,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/main.rs"
 [dependencies]
 
 content_inspector = "0.2.4"
+cyclonedx-bom = "0.6.2"
 dotenv = "0.15.0"
 chrono = { version = "0.4.19", features = ["alloc", "serde"] }
 clap = { version = "4.5.11", features = ["derive"] }

--- a/hipcheck/src/session.rs
+++ b/hipcheck/src/session.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod cyclone_dx;
 pub mod pm;
 #[allow(clippy::module_inception)]
 pub mod session;

--- a/hipcheck/src/session/cyclone_dx.rs
+++ b/hipcheck/src/session/cyclone_dx.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utilities for extracting repository info from CycloneDX documents.
+
+use std::str::FromStr;
+
+use crate::context::Context as _;
+use crate::error::Result;
+use crate::hc_error;
+use crate::session::pm::{extract_repo_for_maven, extract_repo_for_npm, extract_repo_for_pypi};
+use cyclonedx_bom::prelude::*;
+use packageurl::PackageUrl;
+use url::Url;
+
+/// Extract the first compatible package download location from a
+/// CycloneDX document
+pub fn extract_cyclonedx_download_url(filepath: &str) -> Result<Url> {
+	let contents = std::fs::read_to_string(filepath)?;
+
+	if filepath.contains(".json") {
+		let bom = Bom::parse_from_json(contents.as_bytes()).map_err(|_| {
+			hc_error!("CycloneDX JSON file is corrupt or otherwise cannot be parsed")
+		})?;
+		if bom.validate().passed() {
+			extract_download_url(bom)
+		} else {
+			Err(hc_error!("CycloneDX file is not a valid SBOM"))
+		}
+	} else if filepath.contains(".xml") {
+        // TODO: Handle XML files
+        Err(hc_error!("Hipcheck does not currently support CycloneDX SBOMs as XML files"))
+	} else {
+		Err(hc_error!("CycloneDX file is not in a comatible format"))
+	}
+}
+
+// Extract the metadata component download location from a CycloneDX
+// object obtained from a JSON or XML file
+fn extract_download_url(bom: Bom) -> Result<Url> {
+	let purl = PackageUrl::from_str(
+        bom
+        .metadata
+        .ok_or(hc_error!("CycloneDX file is missing a metadata field. Download location cannot be extracted."))?
+        .component
+        .ok_or(hc_error!("CycloneDX file metadata missing a component field describing its own package. Download location cannot be extracted."))?
+        .purl
+        .ok_or(hc_error!("CycloneDX file metadata component information does not include a pURL. Download location cannot be extracted."))?
+        .as_ref()
+    )?;
+
+	match purl.ty() {
+		"github" => {
+			// Get GitHub repo URL from pURL
+			// For now we ignore the "version" field, which has GitHub tag information, until Hipcheck can cleanly handle things other than the main/master branch of a repo
+			let mut url = "https://github.com/".to_string();
+			// A repo must have an owner
+			match purl.namespace() {
+				Some(owner) => url.push_str(owner),
+				None => {
+					return Err(hc_error!(
+					"Download location for CycloneDX file is a GitHub repository with no owner."
+				))
+				}
+			}
+			url.push('/');
+			let name = purl.name();
+			url.push_str(name);
+			url.push_str(".git");
+
+			Url::parse(&url).map_err(|e| hc_error!("Cannot parse constructed GitHub repository URL constructed from CycloneDX file download location: {}", e))
+		}
+		"maven" => {
+			// First construct Maven package POM file URL from pURL as the updated target string
+			// We currently only support parsing Maven packages hosted at repo1.maven.org
+			let mut url = "https://repo1.maven.org/maven2/".to_string();
+			// A package must belong to a group
+			match purl.namespace() {
+				Some(group) => url.push_str(&group.replace('.', "/")),
+				None => {
+					return Err(hc_error!(
+						"Download location for CycloneDX file is a Maven package with no group."
+					))
+				}
+			}
+			url.push('/');
+			let name = purl.name();
+			url.push_str(name);
+			// A package version is needed to construct a URL
+			match purl.version() {
+				Some(version) => {
+					url.push('/');
+					url.push_str(version);
+					url.push('/');
+					let pom_file = format!("{}-{}.pom", name, version);
+					url.push_str(&pom_file);
+				}
+				None => {
+					return Err(hc_error!(
+						"Download location for CycloneDX file is a Maven package with no version."
+					))
+				}
+			}
+
+			// Next attempt to get the git repo URL for the Maven package
+			extract_repo_for_maven(&url).context(
+				"Could not get git repo URL for CycloneDX file's corresponding Maven package",
+			)
+		}
+		"npm" => {
+			// First extract NPM package w/ optional version from the pURL
+			let package = purl.name();
+			let version = purl.version().unwrap_or("no version");
+
+			// Next attempt to get the git repo URL for the NPM package
+			extract_repo_for_npm(package, version).context(
+				"Could not get git repo URL for CycloneDX file's corresponding NPM package",
+			)
+		}
+		"pypi" => {
+			// First extract PyPI package w/ optional version from the pURL
+			let package = purl.name();
+			let version = purl.version().unwrap_or("no version");
+
+			// Next attempt to get the git repo URL for the PyPI package
+			extract_repo_for_pypi(package, version).context(
+				"Could not get git repo URL for CycloneDX file's corresponding PyPI package",
+			)
+		}
+        _ => Err(hc_error!("Download location for CycloneDX file is a pURL for a type not currently supported by Hipcheck."))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::path::PathBuf;
+
+	#[test]
+	fn test_extract_url_from_cyclonedx_json() {
+		let manifest = env!("CARGO_MANIFEST_DIR");
+		let path: PathBuf = [manifest, "src", "session", "tests", "juiceshop_bom.json"]
+			.iter()
+			.collect();
+		let json = path.to_str().unwrap();
+		let url = extract_cyclonedx_download_url(json).unwrap();
+		assert_eq!(
+			url.to_string(),
+			"https://github.com/juice-shop/juice-shop.git".to_string()
+		);
+	}
+}

--- a/hipcheck/src/session/spdx.rs
+++ b/hipcheck/src/session/spdx.rs
@@ -28,7 +28,7 @@ const SCM_HTTPS: &str = "https";
 
 /// Extract the first compatible package download location from an
 /// SPDX document
-pub fn extract_download_url(filepath: &str) -> Result<String> {
+pub fn extract_spdx_download_url(filepath: &str) -> Result<String> {
 	let contents = std::fs::read_to_string(filepath)?;
 
 	if contents.contains(DLOAD_LOCN_TAG) {

--- a/hipcheck/src/session/tests/juiceshop_bom.json
+++ b/hipcheck/src/session/tests/juiceshop_bom.json
@@ -1,0 +1,82 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.3",
+  "serialNumber": "urn:uuid:1f860713-54b9-4253-ba5a-9554851904af",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2020-08-03T03:20:53.771Z",
+    "tools": [
+      {
+        "vendor": "CycloneDX",
+        "name": "Node.js module",
+        "version": "2.0.0"
+      }
+    ],
+    "component": {
+      "type": "library",
+      "bom-ref": "pkg:github/juice-shop/juice-shop",
+      "name": "juice-shop",
+      "version": "11.1.2",
+      "description": "Probably the most modern and sophisticated insecure web application",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:github/juice-shop/juice-shop",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://owasp-juice.shop"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/bkimminich/juice-shop/issues"
+        },
+        {
+          "type": "vcs",
+          "url": "git+https://github.com/bkimminich/juice-shop.git"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "name": "body-parser",
+      "version": "1.19.0",
+      "description": "Node.js body parsing middleware",
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/body-parser@1.19.0",
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://github.com/expressjs/body-parser#readme"
+        },
+        {
+          "type": "issue-tracker",
+          "url": "https://github.com/expressjs/body-parser/issues"
+        },
+        {
+          "type": "vcs",
+          "url": "git+https://github.com/expressjs/body-parser.git"
+        }
+      ]
+    }    
+  ]
+}

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -15,7 +15,7 @@ pub enum TargetType {
 	Pypi,
 	Repo,
 	Request,
-	Spdx,
+	Sbom,
 }
 
 impl TargetType {
@@ -83,7 +83,7 @@ impl TargetType {
 					// Construct PyPI package w/optional version from pURL as the updated target string
 					let name = purl.name();
 					let mut package = name.to_string();
-					// Include version if providedc
+					// Include version if provided
 					if let Some(version) = purl.version() {
 						package.push('@');
 						package.push_str(version);
@@ -121,9 +121,14 @@ impl TargetType {
 		// Otherwise, check if it is a GitHub repo URL
 		} else if tgt.starts_with("https://github.com/") {
 			Some((Repo, tgt.to_string()))
-		// Otherwise check if it has an SPDX file extension
-		} else if tgt.ends_with(".spdx") {
-			Some((Spdx, tgt.to_string()))
+		// Otherwise check if it has an SPDX or CycloneDX SBOM file extension
+		} else if tgt.ends_with(".spdx")
+			|| tgt.ends_with("bom.json")
+			|| tgt.ends_with(".cdx.json")
+			|| tgt.ends_with("bom.xml")
+			|| tgt.ends_with(".cdx.xml")
+		{
+			Some((Sbom, tgt.to_string()))
 		} else {
 			None
 		}

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -76,12 +76,36 @@ impl Display for PackageHost {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Sbom {
+	/// The path to the SBOM file
+	pub path: PathBuf,
+
+	/// What standard the SBOM uses
+	pub standard: SbomStandard,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SbomStandard {
+	Spdx,
+	CycloneDX,
+}
+
+impl Display for SbomStandard {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self {
+			SbomStandard::Spdx => write!(f, "SPDX"),
+			SbomStandard::CycloneDX => write!(f, "CycloneDX"),
+		}
+	}
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TargetSeed {
 	LocalRepo(LocalGitRepo),
 	RemoteRepo(RemoteGitRepo),
 	Package(Package),
 	MavenPackage(MavenPackage),
-	Spdx(PathBuf),
+	Sbom(Sbom),
 }
 
 impl Display for TargetSeed {
@@ -102,7 +126,9 @@ impl Display for TargetSeed {
 			TargetSeed::MavenPackage(package) => {
 				write!(f, "Maven package {}", package.url.as_str())
 			}
-			TargetSeed::Spdx(path) => write!(f, "SPDX file at {}", path.display()),
+			TargetSeed::Sbom(sbom) => {
+				write!(f, "{} SBOM file at {}", sbom.standard, sbom.path.display())
+			}
 		}
 	}
 }


### PR DESCRIPTION
Partially resolves Issue #186  Hipcheck can now process SBOMs using both SPDX and CycloneDX (currently JSON only) standard. Currently we only support CycloneDX JSONs in versions 1.3 - 1.5 of the CycloneDX specification.