### PR TITLE
chore: Include `build.rs` in `hipcheck` crate

### DIFF
--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 license = "Apache-2.0"
 homepage = "https://mitre.github.io/hipcheck"
 repository = "https://github.com/mitre/hipcheck"
-include = ["src/**/*", "../LICENSE", "../README.md"]
+include = ["src/**/*", "../LICENSE", "../README.md", "build.rs"]
 
 # Rename the binary from the default "hipcheck" (based on the package name)
 # to "hc".


### PR DESCRIPTION
Without this included, the `build.rs` won't get published to Crates.ip, which would be a problem.