### PR TITLE
Fix broken website deploy CI job

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,4 +1,4 @@
-name: Commits
+name: Commit Checks
 
 on:
   pull_request:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,4 +1,4 @@
-name: Website
+name: Website Deploy
 
 # Runs on pushed to the default branch but can also be
 # run manually from the GitHub Actions page.
@@ -86,7 +86,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: website-build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -1,4 +1,4 @@
-name: Website
+name: Website Test
 
 # Run when PRs would modify the site code.
 on:


### PR DESCRIPTION
The website deploy CI job was quietly broken by #264, and this commit fixes it by ensuring the job dependency name matches the earlier renamed build job.

It also gives the "Website Deploy" and "Website Test" workflows distinct names so they're clearly different in the GitHub UI.