### PR TITLE
fix(build): Always run tests on main to create reusable caches

### DIFF
--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -1,8 +1,23 @@
 name: Hipcheck
 
-# Run on PRs before merging. We disallow pushing directly to main
-# without going through a PR, so we don't run on `push` events for main.
+# Run on both PRs and pushes to the main branch.
+# It may seem redundant to run tests on main, since we disallow pushing directly
+# to main and all PRs get tested before merging.
+#
+# But due to how GitHub Actions isolates caches, we need to run the tests on
+# main so that caches are available to new PRs. The caches created when testing
+# PR code cannot be re-used outside of testing that PR.
+#
+# See the GitHub Actions documentation here:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 on:
+  push:
+    branches: [main]
+    paths:
+      - "config/**"
+      - "hipcheck/**"
+      - "scripts/**"
+      - "xtask/**"
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
Pull Request #264 changed the build settings so that tests would not be run on all pushes to the `main` branch.
Unfortunately, while it seems wasteful to do redundant builds, this has the consequence of preventing re-use of build caches.

The reason is that build caches created for Pull Requests are isolated from other PRs (except those based on that PR) and the `main` branch. Build caches created for `main` _can_ be re-used in PR builds, which is what we want.

[GitHub Actions docs on re-use of build caches](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)

The good news is that this should save build time overall. It should also reduce churn in the storage of caches: Most of the time, caches made for `main` can be reused in PR builds, which means that no new caches need to be created at all for PRs that don't change `Cargo.toml` or `Cargo.lock`.