### PR TITLE
chore(refactor): distinguish TargetSeed and TargetSeedKind

### DIFF
--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -78,7 +78,7 @@ use std::process::Command;
 use std::process::ExitCode;
 use std::result::Result as StdResult;
 use std::time::Duration;
-use target::{RemoteGitRepo, TargetSeed, ToTargetSeed};
+use target::{RemoteGitRepo, TargetSeed, TargetSeedKind, ToTargetSeed};
 use util::fs::create_dir_all;
 use which::which;
 
@@ -159,14 +159,8 @@ fn main() -> ExitCode {
 
 /// Run the `check` command.
 fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
-	let target = match args.command() {
-		Ok(chk) => match chk.to_target_seed() {
-			Ok(target) => target,
-			Err(e) => {
-				Shell::print_error(&e, Format::Human);
-				return ExitCode::FAILURE;
-			}
-		},
+	let target = match args.to_target_seed() {
+		Ok(target) => target,
 		Err(e) => {
 			Shell::print_error(&e, Format::Human);
 			return ExitCode::FAILURE;
@@ -219,11 +213,11 @@ fn cmd_print_weights(config: &CliConfig) -> Result<()> {
 	// Create a dummy session to query the salsa database for a weight graph for printing.
 	let session = Session::new(
 		// Use the hipcheck repo as a dummy url until checking is de-coupled from `Session`.
-		&TargetSeed::RemoteRepo {
-			target: RemoteGitRepo {
+		&TargetSeed {
+			kind: TargetSeedKind::RemoteRepo(RemoteGitRepo {
 				url: url::Url::parse("https://github.com/mitre/hipcheck.git").unwrap(),
 				known_remote: None,
-			},
+			}),
 			refspec: Some("HEAD".to_owned()),
 		},
 		config.config().map(ToOwned::to_owned),

--- a/hipcheck/src/session/pm.rs
+++ b/hipcheck/src/session/pm.rs
@@ -549,7 +549,7 @@ fn is_none_or_empty(s: Option<&str>) -> bool {
 mod tests {
 	use crate::{
 		cli::{CheckNpmArgs, CheckPypiArgs},
-		target::{TargetSeed, ToTargetSeed},
+		target::{TargetSeedKind, ToTargetSeedKind},
 	};
 
 	// Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -565,9 +565,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -593,9 +593,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -621,9 +621,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -649,9 +649,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -677,9 +677,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -705,9 +705,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -734,9 +734,9 @@ mod tests {
 		let target_seed = CheckPypiArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -766,9 +766,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -794,9 +794,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -822,9 +822,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: link.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -850,9 +850,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: npm_package.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -878,9 +878,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: npm_package.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -906,9 +906,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: npm_package.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -934,9 +934,9 @@ mod tests {
 		let target_seed = CheckNpmArgs {
 			package: npm_package.to_string(),
 		}
-		.to_target_seed()
+		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeed::Package(package) = target_seed {
+		if let TargetSeedKind::Package(package) = target_seed {
 			assert_eq!(
 				package,
 				Package {


### PR DESCRIPTION
Following a team discussion, this PR renames the existing `TargetSeed` enum to `TargetSeedKind` and wraps it with a new `TargetSeed` struct that allows `refspec` info to be passed from the CLI for non-local repos. 

This PR does not introduce git ref support for packages or SBOMs, it simply refactors the existing logic.