### PR TITLE
feat: plugin interface handles multiple active query sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "dummy_rand_data"
-version = "3.5.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "prost",


### PR DESCRIPTION
*Note* This PR relies on #290 . Merge this only after it has been merged.

This PR further wraps `PluginTransport` in an `ActivePlugin` struct, which manages query "sessions". It is responsible for handing out query IDs to new queries (`next_id` is guarded by a Mutex), and converts `Query --> PluginResponse` object which either returns the result or packages the info needed to "resume" the current query once the required information has been gathered.

This also implements multiplexing on the `PuginTransport::rx` receiver, along with a backlog of messages. This way a query session can ignore but save messages not destined for them.

Overall, this PR also accomplishes removing `&mut` references from the plugin communication interface so it can be `Send` and thus eligible for salsa async database functionality.