### PR TITLE
fix: Hipcheck now works with scoped npm packages.

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -568,9 +568,10 @@ impl ToTargetSeed for CheckNpmArgs {
 			_ => pm::extract_package_version(raw_package)?,
 		};
 
+		// If the package is scoped, replace the leading '@' in the scope with %40 for proper pURL formatting
 		let purl = Url::parse(&match version.as_str() {
-			"no version" => format!("pkg:npm/{}", name),
-			_ => format!("pkg:npm/{}@{}", name, version),
+			"no version" => format!("pkg:npm/{}", str::replace(&name, '@', "%40")),
+			_ => format!("pkg:npm/{}@{}", str::replace(&name, '@', "%40"), version),
 		})
 		.unwrap();
 
@@ -1248,7 +1249,7 @@ mod tests {
 
 	#[test]
 	fn test_deductive_check_npm_purl() {
-		let package = "express@4.19.2".to_string();
+		let package = "@expressjs/express@4.19.2".to_string();
 		let cmd =
 			get_check_cmd_from_cli(vec!["hc", "check", "pkg:npm/%40expressjs/express@4.19.2"]);
 		assert!(matches!(cmd, Ok(CheckCommand::Npm(..))));

--- a/hipcheck/src/target.rs
+++ b/hipcheck/src/target.rs
@@ -70,8 +70,15 @@ impl TargetType {
 				}
 				"npm" => {
 					// Construct NPM package w/ optional version from pURL as the updated target string
+					let mut package = String::new();
+
+					// Include scope if provided
+					if let Some(scope) = purl.namespace() {
+						package.push_str(scope);
+						package.push('/');
+					}
 					let name = purl.name();
-					let mut package = name.to_string();
+					package.push_str(name);
 					// Include version if provided
 					if let Some(version) = purl.version() {
 						package.push('@');


### PR DESCRIPTION
Resolves Issue #235. Hipcheck will now include the scope for scoped NPM packages in the format `@scope/package@version`.

This works with NPM targets in `package@version`, NPM registry URL, or pURL formats.