### PR TITLE
chore: now store architecture as an enum

### DIFF
--- a/hipcheck/src/cache/plugin_cache.rs
+++ b/hipcheck/src/cache/plugin_cache.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use pathbuf::pathbuf;
 
-use crate::plugin::{PluginArch, PluginName, PluginPublisher, PluginVersion};
+use crate::plugin::{PluginName, PluginPublisher, PluginVersion, SupportedArch};
 
 /// Plugins are stored with the following format `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>/<arch>`
 pub struct HcPluginCache {
@@ -23,12 +23,12 @@ impl HcPluginCache {
 		publisher: &PluginPublisher,
 		name: &PluginName,
 		version: &PluginVersion,
-		arch: &PluginArch,
+		arch: SupportedArch,
 	) -> PathBuf {
 		self.path
 			.join(&publisher.0)
 			.join(&name.0)
 			.join(&version.0)
-			.join(&arch.0)
+			.join(arch.to_string())
 	}
 }

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -3,6 +3,7 @@ mod kdl_parsing;
 mod manager;
 mod plugin_manifest;
 mod retrieval;
+mod supported_arch;
 mod types;
 
 pub use crate::plugin::manager::*;
@@ -11,7 +12,8 @@ pub use download_manifest::{
 	ArchiveFormat, DownloadManifest, DownloadManifestEntry, HashAlgorithm, HashWithDigest,
 };
 pub use kdl_parsing::{extract_data, ParseKdlNode};
-pub use plugin_manifest::{PluginArch, PluginManifest, PluginName, PluginPublisher, PluginVersion};
+pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
+pub use supported_arch::SupportedArch;
 
 use crate::Result;
 use futures::future::join_all;

--- a/hipcheck/src/plugin/supported_arch.rs
+++ b/hipcheck/src/plugin/supported_arch.rs
@@ -1,0 +1,44 @@
+use std::{fmt::Display, str::FromStr};
+
+use crate::hc_error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// Officially supported target triples, as of RFD #0004
+///
+/// NOTE: these architectures correspond to the offically supported Rust platforms
+pub enum SupportedArch {
+	/// Used for macOS running on "Apple Silicon" running on a 64-bit ARM Instruction Set Architecture (ISA)
+	Aarch64AppleDarwin,
+	/// Used for macOS running on the Intel 64-bit ISA
+	X86_64AppleDarwin,
+	/// Used for Windows running on the Intel 64-bit ISA with the Microsoft Visual Studio Code toolchain for compilation
+	X86_64PcWindowsMsvc,
+	/// Used for Linux operating systems running on the Intel 64-bit ISA with a GNU toolchain for compilation
+	X86_64UnknownLinuxGnu,
+}
+
+impl FromStr for SupportedArch {
+	type Err = crate::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"aarch64-apple-darwin" => Ok(Self::Aarch64AppleDarwin),
+			"x86_64-apple-darwin" => Ok(Self::X86_64AppleDarwin),
+			"x86_64-pc-windows-msvc" => Ok(Self::X86_64PcWindowsMsvc),
+			"x86_64-unknown-linux-gnu" => Ok(Self::X86_64UnknownLinuxGnu),
+			_ => Err(hc_error!("Error parsing arch '{}'", s)),
+		}
+	}
+}
+
+impl Display for SupportedArch {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let target_triple = match self {
+			SupportedArch::Aarch64AppleDarwin => "aarch64-apple-darwin",
+			SupportedArch::X86_64AppleDarwin => "x86_64-apple-darwin",
+			SupportedArch::X86_64PcWindowsMsvc => "x86_64-pc-windows-msvc",
+			SupportedArch::X86_64UnknownLinuxGnu => "x86_64-unknown-linux-gnu",
+		};
+		write!(f, "{}", target_triple)
+	}
+}


### PR DESCRIPTION
Updated `arch` fields in the download and plugin manifest structs to hold an enum of the architectures supported by hipcheck