### PR TITLE
chore: change legacy analyses to return QueryResult

### DIFF
--- a/hipcheck/src/analysis/mod.rs
+++ b/hipcheck/src/analysis/mod.rs
@@ -13,6 +13,7 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::metric::affiliation::AffiliatedType;
 use crate::metric::MetricProvider;
+use crate::plugin::QueryResult;
 use crate::report::Concern;
 use crate::F64;
 use std::collections::HashMap;
@@ -29,31 +30,33 @@ use std::sync::Arc;
 pub trait AnalysisProvider:
 	AttacksConfigQuery + CommitConfigQuery + GitProvider + MetricProvider + PracticesConfigQuery
 {
-	/*
 	/// Returns result of activity analysis
-	fn activity_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn activity_analysis(&self) -> Result<QueryResult>;
 
-	/// Returns result of affiliation analysis
-	fn affiliation_analysis(&self) -> Arc<HCAnalysisReport>;
+	/*
+		/// Returns result of affiliation analysis
+		fn affiliation_analysis(&self) -> Arc<HCAnalysisReport>;
+	*/
 
 	/// Returns result of binary analysis
-	fn binary_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn binary_analysis(&self) -> Result<QueryResult>;
 
 	/// Returns result of churn analysis
-	fn churn_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn churn_analysis(&self) -> Result<QueryResult>;
 
 	/// Returns result of entropy analysis
-	fn entropy_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn entropy_analysis(&self) -> Result<QueryResult>;
 
 	/// Returns result of identity analysis
-	fn identity_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn identity_analysis(&self) -> Result<QueryResult>;
 
 	/// Returns result of fuzz analysis
-	fn fuzz_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn fuzz_analysis(&self) -> Result<QueryResult>;
 
 	/// Returns result of review analysis
-	fn review_analysis(&self) -> Arc<HCAnalysisReport>;
+	fn review_analysis(&self) -> Result<QueryResult>;
 
+	/*
 	/// Returns result of typo analysis
 	fn typo_analysis(&self) -> Arc<HCAnalysisReport>;
 	*/
@@ -148,19 +151,16 @@ impl Display for AnalysisOutcome {
 	}
 }
 
-/*
-pub fn activity_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.activity_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
+pub fn activity_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.activity_metric()?;
 	let value = results.time_since_last_commit.num_weeks() as u64;
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
 		concerns: vec![],
 	})
 }
 
+/*
 pub fn affiliation_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
 	let results = match db.affiliation_metric() {
 		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
@@ -219,99 +219,47 @@ pub fn affiliation_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> 
 		concerns,
 	})
 }
+*/
 
-pub fn binary_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.binary_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
+pub fn binary_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.binary_metric()?;
 	let value = results.binary_files.len() as u64;
-	let concerns = results
+	let concerns: Vec<String> = results
 		.binary_files
 		.clone()
 		.into_iter()
-		.map(|binary_file| Concern::Binary {
-			file_path: binary_file.as_ref().to_string(),
-		})
+		.map(|binary_file| format!("Binary file at '{}'", binary_file.as_ref().to_string()))
 		.collect();
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
 		concerns,
 	})
 }
 
-pub fn churn_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.churn_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
-	let value_threshold = *db.churn_value_threshold();
-	let num_flagged = results
-		.commit_churn_freqs
-		.iter()
-		.filter(|c| c.churn.into_inner() > value_threshold)
-		.count() as u64;
-	let percent_flagged = num_flagged as f64 / results.commit_churn_freqs.len() as f64;
-	let value = F64::new(percent_flagged).expect("Percent threshold should never be NaN");
-	let concerns = results
-		.commit_churn_freqs
-		.iter()
-		.filter(|c| c.churn.into_inner() > value_threshold)
-		.map(|cf| Concern::Churn {
-			commit_hash: cf.commit.hash.clone(),
-			score: cf.churn.into_inner(),
-			threshold: value_threshold,
-		})
-		.collect::<Vec<_>>();
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
-		concerns,
+pub fn churn_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.churn_metric()?;
+	let value: Vec<F64> = results.commit_churn_freqs.iter().map(|o| o.churn).collect();
+	// @Todo - in RFD4 transition we lost the ability to flag commits, because
+	// the need to flag them as concerns is dependent on policy expr
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
+		concerns: vec![],
 	})
 }
 
-pub fn entropy_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.entropy_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
-	let value_threshold = *db.entropy_value_threshold();
-	let num_flagged = results
-		.commit_entropies
-		.iter()
-		.filter(|c| c.entropy.into_inner() > value_threshold)
-		.count() as u64;
-	let percent_flagged = num_flagged as f64 / results.commit_entropies.len() as f64;
-
-	let value = F64::new(percent_flagged).expect("Percent threshold should never be NaN");
-	let res_concerns = results
-		.commit_entropies
-		.iter()
-		.filter(|c| c.entropy.into_inner() > value_threshold)
-		.map(|cf| {
-			db.get_short_hash(Arc::new(cf.commit.hash.clone()))
-				.map(|commit_hash| Concern::Entropy {
-					commit_hash: commit_hash.trim().to_owned(),
-					score: cf.entropy.into_inner(),
-					threshold: value_threshold,
-				})
-		})
-		.collect::<Result<Vec<_>>>();
-	let concerns = match res_concerns {
-		Ok(c) => c,
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-	};
-
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
-		concerns,
+pub fn entropy_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.entropy_metric()?;
+	let value: Vec<F64> = results.commit_entropies.iter().map(|o| o.entropy).collect();
+	// @Todo - in RFD4 transition we lost the ability to flag commits, because
+	// the need to flag them as concerns is dependent on policy expr
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
+		concerns: vec![],
 	})
 }
 
-pub fn identity_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.identity_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
+pub fn identity_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.identity_metric()?;
 	let num_flagged = results
 		.matches
 		.iter()
@@ -319,37 +267,28 @@ pub fn identity_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
 		.count() as u64;
 	let percent_flagged = num_flagged as f64 / results.matches.len() as f64;
 	let value = F64::new(percent_flagged).expect("Percent threshold should never be NaN");
-
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
 		concerns: vec![],
 	})
 }
 
-pub fn fuzz_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.fuzz_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
-	let exists = results.fuzz_result.exists;
-
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(exists.into())),
+pub fn fuzz_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.fuzz_metric()?;
+	let value = results.fuzz_result.exists;
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
 		concerns: vec![],
 	})
 }
 
-pub fn review_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
-	let results = match db.review_metric() {
-		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),
-		Ok(results) => results,
-	};
+pub fn review_analysis(db: &dyn AnalysisProvider) -> Result<QueryResult> {
+	let results = db.review_metric()?;
 	let num_flagged = results
 		.pull_reviews
 		.iter()
 		.filter(|p| p.has_review.not())
 		.count() as u64;
-
 	let percent_flagged = match (num_flagged, results.pull_reviews.len()) {
 		(flagged, total) if flagged != 0 && total != 0 => {
 			num_flagged as f64 / results.pull_reviews.len() as f64
@@ -357,13 +296,13 @@ pub fn review_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
 		_ => 0.0,
 	};
 	let value = F64::new(percent_flagged).expect("Percent threshold should never be NaN");
-
-	Arc::new(HCAnalysisReport {
-		outcome: HCAnalysisOutcome::Completed(HCAnalysisValue::Basic(value.into())),
+	Ok(QueryResult {
+		value: serde_json::to_value(value)?,
 		concerns: vec![],
 	})
 }
 
+/*
 pub fn typo_analysis(db: &dyn AnalysisProvider) -> Arc<HCAnalysisReport> {
 	let results = match db.typo_metric() {
 		Err(err) => return Arc::new(HCAnalysisReport::generic_error(err, vec![])),

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -376,33 +376,29 @@ fn wrapped_query(
 		// @Todo - revise metric functions to return QueryResult
 		let value = match plugin.as_str() {
 			ACTIVITY_PHASE => {
-				let raw = db.activity_metric()?;
-				serde_json::to_value(raw)?
+				return db.activity_analysis();
 			}
 			AFFILIATION_PHASE => {
 				let raw = db.affiliation_metric()?;
 				serde_json::to_value(&raw.affiliations)?
 			}
-			BINARY_PHASE => serde_json::to_value(db.binary_metric()?)?,
+			BINARY_PHASE => {
+				return db.binary_analysis();
+			}
 			CHURN_PHASE => {
-				let raw = db.churn_metric()?;
-				serde_json::to_value(&raw.commit_churn_freqs)?
+				return db.churn_analysis();
 			}
 			ENTROPY_PHASE => {
-				let raw = db.entropy_metric()?;
-				serde_json::to_value(&raw.commit_entropies)?
+				return db.entropy_analysis();
 			}
 			IDENTITY_PHASE => {
-				let raw = db.identity_metric()?;
-				serde_json::to_value(&raw.matches)?
+				return db.identity_analysis();
 			}
 			FUZZ_PHASE => {
-				let raw = db.fuzz_metric()?.fuzz_result.exists;
-				serde_json::to_value(raw)?
+				return db.fuzz_analysis();
 			}
 			REVIEW_PHASE => {
-				let raw = db.review_metric()?;
-				serde_json::to_value(&raw.pull_reviews)?
+				return db.review_analysis();
 			}
 			TYPO_PHASE => {
 				let raw = db.typo_metric()?;


### PR DESCRIPTION
Changed all legacy analyses save for those that rely on special configs to return `Result<QueryResult>`.

Notable side effects:
- Can't return Error that also has concerns
- Lose the ability to flag concerning commits since the way we decide whether they are concerning is in the policy expression