### PR TITLE
feat: introduce plugin-based query infrastructure to scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 # dotenv env configuration file
 .env
 
+# Vim swap files
+.*.swp
+
 # We generate a file with this name when prepping each release, and don't
 # want it to be checked in.
 CHANGELOG-NEXT.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -129,7 +129,7 @@ ureq = { version = "2.10.1", default-features = false, features = [
     "json",
     "tls",
 ] }
-url = "2.5.1"
+url = { version = "2.5.1", features = ["serde"] }
 walkdir = "2.5.0"
 which = { version = "6.0.3", default-features = false }
 xml-rs = "0.8.20"

--- a/hipcheck/src/metric/affiliation.rs
+++ b/hipcheck/src/metric/affiliation.rs
@@ -28,7 +28,7 @@ pub struct AffiliationOutput {
 	pub affiliations: Vec<Affiliation>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Affiliation {
 	pub commit: Arc<Commit>,
 	pub affiliated_type: AffiliatedType,

--- a/hipcheck/src/metric/churn.rs
+++ b/hipcheck/src/metric/churn.rs
@@ -19,7 +19,7 @@ pub struct ChurnOutput {
 	pub commit_churn_freqs: Vec<CommitChurnFreq>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct CommitChurnFreq {
 	pub commit: Arc<Commit>,
 	pub churn: F64,

--- a/hipcheck/src/metric/entropy.rs
+++ b/hipcheck/src/metric/entropy.rs
@@ -94,7 +94,7 @@ impl EntropyOutput {
 }
 
 /// The entropy of a single commit.
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Clone)]
 pub struct CommitEntropy {
 	/// The commit
 	pub commit: Arc<Commit>,

--- a/hipcheck/src/metric/identity.rs
+++ b/hipcheck/src/metric/identity.rs
@@ -12,7 +12,7 @@ pub struct IdentityOutput {
 	pub matches: Vec<Match>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Match {
 	pub commit: Arc<Commit>,
 	pub identities_match: bool,

--- a/hipcheck/src/metric/review.rs
+++ b/hipcheck/src/metric/review.rs
@@ -12,7 +12,7 @@ pub struct ReviewOutput {
 	pub pull_reviews: Vec<PullReview>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct PullReview {
 	pub pull_request: Arc<PullRequest>,
 	pub has_review: bool,

--- a/hipcheck/src/metric/typo.rs
+++ b/hipcheck/src/metric/typo.rs
@@ -23,7 +23,7 @@ pub struct TypoOutput {
 	pub typos: Vec<TypoDep>,
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct TypoDep {
 	pub dependency: Arc<String>,
 	pub typo: Typo,

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -8,17 +8,17 @@ mod types;
 
 pub use crate::plugin::manager::*;
 pub use crate::plugin::types::*;
+use crate::policy_exprs::Expr;
+use crate::Result;
 pub use download_manifest::{
 	ArchiveFormat, DownloadManifest, DownloadManifestEntry, HashAlgorithm, HashWithDigest,
 };
+use futures::future::join_all;
 pub use kdl_parsing::{extract_data, ParseKdlNode};
 pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
-pub use supported_arch::SupportedArch;
-
-use crate::Result;
-use futures::future::join_all;
 use serde_json::Value;
 use std::collections::HashMap;
+pub use supported_arch::SupportedArch;
 use tokio::sync::{mpsc, Mutex};
 
 pub fn dummy() {
@@ -64,6 +64,9 @@ impl ActivePlugin {
 			channel,
 		}
 	}
+	pub fn get_default_policy_expr(&self) -> Option<&Expr> {
+		self.channel.opt_default_policy_expr.as_ref()
+	}
 	async fn get_unique_id(&self) -> usize {
 		let mut id_lock = self.next_id.lock().await;
 		let res: usize = *id_lock;
@@ -74,6 +77,7 @@ impl ActivePlugin {
 	}
 	pub async fn query(&self, name: String, key: Value) -> Result<PluginResponse> {
 		let id = self.get_unique_id().await;
+		// @Todo - check name+key valid for schema
 		let query = Query {
 			id,
 			request: true,

--- a/hipcheck/src/policy_exprs/mod.rs
+++ b/hipcheck/src/policy_exprs/mod.rs
@@ -15,7 +15,7 @@ pub use crate::policy_exprs::expr::Ident;
 pub(crate) use crate::policy_exprs::expr::F64;
 pub use crate::policy_exprs::token::LexingError;
 use env::Binding;
-use expr::parse;
+pub use expr::parse;
 pub use expr::Primitive;
 use std::ops::Deref;
 

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -28,6 +28,7 @@ use crate::data::GitHubProviderStorage;
 use crate::data::ModuleProvider;
 use crate::data::ModuleProviderStorage;
 use crate::data::PullRequestReviewProviderStorage;
+use crate::engine::HcEngineStorage;
 use crate::error::Error;
 use crate::error::Result;
 use crate::hc_error;
@@ -72,6 +73,7 @@ use url::Url;
 	DependenciesProviderStorage,
 	GitProviderStorage,
 	GitHubProviderStorage,
+	HcEngineStorage,
 	LanguagesConfigQueryStorage,
 	LinguistStorage,
 	MetricProviderStorage,

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -1,11 +1,12 @@
 use crate::error::Error;
+use serde::Serialize;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::path::PathBuf;
 use url::Url;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Target {
 	/// The original specifier provided by the user.
 	pub specifier: String,
@@ -20,18 +21,18 @@ pub struct Target {
 	pub package: Option<Package>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RemoteGitRepo {
 	pub url: Url,
 	pub known_remote: Option<KnownRemote>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum KnownRemote {
 	GitHub { owner: String, repo: String },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct LocalGitRepo {
 	/// The path to the repo.
 	pub path: PathBuf,
@@ -39,7 +40,7 @@ pub struct LocalGitRepo {
 	/// The Git ref we're referring to.
 	pub git_ref: String,
 }
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Package {
 	/// A package url for the package.
 	pub purl: Url,
@@ -62,13 +63,13 @@ impl Package {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct MavenPackage {
 	/// The Maven url
 	pub url: Url,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 // Maven as a possible host is ommitted because a MavenPackage is currently its own struct without a host field
 pub enum PackageHost {
 	Npm,
@@ -84,7 +85,7 @@ impl Display for PackageHost {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Sbom {
 	/// The path to the SBOM file
 	pub path: PathBuf,
@@ -93,7 +94,7 @@ pub struct Sbom {
 	pub standard: SbomStandard,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum SbomStandard {
 	Spdx,
 	CycloneDX,


### PR DESCRIPTION
A roughly implemented PR that changes `score_results()` to use the plugin query infrastructure to drive analysis. Does not yet make use of `PolicyExpr` for scoring purposes. `AnalysisTree` ought to be the main object for driving execution/scoring going forward.