### PR TITLE
chore: Create docker image SBOM on release

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -63,3 +63,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           readme-filepath: ./dist/dockerhub/README.md
+  
+  build-sbom:
+    needs: push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create docker image SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: mitre/hipcheck:latest
+          format: spdx-json
+          artifact-name: hipcheck-docker-sbom.spdx


### PR DESCRIPTION
Resolves first part of Issue #171 (other parts are waiting on changes to `cargo-dist`). Adds a GitHub action to create an SPDX SBOM for the Hipcheck docker image after we create and push that image during the normal release workflow. The SBOM _should_ be automatically added as an artifact to the same release.

Draft because this has not been tested yet. We need to come up with a good way to test this that does not involve creating many unnecessary docker images.