### PR TITLE
fix: Update hardcoded policy expressions with new JSON pointer syntax

### DIFF
--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -840,7 +840,7 @@ impl WeightTreeNode {
 	// the policy for our analyses
 	#[allow(dead_code)]
 	pub fn with_hardcoded_expr(&self) -> AnalysisTreeNode {
-		let expr = "true".to_owned();
+		let expr = "#t".to_owned();
 		let analysis = Analysis {
 			publisher: MITRE_PUBLISHER.to_owned(),
 			plugin: LEGACY_PLUGIN.to_owned(),

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -120,7 +120,7 @@ fn parse_activity(
 		// Cap the weight at 65,533
 		let weight = activity.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = activity.week_count_threshold;
-		let expression = format!("(lte {} $.weeks)", threshold);
+		let expression = format!("(lte {} $/weeks)", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
@@ -226,7 +226,7 @@ fn parse_identity(
 		// Cap the weight at 65,533
 		let weight = identity.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = identity.percent_threshold;
-		let expression = format!("(lte {} $.pct_match)", threshold);
+		let expression = format!("(lte {} $/pct_match)", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
@@ -263,7 +263,7 @@ fn parse_review(
 		// Cap the weight at 65,533
 		let weight = review.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = review.percent_threshold;
-		let expression = format!("(lte {} $.pct_reviewed)", threshold);
+		let expression = format!("(lte {} $/pct_reviewed)", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -14,11 +14,11 @@ analyze {
     investigate policy="(gt 0.5 $)"
 
     category "practices" weight=1 {
-        analysis "mitre/activity" policy="(lte 71 $.weeks)" weight=1
+        analysis "mitre/activity" policy="(lte 71 $/weeks)" weight=1
         analysis "mitre/binary" policy="(eq 0 (count $))" weight=1
         analysis "mitre/fuzz" policy="(eq #t $)" weight=1
-        analysis "mitre/identity" policy="(lte 0.2 $.pct_match)" weight=1
-        analysis "mitre/review" policy="(lte 0.05 $.pct_reviewed)" weight=1
+        analysis "mitre/identity" policy="(lte 0.2 $/pct_match)" weight=1
+        analysis "mitre/review" policy="(lte 0.05 $/pct_reviewed)" weight=1
     }
 
     category "attacks" weight=1 {

--- a/hipcheck/src/policy/tests.rs
+++ b/hipcheck/src/policy/tests.rs
@@ -164,7 +164,7 @@ mod test {
             investigate-if-fail "mitre/typo" "mitre/binary"
 
             category "practices" weight=2 {
-                analysis "mitre/activity" policy="(lte 52 $.weeks)" weight=3
+                analysis "mitre/activity" policy="(lte 52 $/weeks)" weight=3
                 analysis "mitre/binary" policy="(eq 0 (count $))"
             }
 
@@ -194,7 +194,7 @@ mod test {
 		let mut practices = PolicyCategory::new("practices".to_string(), Some(2));
 		practices.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			Some("(lte 52 $.weeks)".to_string()),
+			Some("(lte 52 $/weeks)".to_string()),
 			Some(3),
 			None,
 		)));
@@ -263,7 +263,7 @@ mod test {
             investigate-if-fail "mitre/binary"
 
             category "practices" {
-                analysis "mitre/activity" policy="(lte 52 $.weeks)" weight=3
+                analysis "mitre/activity" policy="(lte 52 $/weeks)" weight=3
                 analysis "mitre/binary" policy="(eq 0 (count $))"
             }
         }"#;
@@ -298,7 +298,7 @@ mod test {
 		let mut practices = PolicyCategory::new("practices".to_string(), None);
 		practices.push(PolicyCategoryChild::Analysis(PolicyAnalysis::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			Some("(lte 52 $.weeks)".to_string()),
+			Some("(lte 52 $/weeks)".to_string()),
 			Some(3),
 			None,
 		)));


### PR DESCRIPTION
PR #315 implemented JSON Pointer syntax, and it uses slashes instead of the dotted syntax originally used in the RFD.
This PR updates the hardcoded policy expressions to use the new syntax.

Also fix syntax for literal `true` value (`#t`).