### PR TITLE
fix: Install the protobuf compiler in release CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,13 @@
 resolver = "2"
 
 # Members of the workspace.
-members = ["hipcheck", "hipcheck-macros", "xtask", "plugins/dummy_rand_data", "plugins/dummy_sha256"]
+members = [
+    "hipcheck",
+    "hipcheck-macros",
+    "xtask",
+    "plugins/dummy_rand_data",
+    "plugins/dummy_sha256",
+]
 
 # Make sure Hipcheck is run with `cargo run`.
 #
@@ -33,7 +39,7 @@ targets = [
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",
-    ]
+]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 # Whether to install an updater program
@@ -43,6 +49,17 @@ include = ["config/", "scripts/"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 
+# Ubuntu build dependencies for `cargo-dist`
+[workspace.metadata.dist.dependencies.apt]
+protobuf-compiler = "*"
+
+# macOS build dependencies for `cargo-dist`
+[workspace.metadata.dist.dependencies.homebrew]
+protobuf = "*"
+
+# Windows build dependencies for `cargo-dist`
+[workspace.metadata.dist.dependencies.chocolatey]
+protoc = "*"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
Turns out we'd forgotten to update the cargo-dist configuration to install the protobuf compiler for our release builds in CI. This commit _should_ fix it, though I'm not able to test it until it's deployed and I try to cut a new release.

The basic idea here is that cargo-dist provides configuration items to use platform-specific package managers to install needed packages. In our case, funnily enough, the protobuf compiler package has a different name on every platform.

For the moment I am not tying us to a specific version, just using the `*` to indicate we should always be using latest. If that becomes an issue in the future we can tighten it up.