### PR TITLE
feat: plugin downloading and extraction added to `hc check`

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,0 +1,43 @@
+plugins {
+    plugin "mitre/activity" version="0.1.0"
+    plugin "mitre/binary" version="0.1.0"
+    plugin "mitre/fuzz" version="0.1.0"
+    plugin "mitre/review" version="0.1.0"
+    plugin "mitre/typo" version="0.1.0"
+    plugin "mitre/affiliation" version="0.1.0"
+    plugin "mitre/entropy" version="0.1.0"
+    plugin "mitre/churn" version="0.1.0"
+}
+
+analyze {
+    investigate policy="(gt 0.5 $)"
+    investigate-if-fail "mitre/typo" "mitre/binary"
+
+    category "practices" {
+        analysis "mitre/activity" policy="(lte 52 $)" weight=3
+        analysis "mitre/binary" policy="(eq 0 (count $))" {
+			binary-file "./config/Binary.toml"
+		}
+        analysis "mitre/fuzz" policy="(eq #t $)"
+        analysis "mitre/review" policy="(lte 0.05 $)"
+    }
+
+    category "attacks" {
+        analysis "mitre/typo" policy="(eq 0 (count $))" {
+            typo-file "./config/Typos.toml"
+        }
+
+        category "commit" {
+            analysis "mitre/affiliation" policy="(eq 0 (count $))" {
+                orgs-file "./config/Orgs.toml"
+            }
+
+            analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
+				langs-file "./config/Langs.toml"
+			}
+            analysis "mitre/churn" policy="(eq 0 (count (filter (gt 8.0) $)))" {
+				langs-file "./config/Langs.toml"
+			}
+        }
+    }
+}

--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -368,7 +368,6 @@ fn wrapped_query(
 	query: String,
 	key: Value,
 ) -> Result<QueryResult> {
-	println!("publisher: {publisher}, plugin: {plugin}, query: {query}");
 	if publisher == *MITRE_PUBLISHER {
 		if query != *DEFAULT_QUERY {
 			return Err(hc_error!("legacy analyses only have a default query"));
@@ -379,8 +378,7 @@ fn wrapped_query(
 				return db.activity_analysis();
 			}
 			AFFILIATION_PHASE => {
-				let raw = db.affiliation_metric()?;
-				serde_json::to_value(&raw.affiliations)?
+				return db.affiliation_analysis();
 			}
 			BINARY_PHASE => {
 				return db.binary_analysis();
@@ -442,7 +440,6 @@ pub fn score_results(phase: &SpinnerPhase, db: &dyn ScoringProvider) -> Result<S
 	// RFD4 analysis style - get all "leaf" analyses and call through plugin architecture
 	let analyses = analysis_tree.get_analyses();
 	for a in analyses {
-		println!("Analysis: {a:?}");
 		let result = db.wrapped_query(
 			a.publisher.clone(),
 			a.plugin.clone(),

--- a/hipcheck/src/cache/plugin_cache.rs
+++ b/hipcheck/src/cache/plugin_cache.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 
 use pathbuf::pathbuf;
 
-use crate::plugin::{PluginName, PluginPublisher, PluginVersion, SupportedArch};
+use crate::plugin::{PluginName, PluginPublisher, PluginVersion};
 
-/// Plugins are stored with the following format `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>/<arch>`
+/// Plugins are stored with the following format `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>`
 pub struct HcPluginCache {
 	path: PathBuf,
 }
@@ -17,18 +17,13 @@ impl HcPluginCache {
 		Self { path: plugins_path }
 	}
 
-	/// `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>/<arch>`
+	/// `<path_to_plugin_cache>/<publisher>/<plugin_name>/<version>`
 	pub fn plugin_download_dir(
 		&self,
 		publisher: &PluginPublisher,
 		name: &PluginName,
 		version: &PluginVersion,
-		arch: SupportedArch,
 	) -> PathBuf {
-		self.path
-			.join(&publisher.0)
-			.join(&name.0)
-			.join(&version.0)
-			.join(arch.to_string())
+		self.path.join(&publisher.0).join(&name.0).join(&version.0)
 	}
 }

--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -1,21 +1,32 @@
 #![allow(unused)]
 
-use crate::analysis::{
-	score::{
-		ACTIVITY_PHASE, AFFILIATION_PHASE, BINARY_PHASE, CHURN_PHASE, ENTROPY_PHASE, FUZZ_PHASE,
-		IDENTITY_PHASE, REVIEW_PHASE, TYPO_PHASE,
-	},
-	AnalysisProvider,
-};
+use crate::cache::plugin_cache::HcPluginCache;
 use crate::metric::{review::PullReview, MetricProvider};
-use crate::plugin::{ActivePlugin, PluginResponse, QueryResult};
+use crate::plugin::{
+	retrieve_plugins, ActivePlugin, Plugin, PluginManifest, PluginResponse, QueryResult,
+	CURRENT_ARCH,
+};
 pub use crate::plugin::{HcPluginCore, PluginExecutor, PluginWithConfig};
 use crate::policy::PolicyFile;
 use crate::policy_exprs::Expr;
 use crate::session::Session;
+use crate::util::fs::{find_file_by_name, read_string};
+use crate::{
+	analysis::{
+		score::{
+			ACTIVITY_PHASE, AFFILIATION_PHASE, BINARY_PHASE, CHURN_PHASE, ENTROPY_PHASE,
+			FUZZ_PHASE, IDENTITY_PHASE, REVIEW_PHASE, TYPO_PHASE,
+		},
+		AnalysisProvider,
+	},
+	shell,
+};
 use crate::{hc_error, Result};
 use futures::future::{BoxFuture, FutureExt};
+use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use tokio::runtime::{Handle, Runtime};
 
@@ -191,7 +202,10 @@ impl HcEngineImpl {
 	// analysis plugin to kick off the execution
 }
 
-pub fn start_plugins(policy_file: &PolicyFile) -> Result<Arc<HcPluginCore>> {
+pub fn start_plugins(
+	policy_file: &PolicyFile,
+	plugin_cache: &HcPluginCache,
+) -> Result<Arc<HcPluginCore>> {
 	let executor = PluginExecutor::new(
 		/* max_spawn_attempts */ 3,
 		/* max_conn_attempts */ 5,
@@ -199,7 +213,60 @@ pub fn start_plugins(policy_file: &PolicyFile) -> Result<Arc<HcPluginCore>> {
 		/* backoff_interval_micros */ 1000,
 		/* jitter_percent */ 10,
 	)?;
-	let plugins = vec![];
+
+	// retrieve, verify and extract all required plugins
+	let required_plugin_names = retrieve_plugins(&policy_file.plugins.0, plugin_cache)?;
+
+	let mut plugins = vec![];
+	for plugin_id in required_plugin_names.iter() {
+		let plugin_dir = plugin_cache.plugin_download_dir(
+			&plugin_id.publisher,
+			&plugin_id.name,
+			&plugin_id.version,
+		);
+
+		// determine entrypoint for this plugin
+		let plugin_kdl = find_file_by_name(plugin_dir, "plugin.kdl")?;
+		let contents = read_string(&plugin_kdl)?;
+		let plugin_manifest = PluginManifest::from_str(contents.as_str())?;
+		let entrypoint = plugin_manifest
+			.get_entrypoint(CURRENT_ARCH)
+			.ok_or_else(|| {
+				hc_error!(
+					"Could not find {} entrypoint for {}/{} {}",
+					CURRENT_ARCH,
+					plugin_id.publisher.0,
+					plugin_id.name.0,
+					plugin_id.version.0
+				)
+			})?;
+
+		let plugin = Plugin {
+			name: plugin_id.name.0.clone(),
+			entrypoint,
+		};
+
+		// find and serialize config for plugin
+		let config = policy_file
+			.get_config(plugin_id.to_policy_file_plugin_identifier().as_str())
+			.ok_or_else(|| {
+				hc_error!(
+					"Could not find config for {} {}",
+					plugin_id.to_policy_file_plugin_identifier(),
+					plugin_id.version.0
+				)
+			})?;
+		let config = serde_json::to_value(&config).map_err(|e| {
+			hc_error!(
+				"Error serializing config for {}",
+				plugin_id.to_policy_file_plugin_identifier()
+			)
+		})?;
+
+		let plugin_with_config = PluginWithConfig(plugin, config);
+		plugins.push(plugin_with_config);
+	}
+
 	let runtime = RUNTIME.handle();
 	let core = runtime.block_on(HcPluginCore::new(executor, plugins))?;
 	Ok(Arc::new(core))

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -1,23 +1,28 @@
 mod download_manifest;
 mod manager;
+mod plugin_id;
 mod plugin_manifest;
 mod retrieval;
 mod supported_arch;
 mod types;
 
-use crate::context::Context;
-use crate::kdl_helper::{extract_data, ParseKdlNode};
 pub use crate::plugin::manager::*;
+pub use crate::plugin::plugin_id::PluginId;
 pub use crate::plugin::types::*;
-use crate::Result;
+use crate::policy::policy_file::PolicyPluginName;
 pub use download_manifest::{
 	ArchiveFormat, DownloadManifest, DownloadManifestEntry, HashAlgorithm, HashWithDigest,
 };
-use futures::future::join_all;
 pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
+pub use retrieval::retrieve_plugins;
+pub use supported_arch::{SupportedArch, CURRENT_ARCH};
+
+use crate::context::Context;
+use crate::kdl_helper::{extract_data, ParseKdlNode};
+use crate::Result;
+use futures::future::join_all;
 use serde_json::Value;
 use std::collections::HashMap;
-pub use supported_arch::SupportedArch;
 use tokio::sync::{mpsc, Mutex};
 
 pub fn dummy() {

--- a/hipcheck/src/plugin/plugin_id.rs
+++ b/hipcheck/src/plugin/plugin_id.rs
@@ -1,0 +1,27 @@
+use super::{PluginName, PluginPublisher, PluginVersion};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+/// This structure is used to uniquely identify a plugin, when downloading/extracting
+pub struct PluginId {
+	pub publisher: PluginPublisher,
+	pub name: PluginName,
+	pub version: PluginVersion,
+}
+
+impl PluginId {
+	pub fn new(publisher: PluginPublisher, name: PluginName, version: PluginVersion) -> Self {
+		Self {
+			publisher,
+			name,
+			version,
+		}
+	}
+
+	/// converts the `PluginId` to the format of the plugin identifier in a policy file
+	///
+	/// Example:
+	/// `"mitre/git"`
+	pub fn to_policy_file_plugin_identifier(&self) -> String {
+		format!("{}/{}", self.publisher.0, self.name.0)
+	}
+}

--- a/hipcheck/src/plugin/plugin_manifest.rs
+++ b/hipcheck/src/plugin/plugin_manifest.rs
@@ -11,15 +11,15 @@ use std::{fmt::Display, str::FromStr};
 
 // NOTE: the implementation in this crate was largely derived from RFD #0004
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PluginPublisher(pub String);
 string_newtype_parse_kdl_node!(PluginPublisher, "publisher");
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PluginName(pub String);
 string_newtype_parse_kdl_node!(PluginName, "name");
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PluginVersion(pub String);
 string_newtype_parse_kdl_node!(PluginVersion, "version");
 
@@ -192,6 +192,12 @@ pub struct PluginManifest {
 	pub license: License,
 	pub entrypoints: Entrypoints,
 	pub dependencies: PluginDependencyList,
+}
+
+impl PluginManifest {
+	pub fn get_entrypoint(&self, arch: SupportedArch) -> Option<String> {
+		self.entrypoints.0.get(&arch).cloned()
+	}
 }
 
 impl FromStr for PluginManifest {

--- a/hipcheck/src/plugin/supported_arch.rs
+++ b/hipcheck/src/plugin/supported_arch.rs
@@ -17,6 +17,32 @@ pub enum SupportedArch {
 	X86_64UnknownLinuxGnu,
 }
 
+/// Architecture `hc` was built for
+pub const CURRENT_ARCH: SupportedArch = {
+	#[cfg(target_arch = "x86_64")]
+	{
+		#[cfg(target_os = "macos")]
+		{
+			SupportedArch::X86_64AppleDarwin
+		}
+		#[cfg(target_os = "linux")]
+		{
+			SupportedArch::X86_64UnknownLinuxGnu
+		}
+		#[cfg(target_os = "windows")]
+		{
+			SupportedArch::X86_64PcWindowsMsvc
+		}
+	}
+	#[cfg(target_arch = "aarch64")]
+	{
+		#[cfg(target_os = "macos")]
+		{
+			SupportedArch::Aarch64AppleDarwin
+		}
+	}
+};
+
 impl FromStr for SupportedArch {
 	type Err = crate::Error;
 

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -1,3 +1,5 @@
+use crate::plugin::PluginName;
+use crate::policy::policy_file::PolicyPluginName;
 use crate::{
 	hc_error,
 	hipcheck::{

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -13,6 +13,7 @@ use crate::config::{
 };
 use crate::error::Result;
 use crate::hc_error;
+use crate::plugin::PluginVersion;
 
 use url::Url;
 
@@ -125,7 +126,7 @@ fn parse_activity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-activity.kdl",
@@ -162,7 +163,7 @@ fn parse_binary(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/binary").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-binary.kdl",
@@ -194,7 +195,7 @@ fn parse_fuzz(plugins: &mut PolicyPluginList, practices: &mut PolicyCategory, fu
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/fuzz").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-fuzz.kdl",
@@ -231,7 +232,7 @@ fn parse_identity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/identity").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-identity.kdl",
@@ -268,7 +269,7 @@ fn parse_review(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/review").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-review.kdl",
@@ -306,7 +307,7 @@ fn parse_typo(plugins: &mut PolicyPluginList, attacks: &mut PolicyCategory, typo
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/typo").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-typo.kdl",
@@ -348,7 +349,7 @@ fn parse_affiliation(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/affiliation").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-affiliation.kdl",
@@ -385,7 +386,7 @@ fn parse_churn(plugins: &mut PolicyPluginList, commit: &mut PolicyCategory, chur
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/churn").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-churn.kdl",
@@ -426,7 +427,7 @@ fn parse_entropy(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/entropy").unwrap(),
-			PLUGIN_VERSION.to_string(),
+			PluginVersion::new(PLUGIN_VERSION.to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-entropy.kdl",

--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -5,6 +5,7 @@
 use crate::error::Result;
 use crate::hc_error;
 use crate::kdl_helper::{extract_data, ParseKdlNode};
+use crate::plugin::{PluginName, PluginPublisher, PluginVersion};
 use crate::string_newtype_parse_kdl_node;
 
 use kdl::KdlNode;
@@ -15,14 +16,14 @@ use url::Url;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolicyPlugin {
-	name: PolicyPluginName,
-	version: String,
-	manifest: Option<Url>,
+	pub name: PolicyPluginName,
+	pub version: PluginVersion,
+	pub manifest: Option<Url>,
 }
 
 impl PolicyPlugin {
 	#[allow(dead_code)]
-	pub fn new(name: PolicyPluginName, version: String, manifest: Option<Url>) -> Self {
+	pub fn new(name: PolicyPluginName, version: PluginVersion, manifest: Option<Url>) -> Self {
 		Self {
 			name,
 			version,
@@ -51,7 +52,7 @@ impl ParseKdlNode for PolicyPlugin {
 				return None;
 			}
 		};
-		let version = node.get("version")?.value().as_string()?.to_string();
+		let version = PluginVersion::new(node.get("version")?.value().as_string()?.to_string());
 
 		// The manifest is technically optional, as there should be a default Hipcheck plugin artifactory sometime in the future
 		// But for now it is essentially mandatory, so a plugin without a manifest will return an error downstream
@@ -335,7 +336,12 @@ impl PolicyCategoryChild {
 	fn find_analysis_by_name(&self, name: &str) -> Option<PolicyAnalysis> {
 		match self {
 			PolicyCategoryChild::Analysis(analysis) => {
-				if analysis.name.name == name {
+				let analysis_name = format!(
+					"{}/{}",
+					analysis.name.publisher.0.as_str(),
+					analysis.name.name.0.as_str()
+				);
+				if analysis_name.as_str() == name {
 					Some(analysis.clone())
 				} else {
 					None
@@ -486,18 +492,18 @@ impl ParseKdlNode for PolicyAnalyze {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PolicyPluginName {
-	pub publisher: String,
-	pub name: String,
+	pub publisher: PluginPublisher,
+	pub name: PluginName,
 }
 
 impl PolicyPluginName {
 	pub fn new(full_name: &str) -> Result<Self> {
 		let parsed_name: Vec<&str> = full_name.split('/').collect();
 		if parsed_name.len() > 1 {
-			let publisher = parsed_name[0].to_string();
-			let name = parsed_name[1].to_string();
+			let publisher = PluginPublisher::new(parsed_name[0].to_string());
+			let name = PluginName::new(parsed_name[1].to_string());
 			Ok(Self { publisher, name })
 		} else {
 			Err(hc_error!(
@@ -510,6 +516,6 @@ impl PolicyPluginName {
 
 impl Display for PolicyPluginName {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}/{}", self.publisher, self.name)
+		write!(f, "{}/{}", self.publisher.0, self.name.0)
 	}
 }

--- a/hipcheck/src/policy/tests.rs
+++ b/hipcheck/src/policy/tests.rs
@@ -5,6 +5,7 @@
 mod test {
 	use crate::config::Config;
 	use crate::kdl_helper::ParseKdlNode;
+	use crate::plugin::PluginVersion;
 	use crate::policy::config_to_policy::config_to_policy;
 	use crate::policy::policy_file::*;
 	use crate::policy::PolicyFile;
@@ -22,7 +23,7 @@ mod test {
 
 		let expected = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			"0.1.0".to_string(),
+			PluginVersion::new("0.1.0".to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-activity.kdl",
@@ -45,7 +46,7 @@ mod test {
 		let mut expected = PolicyPluginList::new();
 		expected.push(PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			"0.1.0".to_string(),
+			PluginVersion::new("0.1.0".to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-activity.kdl",
@@ -55,7 +56,7 @@ mod test {
 		));
 		expected.push(PolicyPlugin::new(
 			PolicyPluginName::new("mitre/binary").unwrap(),
-			"0.1.1".to_string(),
+			PluginVersion::new("0.1.1".to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-binary.kdl",
@@ -271,7 +272,7 @@ mod test {
 		let mut plugins = PolicyPluginList::new();
 		plugins.push(PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			"0.1.0".to_string(),
+			PluginVersion::new("0.1.0".to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-activity.kdl",
@@ -281,7 +282,7 @@ mod test {
 		));
 		plugins.push(PolicyPlugin::new(
 			PolicyPluginName::new("mitre/binary").unwrap(),
-			"0.1.1".to_string(),
+			PluginVersion::new("0.1.1".to_string()),
 			Some(
 				Url::parse(
 					"https://github.com/mitre/hipcheck/blob/main/plugin/dist/mitre-binary.kdl",

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -6,6 +6,7 @@ pub mod spdx;
 
 use crate::analysis::score::ScoringProviderStorage;
 use crate::analysis::AnalysisProviderStorage;
+use crate::cache::plugin_cache::HcPluginCache;
 use crate::command_util::DependentProgram;
 use crate::config::AttacksConfigQueryStorage;
 use crate::config::CommitConfigQueryStorage;
@@ -214,6 +215,10 @@ impl Session {
 			Err(err) => return Err(err),
 		};
 
+		session.set_cache_dir(Rc::new(home.clone()));
+
+		let plugin_cache = HcPluginCache::new(&home);
+
 		/*===================================================================
 		 *  Resolving the source.
 		 *-----------------------------------------------------------------*/
@@ -251,7 +256,7 @@ impl Session {
 		// equal, and the idea of memoizing/invalidating it does not make sense.
 		// Thus, we will do the plugin startup here.
 		let policy = session.policy();
-		let core = start_plugins(policy.as_ref())?;
+		let core = start_plugins(policy.as_ref(), &plugin_cache)?;
 		session.set_core(core);
 
 		Ok(session)

--- a/hipcheck/src/util/fs.rs
+++ b/hipcheck/src/util/fs.rs
@@ -4,9 +4,9 @@ use crate::context::Context as _;
 use crate::error::Result;
 use crate::hc_error;
 use serde::de::DeserializeOwned;
-use std::fs;
+use std::fs::{self, read_dir};
 use std::ops::Not;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Read a file to a string.
 pub fn read_string<P: AsRef<Path>>(path: P) -> Result<String> {
@@ -67,4 +67,32 @@ pub fn exists<P: AsRef<Path>>(path: P) -> Result<()> {
 	}
 
 	inner(path.as_ref())
+}
+
+/// find the first file that has a given name
+pub fn find_file_by_name<P: AsRef<Path>>(dir: P, file_name: &str) -> Result<PathBuf> {
+	fn inner(dir: &Path, file_name: &str) -> Result<PathBuf> {
+		if dir.is_dir() {
+			for entry in read_dir(dir)
+				.map_err(|e| hc_error!("Error [{}] reading {}", e, dir.to_string_lossy()))?
+			{
+				let entry = entry.map_err(|_| hc_error!("Failed to read entry"))?;
+				let path = entry.path();
+				if path.is_dir() {
+					if let Ok(found) = find_file_by_name(&path, file_name) {
+						return Ok(found);
+					}
+				} else if path.file_name().map_or(false, |name| name == file_name) {
+					return Ok(path);
+				}
+			}
+		}
+		Err(hc_error!(
+			"Could not find {} inside {}",
+			file_name,
+			dir.to_string_lossy()
+		))
+	}
+
+	inner(dir.as_ref(), file_name)
 }

--- a/site/content/rfds/0004-plugin-api.md
+++ b/site/content/rfds/0004-plugin-api.md
@@ -62,7 +62,8 @@ in the plugin's manifest.
 The __plugin manifest__ describes the start command for the plugin, along
 with additional metadata necessary for Hipcheck to run the plugin. The
 set of metadata intended for plugins was initially defined in RFD #3, but
-is updated and superseded here. The manifests will be defined using [KDL].
+is updated and superseded here. The manifests will be defined using [KDL], and
+should be named `plugin.kdl`.
 
 - __Publisher__ (`String`): The name of the individual or organization that
   created the plugin.


### PR DESCRIPTION
This pull request does the following:
- adds example `Hipcheck.kdl` to `config/`
- download and extract specified plugins (excluding legacy mitre/* plugins)
- updated RFD 4 to indicate `plugin.kdl` is the expected name of the plugin manifest for a plugin
- added SUPPORTED_ARCH constant that can be used to determine what rust triple version is currently running, used to determine which version of plugins to download and which entrypoints to use