### PR TITLE
fix: Copy plugins into containerfile build step

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ WORKDIR /build
 COPY .cargo/ .cargo/
 COPY hipcheck-macros/ hipcheck-macros/
 COPY hipcheck/ hipcheck/
+COPY plugins/ plugins/
 COPY xtask/ xtask/
 COPY Cargo.toml Cargo.lock ./
 


### PR DESCRIPTION
Builds for Docker images to publish to Docker Hub were failing because we weren't copying in all the crates found in the top-level workspace `Cargo.toml` file, causing Cargo to complain. This fixes that by copying them into the builder, though they don't get built.