### PR TITLE
docs: added README for dockerhub

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -41,3 +41,25 @@ jobs:
           push: true
           platforms: "linux/amd64,linux/arm64"
           tags: mitre/hipcheck:latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}
+      - name: Verify Dockerhub Description Size
+        id: verify_dockerhub_readme_size
+        run: |
+          FILE_PATH="./dist/dockerhub/README.md"
+          MAX_SIZE=25000
+          if [ ! -f "$FILE_PATH" ]; then
+            echo "File does not exist: $FILE_PATH"
+            exit 1
+          fi
+          FILE_SIZE=$(wc -c < $FILE_PATH)
+          if [ $FILE_SIZE -ge $MAX_SIZE ]; then
+            echo "File is too large: $FILE_SIZE bytes (MAX allowed is $MAX_SIZE)"
+            exit 1
+          fi
+          echo "File is small enough to push: $FILE_SIZE (MAX allowed is $MAX_SIZE)"
+      - name: Update Dockerhub description
+        if: success()
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          readme-filepath: ./dist/dockerhub/README.md

--- a/dist/dockerhub/README.md
+++ b/dist/dockerhub/README.md
@@ -1,0 +1,36 @@
+# What is Hipcheck?
+
+Hipcheck is a command line interface (CLI) tool for analyzing open source
+software packages and source repositories to understand their software supply
+chain risk. It analyzes a project's _software development practices_ and
+detects _active supply chain attacks_ to give you both a long-term and
+immediate picture of the risk from using a package.
+
+## How to Use the Image
+
+To run a short-lived container with the latest version of `hipcheck`, you might run:
+
+NOTE: `latest` __always__ refers to the most-recently published image.
+
+```
+docker run mitre/hipcheck:latest
+```
+
+Hipcheck currently provides images for the following architectures:
+
+* `linux/amd64`
+* `linux/arm64`
+
+## Helpful Links
+
+* [Website](https://mitre.github.io/hipcheck)
+* [Quickstart Guide](https://mitre.github.io/hipcheck/docs/quickstart/)
+* [Complete Guide](https://mitre.github.io/hipcheck/docs/guide/)
+* [Github](https://github.com/mitre/hipcheck)
+* [Report an Issue](https://github.com/mitre/hipcheck/issues/new)
+
+## License
+
+Hipcheck's software is licensed under the Apache 2.0 license, which can be
+found [here](https://github.com/mitre/hipcheck/blob/main/LICENSE)
+


### PR DESCRIPTION
I added a new folder to the top level of the repo `third-party-docs` and added `README-dockerhub.md` file with a README that can be added to `mitre/hipcheck` page on dockerhub. I am not sure if we want to make another top-level directory, but I did not want to clutter the root of the repository with something that is only for Dockerhub. If anyone has suggested alternatives, please let me know!

I could not find any information for adding/editing the description via any official Docker tooling, but I found this [link](https://github.com/peter-evans/dockerhub-description) if we want to add this to CI to be run after deploying the latest image to Dockerhub

As far as adding tags, there did not seem to be an automated way of doing it. This [link](https://docs.docker.com/docker-hub/repos/categories/) shows how to adjust the settings for the project and also contains the `Categories` supported by Dockerhub. I would propose that we add the following tags to the `mitre/hipcheck` image:
- `Security`
- `Integrations & Delivery` (if `hipcheck` is ever designed to be run in CI/CD pipelines)