### PR TITLE
feat: added primitive support for plugin downloading, decompression a…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +121,18 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -224,7 +242,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -258,6 +276,19 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -315,12 +346,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -818,12 +850,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1122,6 +1154,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "clap",
  "console",
@@ -1134,6 +1167,7 @@ dependencies = [
  "duct",
  "env_logger",
  "finl_unicode",
+ "flate2",
  "fs_extra",
  "futures",
  "git2",
@@ -1169,6 +1203,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha256",
  "smart-default",
  "spdx-rs",
  "tabled",
@@ -1190,6 +1225,8 @@ dependencies = [
  "xml-rs",
  "xz2",
  "zip",
+ "zip-extensions",
+ "zstd",
 ]
 
 [[package]]
@@ -1698,6 +1735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -2566,6 +2612,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha256"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2647,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -3669,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
  "aes",
  "arbitrary",
@@ -3694,6 +3758,15 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386508a00aae1d8218b9252a41f59bba739ccee3f8e420bb90bcb1c30d960d4a"
+dependencies = [
+ "zip",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -33,6 +33,7 @@ benchmarking = []
 
 async-stream = "0.3.5"
 base64 = "0.22.1"
+blake3 = "1.5.4"
 content_inspector = "0.2.4"
 cyclonedx-bom = "0.7.0"
 dotenv = "0.15.0"
@@ -47,6 +48,7 @@ env_logger = { version = "0.11.5" }
 finl_unicode = { version = "1.2.0", default-features = false, features = [
     "grapheme_clusters",
 ] }
+flate2 = "1.0.33"
 fs_extra = "1.3.0"
 futures = "0.3.30"
 # Vendor libgit2 and openssl so that they will be statically included
@@ -106,6 +108,7 @@ semver = "1.0.9"
 serde = { version = "1.0.206", features = ["derive", "rc"] }
 serde_derive = "1.0.137"
 serde_json = "1.0.122"
+sha256 = { version = "1.5.0", default-features = false }
 smart-default = "0.7.1"
 spdx-rs = "0.5.0"
 tabled = "0.16.0"
@@ -117,6 +120,7 @@ tokio = { version = "1.39.3", features = [
     "sync",
     "time",
 ] }
+tokio-stream = "0.1.15"
 toml = "0.8.19"
 tonic = "0.12.1"
 thiserror = "1.0.63"
@@ -130,8 +134,9 @@ walkdir = "2.5.0"
 which = { version = "6.0.3", default-features = false }
 xml-rs = "0.8.20"
 xz2 = "0.1.7"
-zip = "2.1.6"
-tokio-stream = "0.1.15"
+zip = "2.2.0"
+zip-extensions = "0.8.1"
+zstd = "0.13.2"
 
 [build-dependencies]
 

--- a/hipcheck/src/cache/plugin_cache.rs
+++ b/hipcheck/src/cache/plugin_cache.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 
 use pathbuf::pathbuf;
 
+use crate::plugin::{PluginArch, PluginName, PluginPublisher, PluginVersion};
+
+/// Plugins are stored with the following format `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>/<arch>`
 pub struct HcPluginCache {
 	path: PathBuf,
 }
@@ -12,5 +15,20 @@ impl HcPluginCache {
 	pub fn new(path: &Path) -> Self {
 		let plugins_path = pathbuf![path, "plugins"];
 		Self { path: plugins_path }
+	}
+
+	/// `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>/<arch>`
+	pub fn plugin_download_dir(
+		&self,
+		publisher: &PluginPublisher,
+		name: &PluginName,
+		version: &PluginVersion,
+		arch: &PluginArch,
+	) -> PathBuf {
+		self.path
+			.join(&publisher.0)
+			.join(&name.0)
+			.join(&version.0)
+			.join(&arch.0)
 	}
 }

--- a/hipcheck/src/plugin/kdl_parsing.rs
+++ b/hipcheck/src/plugin/kdl_parsing.rs
@@ -1,10 +1,7 @@
-mod download_manifest;
-mod plugin_manifest;
-
 use kdl::KdlNode;
 
 // Helper trait to make it easier to parse KdlNodes into our own types
-trait ParseKdlNode
+pub trait ParseKdlNode
 where
 	Self: Sized,
 {
@@ -16,7 +13,7 @@ where
 }
 
 /// Returns the first successful node that can be parsed into T, if there is one
-fn extract_data<T>(nodes: &[KdlNode]) -> Option<T>
+pub fn extract_data<T>(nodes: &[KdlNode]) -> Option<T>
 where
 	T: ParseKdlNode,
 {

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -1,9 +1,18 @@
+mod download_manifest;
+mod kdl_parsing;
 mod manager;
-mod parser;
+mod plugin_manifest;
+mod retrieval;
 mod types;
 
 pub use crate::plugin::manager::*;
 pub use crate::plugin::types::*;
+pub use download_manifest::{
+	ArchiveFormat, DownloadManifest, DownloadManifestEntry, HashAlgorithm, HashWithDigest,
+};
+pub use kdl_parsing::{extract_data, ParseKdlNode};
+pub use plugin_manifest::{PluginArch, PluginManifest, PluginName, PluginPublisher, PluginVersion};
+
 use crate::Result;
 use futures::future::join_all;
 use serde_json::Value;

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -1,0 +1,143 @@
+use std::{
+	fs::File,
+	io::{Read, Seek, Write},
+	path::{Path, PathBuf},
+};
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+use url::Url;
+use xz2::read::XzDecoder;
+use zip_extensions::{zip_extract, ZipArchiveExtensions};
+
+use crate::error::Error;
+use crate::hc_error;
+use crate::plugin::{ArchiveFormat, HashAlgorithm, HashWithDigest};
+use crate::util::http::agent::agent;
+
+/// download a plugin, verify its size and hash
+pub fn download_plugin(
+	url: &Url,
+	download_dir: &Path,
+	expected_size: u64,
+	expected_hash_with_digest: &HashWithDigest,
+) -> Result<PathBuf, Error> {
+	// retrieve archive
+	let agent = agent();
+	let response = agent
+		.get(url.as_str())
+		.call()
+		.map_err(|e| hc_error!("Error [{}] retrieving download manifest {}", e, url))?;
+	let error_code = response.status();
+	if error_code != 200 {
+		return Err(hc_error!(
+			"HTTP error code {} when retrieving {}",
+			error_code,
+			url
+		));
+	}
+
+	// extract bytes from response
+	// preallocate 10 MB to cut down on number of allocations needed
+	let mut contents = Vec::with_capacity(10 * 1024 * 1024);
+	let amount_read = response
+		.into_reader()
+		.read_to_end(&mut contents)
+		.map_err(|e| hc_error!("Error [{}] reading download into buffer", e))?;
+	contents.truncate(amount_read);
+
+	// verify size of download
+	if expected_size != amount_read as u64 {
+		return Err(hc_error!(
+			"File size mismatch, Expected {} B, Found {} B",
+			expected_size,
+			amount_read
+		));
+	}
+
+	// verify hash
+	let actual_hash = match expected_hash_with_digest.hash_algorithm {
+		HashAlgorithm::Sha256 => sha256::digest(&contents),
+		HashAlgorithm::Blake3 => blake3::hash(&contents).to_string(),
+	};
+	if actual_hash != expected_hash_with_digest.digest {
+		return Err(hc_error!(
+			"Plugin hash mismatch. Expected [{}], Received [{}]",
+			actual_hash,
+			expected_hash_with_digest.digest
+		));
+	}
+
+	let filename = url.path_segments().unwrap().last().unwrap();
+	let output_path = Path::new(download_dir).join(filename);
+	let mut file = File::create(&output_path).map_err(|e| {
+		hc_error!(
+			"Error [{}] creating file: {}",
+			e,
+			output_path.to_string_lossy()
+		)
+	})?;
+	file.write_all(&contents).map_err(|e| {
+		hc_error!(
+			"Error [{}] writing to file: {}",
+			e,
+			output_path.to_string_lossy()
+		)
+	})?;
+
+	Ok(output_path)
+}
+
+/// Extract a bundle located at `bundle_path` into `extract_dir` by applying the specified `ArchiveFormat` extractions
+pub fn extract_plugin(
+	bundle_path: &Path,
+	extract_dir: &Path,
+	archive_format: ArchiveFormat,
+) -> Result<(), Error> {
+	let file = File::open(bundle_path).map_err(|e| {
+		hc_error!(
+			"Error [{}] opening file {}",
+			e,
+			bundle_path.to_string_lossy()
+		)
+	})?;
+
+	// perform decompression, if necessary, then unarchive
+	match archive_format {
+		ArchiveFormat::TarXz => {
+			let decoder = XzDecoder::new(file);
+			let mut archive = Archive::new(decoder);
+			archive.unpack(extract_dir).map_err(|e| {
+				hc_error!("Error [{}] extracting {}", e, bundle_path.to_string_lossy())
+			})?;
+		}
+		ArchiveFormat::TarGz => {
+			let decoder = GzDecoder::new(file);
+			let mut archive = Archive::new(decoder);
+			archive.unpack(extract_dir).map_err(|e| {
+				hc_error!("Error [{}] extracting {}", e, bundle_path.to_string_lossy())
+			})?;
+		}
+		ArchiveFormat::TarZst => {
+			let decoder = zstd::Decoder::new(file).unwrap();
+			let mut archive = Archive::new(decoder);
+			archive.unpack(extract_dir).map_err(|e| {
+				hc_error!("Error [{}] extracting {}", e, bundle_path.to_string_lossy())
+			})?;
+		}
+		ArchiveFormat::Tar => {
+			let mut archive = Archive::new(file);
+			archive.unpack(extract_dir).map_err(|e| {
+				hc_error!("Error [{}] extracting {}", e, bundle_path.to_string_lossy())
+			})?;
+		}
+		ArchiveFormat::Zip => {
+			let mut archive = zip::ZipArchive::new(file).unwrap();
+			archive.extract(extract_dir).map_err(|e| {
+				hc_error!("Error [{}] extracting {}", e, bundle_path.to_string_lossy())
+			})?;
+		}
+	};
+
+	Ok(())
+}


### PR DESCRIPTION
This pull request adds the following:

- Preliminary support for downloading, decompressing and unarchiving plugins into the `HC_CACHE/plugins` folder
- Renamed several structs related to plugins to include `Plugin` as a prefix to avoid confusion
- Removed `hipcheck/plugin/parser`, as it started to contain code that was outside of the scope of just `KDL` parsing