### PR TITLE
chore (CLI): Deprecates the config arg

### DIFF
--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -413,7 +413,6 @@ struct ReadyChecks {
 	hipcheck_version_check: StdResult<String, VersionCheckError>,
 	git_version_check: StdResult<String, VersionCheckError>,
 	npm_version_check: StdResult<String, VersionCheckError>,
-	config_path_check: StdResult<PathBuf, PathCheckError>,
 	data_path_check: StdResult<PathBuf, PathCheckError>,
 	cache_path_check: StdResult<PathBuf, PathCheckError>,
 	policy_path_check: StdResult<PathBuf, PathCheckError>,
@@ -428,7 +427,6 @@ impl ReadyChecks {
 		self.hipcheck_version_check.is_ok()
 			&& self.git_version_check.is_ok()
 			&& self.npm_version_check.is_ok()
-			&& self.config_path_check.is_ok()
 			&& self.data_path_check.is_ok()
 			&& self.cache_path_check.is_ok()
 			&& self.policy_path_check.is_ok()
@@ -548,18 +546,6 @@ fn check_npm_version() -> StdResult<String, VersionCheckError> {
 		})
 }
 
-fn check_config_path(config: &CliConfig) -> StdResult<PathBuf, PathCheckError> {
-	let path = config.config().ok_or(PathCheckError::PathNotFound)?;
-
-	let path = pathbuf![path, HIPCHECK_TOML_FILE];
-
-	if path.exists().not() {
-		return Err(PathCheckError::PathNotFound);
-	}
-
-	Ok(path)
-}
-
 fn check_cache_path(config: &CliConfig) -> StdResult<PathBuf, PathCheckError> {
 	let path = config.cache().ok_or(PathCheckError::PathNotFound)?;
 
@@ -582,7 +568,7 @@ fn check_data_path(config: &CliConfig) -> StdResult<PathBuf, PathCheckError> {
 }
 
 fn check_policy_path(config: &CliConfig) -> StdResult<PathBuf, PathCheckError> {
-	let path = config.policy().ok_or(PathCheckError::PathNotFound)?;
+	let path = config.policy().ok_or(PathCheckError::PolicyNotFound)?;
 
 	if path.exists().not() {
 		return Err(PathCheckError::PolicyNotFound);
@@ -706,7 +692,6 @@ fn cmd_ready(config: &CliConfig) {
 		hipcheck_version_check: check_hipcheck_version(),
 		git_version_check: check_git_version(),
 		npm_version_check: check_npm_version(),
-		config_path_check: check_config_path(config),
 		data_path_check: check_data_path(config),
 		cache_path_check: check_cache_path(config),
 		policy_path_check: check_policy_path(config),
@@ -731,11 +716,6 @@ fn cmd_ready(config: &CliConfig) {
 	match &ready.cache_path_check {
 		Ok(path) => println!("{:<17} {}", "Cache Path:", path.display()),
 		Err(e) => println!("{:<17} {}", "Cache Path:", e),
-	}
-
-	match &ready.config_path_check {
-		Ok(path) => println!("{:<17} {}", "Config Path:", path.display()),
-		Err(e) => println!("{:<17} {}", "Config Path:", e),
 	}
 
 	match &ready.data_path_check {
@@ -911,7 +891,6 @@ const LANGS_FILE: &str = "Langs.toml";
 const BINARY_CONFIG_FILE: &str = "Binary.toml";
 const TYPO_FILE: &str = "Typos.toml";
 const ORGS_FILE: &str = "Orgs.toml";
-const HIPCHECK_TOML_FILE: &str = "Hipcheck.toml";
 
 // Constants for exiting with error codes.
 /// Indicates the program failed.

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -160,7 +160,7 @@ impl Session {
 		 *  Loading configuration.
 		 *-----------------------------------------------------------------*/
 
-		// Check if a policy file was provided, otherwise convert a deprecated config file to a policy file
+		// Check if a policy file was provided, otherwise convert a deprecated config file to a policy file. If neither was provided, error out.
 		if policy_path.is_some() {
 			let (policy, policy_path, data_dir, hc_github_token) =
 				match load_policy_and_data(policy_path.as_deref(), data_path.as_deref()) {
@@ -177,7 +177,7 @@ impl Session {
 
 			// Set github token in salsa
 			session.set_github_api_token(Some(Rc::new(hc_github_token)));
-		} else {
+		} else if config_path.is_some() {
 			let (policy, config_dir, data_dir, hc_github_token) =
 				match load_config_and_data(config_path.as_deref(), data_path.as_deref()) {
 					Ok(results) => results,
@@ -196,6 +196,8 @@ impl Session {
 
 			// Set github token in salsa
 			session.set_github_api_token(Some(Rc::new(hc_github_token)));
+		} else {
+			return Err(hc_error!("No policy file or (deprecated) config file found. Please provide a policy file before running Hipcheck."));
 		}
 
 		/*===================================================================
@@ -256,7 +258,7 @@ fn load_config_and_data(
 	data_path: Option<&Path>,
 ) -> Result<(PolicyFile, PathBuf, PathBuf, String)> {
 	// Start the phase.
-	let phase = SpinnerPhase::start("loading configuration and data files");
+	let phase = SpinnerPhase::start("Loading configuration and data files from config file. Note: The use of a config TOML file is deprecated. Please consider using a policy KDL file in the future.");
 	// Increment the phase into the "running" stage.
 	phase.inc();
 	// Set the spinner phase to tick constantly, 10 times a second.
@@ -311,7 +313,7 @@ fn load_policy_and_data(
 
 	// Load the policy file.
 	let policy = PolicyFile::load_from(valid_policy_path)
-		.context("Failed to load policy. Plase make sure the policy file is in the proived location and is formatted correctly.")?;
+		.context("Failed to load policy. Plase make sure the policy file is in the proidved location and is formatted correctly.")?;
 
 	// Get the directory the data file is in.
 	let data_dir = data_path


### PR DESCRIPTION
Resolves #335  Makes the `--config` flag a deprecated flag, so that it will not appear under in the `hc` executable's help text. Adds various warning and error messages to the user explaining that a policy file is preferred over a config file.

Swaps the `-c`  and `-C' short flags between the now deprecated `--config` and the still support `--cache` flags.