### PR TITLE
chore: More CI jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,19 @@
+name: Docker
+
+# Run once a week on Monday at midnight.
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+
+# This only tries to build the Containerfile, and does not push
+# the resulting image to Docker Hub.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          file: Containerfile
+          push: false

--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "config/**"
       - "hipcheck/**"
+      - "plugins/**"
       - "scripts/**"
       - "xtask/**"
   pull_request:
@@ -23,6 +24,7 @@ on:
     paths:
       - "config/**"
       - "hipcheck/**"
+      - "plugins/**"
       - "scripts/**"
       - "xtask/**"
 
@@ -42,27 +44,40 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
+      # Get the repo, get Rust, get `cargo-nextest`, setup caching.
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
-        # Install protoc dependency - Linux
+
+      # Install the protobuf compiler
       - if: runner.os == 'Linux'
         run: sudo apt-get install -y protobuf-compiler
-        # Install protoc dependency - MacOS
       - if: runner.os == 'macOS'
         run: brew install protobuf
-        # Install protoc dependency - Windows
       - if: runner.os == 'Windows'
-        run: |
-          curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-win64.zip
-          unzip -j protoc-27.3-win64.zip bin/protoc.exe -d C:\Windows\System32\
+        run: choco install protoc
+
+      # Print dependency info (useful for debugging)
       - name: Dependency Tree
         run: cargo tree
+
+      # Try building every crate in the workspace.
+      # Note that this actually runs "cargo check" and doesn't attempt
+      # to link the resulting artifacts together.
       - name: Build
-        run: cargo build --verbose --workspace
+        run: cargo check --verbose --workspace
+
+      # Test the code.
       - name: Test
-        run: cargo test --verbose --workspace
+        run: cargo nextest r --verbose --workspace
+
+      # Run the linter.
       - name: Lint
         run: cargo clippy --verbose --workspace
+
+      # Run our own checks for licensing and other info.
+      - name: Check
+        run: cargo xtask check

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,46 @@
+name: Release Dry Run
+
+# Run once a week on Monday at midnight.
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    name: "Test (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      # Get the repo, get Rust, get `cargo-nextest`, setup caching.
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+
+      # Install the protobuf compiler
+      - if: runner.os == 'Linux'
+        run: sudo apt-get install -y protobuf-compiler
+      - if: runner.os == 'macOS'
+        run: brew install protobuf
+      - if: runner.os == 'Windows'
+        run: choco install protoc
+
+      # Print dependency info (useful for debugging)
+      - name: Dependency Tree
+        run: cargo tree
+
+      # Try building as-if for publishing a new version.
+      - name: Publish
+        run: cargo publish --dry-run --allow-dirty --verbose -p hipcheck


### PR DESCRIPTION
This commit adds three new categories of CI jobs:

- Weekly Docker image build testing
- Weekly release dry run testing (not currently including `cargo-dist`)
- Simplifications to regular testing, including installing `protoc` with Chocolatey on Windows, and using `cargo-nextest` for testing, along with validating `cargo xtask check` in CI now.