### PR TITLE
feat: update remote-repo updating to support git refs

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -620,17 +620,20 @@ pub struct CheckRepoArgs {
 	pub source: String,
 	/// The ref of the repo to analyze
 	#[clap(long = "ref")]
-	pub ref_: Option<String>,
+	pub refspec: Option<String>,
 }
 
 impl ToTargetSeed for CheckRepoArgs {
 	fn to_target_seed(&self) -> Result<TargetSeed> {
 		if let Ok(url) = Url::parse(&self.source) {
 			let remote_repo = source::get_remote_repo_from_url(url)?;
-			Ok(TargetSeed::RemoteRepo(remote_repo))
+			Ok(TargetSeed::RemoteRepo {
+				target: remote_repo,
+				refspec: self.refspec.clone(),
+			})
 		} else {
 			let path = PathBuf::from(&self.source);
-			let git_ref = match &self.ref_ {
+			let git_ref = match &self.refspec {
 				Some(r) => r.clone(),
 				None => source::get_head_commit(path.as_path())
 					.context("can't get head commit for local source")?,

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -219,10 +219,13 @@ fn cmd_print_weights(config: &CliConfig) -> Result<()> {
 	// Create a dummy session to query the salsa database for a weight graph for printing.
 	let session = Session::new(
 		// Use the hipcheck repo as a dummy url until checking is de-coupled from `Session`.
-		&TargetSeed::RemoteRepo(RemoteGitRepo {
-			url: url::Url::parse("https://github.com/mitre/hipcheck.git").unwrap(),
-			known_remote: None,
-		}),
+		&TargetSeed::RemoteRepo {
+			target: RemoteGitRepo {
+				url: url::Url::parse("https://github.com/mitre/hipcheck.git").unwrap(),
+				known_remote: None,
+			},
+			refspec: Some("HEAD".to_owned()),
+		},
 		config.config().map(ToOwned::to_owned),
 		config.data().map(ToOwned::to_owned),
 		config.cache().map(ToOwned::to_owned),

--- a/hipcheck/src/session/session.rs
+++ b/hipcheck/src/session/session.rs
@@ -271,7 +271,9 @@ fn load_config_and_data(
 fn load_target(seed: &TargetSeed, home: &Path) -> Result<Target> {
 	// Resolve the source specifier into an actual source.
 	let phase_desc = match seed {
-		TargetSeed::LocalRepo(_) | TargetSeed::RemoteRepo(_) => "resolving git repository target",
+		TargetSeed::LocalRepo(_) | TargetSeed::RemoteRepo { .. } => {
+			"resolving git repository target"
+		}
 		TargetSeed::Package(_) => "resolving package target",
 		TargetSeed::Sbom(_) => "parsing SBOM document",
 		TargetSeed::MavenPackage(_) => "resolving maven package target",
@@ -300,7 +302,9 @@ fn resolve_target(seed: &TargetSeed, phase: &SpinnerPhase, home: &Path) -> Resul
 	let _0 = crate::benchmarking::print_scope_time!("resolve_source");
 
 	match seed {
-		TargetSeed::RemoteRepo(repo) => source::resolve_remote_repo(phase, home, repo.to_owned()),
+		TargetSeed::RemoteRepo { target, refspec } => {
+			source::resolve_remote_repo(phase, home, target.to_owned(), refspec.clone())
+		}
 		TargetSeed::LocalRepo(source) => source::resolve_local_repo(phase, home, source.to_owned()),
 		TargetSeed::Package(package) => {
 			// Attempt to get the git repo URL for the package

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -102,7 +102,10 @@ impl Display for SbomStandard {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TargetSeed {
 	LocalRepo(LocalGitRepo),
-	RemoteRepo(RemoteGitRepo),
+	RemoteRepo {
+		target: RemoteGitRepo,
+		refspec: Option<String>,
+	},
 	Package(Package),
 	MavenPackage(MavenPackage),
 	Sbom(Sbom),
@@ -112,11 +115,11 @@ impl Display for TargetSeed {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			TargetSeed::LocalRepo(repo) => write!(f, "local repo at {}", repo.path.display()),
-			TargetSeed::RemoteRepo(remote_repo) => match &remote_repo.known_remote {
+			TargetSeed::RemoteRepo { target, .. } => match &target.known_remote {
 				Some(KnownRemote::GitHub { owner, repo }) => {
-					write!(f, "GitHub repo {}/{} from {}", owner, repo, remote_repo.url)
+					write!(f, "GitHub repo {}/{} from {}", owner, repo, target.url)
 				}
-				_ => write!(f, "remote repo at {}", remote_repo.url.as_str()),
+				_ => write!(f, "remote repo at {}", target.url.as_str()),
 			},
 			TargetSeed::Package(package) => write!(
 				f,


### PR DESCRIPTION
This PR splits `source/git.rs::update()` into `fetch()`, and `checkout()`. It also updates the `TargetSeed::RemoteRepo` variant to pass along `--ref` info from the cmdline to the new `checkout()` function.

The desire for `--ref` exposes some limitations of the current `TargetSeed` enum. Data passed on the CLI through `--ref` can easily be slotted into `LocalGitRepo`, but not into the other variants. One option would be to break away from using `Target` subfields for each variant so the wrapped structs can carry more information. I opted instead to just add another field to the variant, but the decision is very much up for discussion.

Note that this PR does not address passing `--ref` info for other `TargetSeed` variants.