### PR TITLE
fix: Adds weight field to policy file categories

### DIFF
--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -241,22 +241,25 @@ impl ParseKdlNode for PolicyAnalysis {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyCategory {
 	name: String,
+	weight: Option<u16>,
 	children: Vec<PolicyCategoryChild>,
 }
 
 impl PolicyCategory {
 	#[allow(dead_code)]
-	pub fn new(name: String) -> Self {
+	pub fn new(name: String, weight: Option<u16>) -> Self {
 		Self {
 			name,
+			weight,
 			children: Vec::new(),
 		}
 	}
 
 	#[allow(dead_code)]
-	pub fn with_capacity(name: String, capacity: usize) -> Self {
+	pub fn with_capacity(name: String, weight: Option<u16>, capacity: usize) -> Self {
 		Self {
 			name,
+			weight,
 			children: Vec::with_capacity(capacity),
 		}
 	}
@@ -283,6 +286,10 @@ impl ParseKdlNode for PolicyCategory {
 		}
 
 		let name = node.entries().first()?.value().as_string()?.to_string();
+		let weight = match node.get("weight") {
+			Some(entry) => Some(entry.value().as_i64()? as u16),
+			None => None,
+		};
 
 		let mut children = Vec::new();
 
@@ -299,7 +306,7 @@ impl ParseKdlNode for PolicyCategory {
 			}
 		}
 
-		Some(Self { name, children })
+		Some(Self { name, weight, children })
 	}
 }
 

--- a/hipcheck/src/policy/tests.rs
+++ b/hipcheck/src/policy/tests.rs
@@ -159,7 +159,7 @@ mod test {
             investigate policy="(gt 0.5 $)"
             investigate-if-fail "mitre/typo" "mitre/binary"
 
-            category "practices" {
+            category "practices" weight=2 {
                 analysis "mitre/activity" policy="(lte 52 $.weeks)" weight=3
                 analysis "mitre/binary" policy="(eq 0 (count $))"
             }
@@ -187,7 +187,7 @@ mod test {
 		if_fail.push("mitre/typo");
 		if_fail.push("mitre/binary");
 
-		let mut practices = PolicyCategory::new("practices".to_string());
+		let mut practices = PolicyCategory::new("practices".to_string(), Some(2));
 		practices.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
 			Some("(lte 52 $.weeks)".to_string()),
@@ -211,7 +211,7 @@ mod test {
 			.insert("typo-file".to_string(), "./config/typo.kdl".to_string())
 			.unwrap();
 
-		let mut commit = PolicyCategory::new("commit".to_string());
+		let mut commit = PolicyCategory::new("commit".to_string(), None);
 		commit.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/affiliation").unwrap(),
 			Some("(eq 0 (count $))".to_string()),
@@ -231,7 +231,7 @@ mod test {
 			None,
 		)));
 
-		let mut attacks = PolicyCategory::new("attacks".to_string());
+		let mut attacks = PolicyCategory::new("attacks".to_string(), None);
 		attacks.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/typo").unwrap(),
 			Some("(eq 0 (count $))".to_string()),
@@ -291,7 +291,7 @@ mod test {
 		let mut if_fail = InvestigateIfFail::new();
 		if_fail.push("mitre/binary");
 
-		let mut practices = PolicyCategory::new("practices".to_string());
+		let mut practices = PolicyCategory::new("practices".to_string(), None);
 		practices.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
 			Some("(lte 52 $.weeks)".to_string()),


### PR DESCRIPTION
Adds the missing `weight` field to the `PolicyCategory` struct. This field represents optional weights that can be given to categories of analyses in the policy file and was accidentally omitted in the PR that added that struct.