### PR TITLE
feat: implement PolicyFile --> AnalysisTree conversion, remove use of WeightTree in scoring

### DIFF
--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -7,7 +7,6 @@ use crate::analysis::{
 	},
 	AnalysisProvider,
 };
-use crate::config::{visit_leaves, WeightTree, WeightTreeProvider};
 use crate::metric::{review::PullReview, MetricProvider};
 use crate::plugin::{ActivePlugin, PluginResponse};
 pub use crate::plugin::{HcPluginCore, PluginExecutor, PluginWithConfig};
@@ -29,7 +28,7 @@ pub trait HcEngine: salsa::Database {
 	#[salsa::input]
 	fn core(&self) -> Arc<HcPluginCore>;
 
-	fn default_policy_expr(&self, publisher: String, plugin: String) -> Result<Option<Expr>>;
+	fn default_policy_expr(&self, publisher: String, plugin: String) -> Result<Option<String>>;
 
 	fn query(&self, publisher: String, plugin: String, query: String, key: Value) -> Result<Value>;
 }
@@ -38,7 +37,7 @@ fn default_policy_expr(
 	db: &dyn HcEngine,
 	publisher: String,
 	plugin: String,
-) -> Result<Option<Expr>> {
+) -> Result<Option<String>> {
 	let core = db.core();
 	// @Todo - plugins map should be keyed on publisher too
 	let Some(p_handle) = core.plugins.get(&plugin) else {

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -9,7 +9,6 @@ use crate::context::Context;
 use crate::kdl_helper::{extract_data, ParseKdlNode};
 pub use crate::plugin::manager::*;
 pub use crate::plugin::types::*;
-use crate::policy_exprs::Expr;
 use crate::Result;
 pub use download_manifest::{
 	ArchiveFormat, DownloadManifest, DownloadManifestEntry, HashAlgorithm, HashWithDigest,
@@ -64,7 +63,7 @@ impl ActivePlugin {
 			channel,
 		}
 	}
-	pub fn get_default_policy_expr(&self) -> Option<&Expr> {
+	pub fn get_default_policy_expr(&self) -> Option<&String> {
 		self.channel.opt_default_policy_expr.as_ref()
 	}
 	async fn get_unique_id(&self) -> usize {

--- a/hipcheck/src/policy/mod.rs
+++ b/hipcheck/src/policy/mod.rs
@@ -2,7 +2,7 @@
 
 //! Data types and functions for parsing policy KDL files
 
-mod policy_file;
+pub mod policy_file;
 mod tests;
 
 use crate::kdl_helper::extract_data;

--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -174,10 +174,10 @@ impl ParseKdlNode for PolicyConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyAnalysis {
-	name: PolicyPluginName,
-	policy_expression: Option<String>,
-	weight: Option<u16>,
-	config: Option<PolicyConfig>,
+	pub name: PolicyPluginName,
+	pub policy_expression: Option<String>,
+	pub weight: Option<u16>,
+	pub config: Option<PolicyConfig>,
 }
 
 impl PolicyAnalysis {
@@ -240,9 +240,9 @@ impl ParseKdlNode for PolicyAnalysis {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyCategory {
-	name: String,
-	weight: Option<u16>,
-	children: Vec<PolicyCategoryChild>,
+	pub name: String,
+	pub weight: Option<u16>,
+	pub children: Vec<PolicyCategoryChild>,
 }
 
 impl PolicyCategory {
@@ -306,7 +306,11 @@ impl ParseKdlNode for PolicyCategory {
 			}
 		}
 
-		Some(Self { name, weight, children })
+		Some(Self {
+			name,
+			weight,
+			children,
+		})
 	}
 }
 
@@ -379,7 +383,7 @@ impl ParseKdlNode for InvestigateIfFail {
 pub struct PolicyAnalyze {
 	investigate_policy: InvestigatePolicy,
 	if_fail: Option<InvestigateIfFail>,
-	categories: Vec<PolicyCategory>,
+	pub categories: Vec<PolicyCategory>,
 }
 
 impl PolicyAnalyze {
@@ -451,8 +455,8 @@ impl ParseKdlNode for PolicyAnalyze {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyPluginName {
-	publisher: String,
-	name: String,
+	pub publisher: String,
+	pub name: String,
 }
 
 impl PolicyPluginName {

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -163,24 +163,26 @@ impl Session {
 		// Check if a policy file was provided, otherwise use a config folder the old way
 		// Currently this does nothing, as the PolicyFile is not actively parsed
 		if policy_path.is_some() {
-			let (_policy, _policy_dir, _data_dir, _hc_github_token) =
+			let (policy, _policy_dir, _data_dir, _hc_github_token) =
 				match load_policy_and_data(policy_path.as_deref(), data_path.as_deref()) {
 					Ok(results) => results,
 					Err(err) => return Err(err),
 				};
 
 			// Needed if we use Salsa for this
-			// session.set_policy(Rc::new(policy));
-			// session.set_policy_dir(Rc::new(policy_dir));
+			session.set_policy(Some(Rc::new(policy)));
+		// session.set_policy_dir(Rc::new(policy_dir));
 
-			// Set data folder location for module analysis
-			// session.set_data_dir(Arc::new(data_dir));
+		// Set data folder location for module analysis
+		// session.set_data_dir(Arc::new(data_dir));
 
-			// Set github token in salsa
-			// session.set_github_api_token(Some(Rc::new(hc_github_token)));
+		// Set github token in salsa
+		// session.set_github_api_token(Some(Rc::new(hc_github_token)));
+		} else {
+			session.set_policy(None);
 		}
-		// Once we no longer need config information, put this in an else block until config has been deprecated
-		// Until then we need this for Hipcheck to still run
+		// Once we no longer need config information, put this in the above else block until config has
+		// been deprecated. Until then we need this for Hipcheck to still run
 		let (config, config_dir, data_dir, hc_github_token) =
 			match load_config_and_data(config_path.as_deref(), data_path.as_deref()) {
 				Ok(results) => results,


### PR DESCRIPTION
Replaced use of WeightTree in scoring with AnalysisTree to help phase out that part of the infrastructure. Added `policy()` salsa function, currently returns an `Option` until we introduce the `ConfigFile-->PolicyFile` conversion so we always have a working policy file. 