### PR TITLE
feat: add --ref support to remaining target seed kinds

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -512,10 +512,21 @@ impl CheckArgs {
 impl ToTargetSeed for CheckArgs {
 	fn to_target_seed(&self) -> Result<TargetSeed> {
 		let kind = self.command()?.to_target_seed_kind()?;
-		Ok(TargetSeed {
+		let target = TargetSeed {
 			kind,
 			refspec: self.refspec.clone(),
-		})
+		};
+		// Validate
+		if let Some(refspec) = &target.refspec {
+			if let TargetSeedKind::Package(p) = &target.kind {
+				if p.has_version() && &p.version != refspec {
+					return Err(hc_error!("ambiguous version for package target: package target specified {}, but refspec flag specified {}. please specify only one.", p.version, refspec));
+				}
+			}
+		};
+
+		// TargetSeed is valid
+		Ok(target)
 	}
 }
 

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -53,6 +53,15 @@ pub struct Package {
 	/// What host the package is from.
 	pub host: PackageHost,
 }
+impl Package {
+	pub fn has_version(&self) -> bool {
+		self.version != Package::no_version()
+	}
+	pub fn no_version() -> &'static str {
+		"no version"
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MavenPackage {
 	/// The Maven url


### PR DESCRIPTION
We do not seem to currently harvest version information from SBOMs and Maven URLs. In the future we will need to add `--ref` vs. harvested-version resolution strategies to them like has been done here for `TargetSeedKind::Package`.