### PR TITLE
fix quiet bug regression

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -17,7 +17,7 @@ use crate::target::{
 use clap::{Parser as _, ValueEnum};
 use hipcheck_macros as hc;
 use pathbuf::pathbuf;
-use std::{env, path::{Path, PathBuf}};
+use std::path::{Path, PathBuf};
 use url::Url;
 
 /// Automatated supply chain risk assessment of software packages.
@@ -324,7 +324,10 @@ impl CliConfig {
 				config: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "config"]),
 				data: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "data"]),
 				cache: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "cache"]),
-				policy: env::current_dir().ok().map(|dir| pathbuf![&dir, "Hipcheck.kdl"]),
+				// TODO: currently if this is set, then when running `hc check`, it errors out
+				// because policy files are not yet supported
+				// policy: env::current_dir().ok().map(|dir| pathbuf![&dir, "Hipcheck.kdl"]),
+				policy: None,
 			},
 			..Default::default()
 		}

--- a/hipcheck/src/session/session.rs
+++ b/hipcheck/src/session/session.rs
@@ -290,7 +290,6 @@ fn load_target(seed: &TargetSeed, home: &Path) -> Result<Target> {
 	// Set the phase to tick steadily 10 times a second.
 	phase.enable_steady_tick(Duration::from_millis(100));
 	let target = resolve_target(seed, &phase, home)?;
-	println!("TARGET: {target:?}");
 	phase.finish_successful();
 
 	Ok(target)

--- a/hipcheck/src/shell.rs
+++ b/hipcheck/src/shell.rs
@@ -224,7 +224,12 @@ impl Shell {
 
 	/// Print "Analysing {source}" with the proper color/styling.
 	pub fn print_prelude(source: impl AsRef<str>) {
-		macros::println!("{:>LEFT_COL_WIDTH$} {}", Title::Analyzing, source.as_ref());
+		match Shell::get_verbosity() {
+			Verbosity::Normal => {
+				macros::println!("{:>LEFT_COL_WIDTH$} {}", Title::Analyzing, source.as_ref());
+			}
+			Verbosity::Quiet | Verbosity::Silent => {}
+		}
 	}
 
 	/// Print a hipcheck [Error]. Human readable errors will go to the standard error, JSON will go to the standard output.


### PR DESCRIPTION
When running `hc check --format json -v quiet https://github.com/mitre/hipcheck`, the following error occurs on `origin/main`

![image](https://github.com/user-attachments/assets/5f8170f5-e890-4531-a9e0-f595b435c5ea)

Here is the tip of `origin/main` with the policy file error omitted

![image](https://github.com/user-attachments/assets/e1226734-4382-4373-9a8f-fffbe8c15b43)

The tip of this branch has nothing printed before the JSON is output

![image](https://github.com/user-attachments/assets/de344a28-fa82-475e-9b92-1169773ca3f6)

If anyone has an idea of how to test this/ensure I hid everything that should be hidden when `-v quiet` is passed, I would love to hear it!