### PR TITLE
chore: update legacy config salsa funcs to use policy file get_config()

### DIFF
--- a/hipcheck/src/metric/commit_trust.rs
+++ b/hipcheck/src/metric/commit_trust.rs
@@ -26,7 +26,7 @@ pub fn commit_trust_metric(db: &dyn MetricProvider) -> Result<Arc<CommitTrustOut
 
 	let mut trust_map: HashMap<String, bool> = HashMap::new();
 
-	let value_threshold = db.contributor_trust_value_threshold() as u32;
+	let value_threshold = db.contributor_trust_value_threshold()? as u32;
 
 	for commit in commits.iter() {
 		// Check if a commit matches contributor trust map

--- a/hipcheck/src/metric/contributor_trust.rs
+++ b/hipcheck/src/metric/contributor_trust.rs
@@ -24,9 +24,9 @@ pub struct ContributorTrustResult {
 pub fn contributor_trust_metric(db: &dyn MetricProvider) -> Result<Arc<ContributorTrustOutput>> {
 	log::debug!("running {} metric", TRUST_PHASE);
 
-	let month_range = db.contributor_trust_month_count_threshold().to_string();
+	let month_range = db.contributor_trust_month_count_threshold()?.to_string();
 
-	let value_threshold = db.contributor_trust_value_threshold() as u32;
+	let value_threshold = db.contributor_trust_value_threshold()? as u32;
 
 	let commit_from_date = Arc::new(month_range);
 

--- a/hipcheck/src/policy/mod.rs
+++ b/hipcheck/src/policy/mod.rs
@@ -65,11 +65,6 @@ impl PolicyFile {
 	pub fn get_config(&self, analysis_name: &str) -> Option<HashMap<String, String>> {
 		self.analyze
 			.find_analysis_by_name(analysis_name)
-			.map(|analysis| {
-				analysis
-					.config
-					.map(|config| config.0)
-					.unwrap_or_else(HashMap::new)
-			})
+			.map(|analysis| analysis.config.map(|config| config.0).unwrap_or_default())
 	}
 }

--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -140,6 +140,7 @@ impl PolicyConfig {
 		}
 	}
 
+	#[allow(dead_code)]
 	pub fn get(self, description: &str) -> Option<String> {
 		self.0.get(description).map(|info| info.to_string())
 	}


### PR DESCRIPTION
Change the legacy salsa functions that provide analysis-specific configuration to extract from policy file. 