### PR TITLE
chore: Update cargo-dist to 0.21.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.18.1-prerelease.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.21.0/cargo-dist-installer.sh | sh"
       - name: Cache cargo-dist
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-members = ["hipcheck"]
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.18.1-prerelease.1"
+cargo-dist-version = "0.21.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -40,6 +40,8 @@ pr-run-mode = "plan"
 install-updater = true
 # Extra static files to include in each App (path relative to this Cargo.toml's dir)
 include = ["config/", "scripts/"]
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
 
 
 # The profile that 'cargo dist' will build with


### PR DESCRIPTION
Resolves #280  Updates `cargo-dist` to version 0.21.0. Makes necessary changes to cargo dist's config in the `Cargo.toml` file.