### PR TITLE
fix: make HcEngine plugin lookup use {publisher}/{plugin} as key

### DIFF
--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -588,11 +588,11 @@ fn cmd_plugin(args: PluginArgs) {
 	let entrypoint1 = pathbuf![tgt_dir, "dummy_rand_data"];
 	let entrypoint2 = pathbuf![tgt_dir, "dummy_sha256"];
 	let plugin1 = Plugin {
-		name: "rand_data".to_owned(),
+		name: "dummy/rand_data".to_owned(),
 		entrypoint: entrypoint1.display().to_string(),
 	};
 	let plugin2 = Plugin {
-		name: "sha256".to_owned(),
+		name: "dummy/sha256".to_owned(),
 		entrypoint: entrypoint2.display().to_string(),
 	};
 	let plugin_executor = PluginExecutor::new(
@@ -627,7 +627,7 @@ fn cmd_plugin(args: PluginArgs) {
 				println!("Spawning");
 				futs.spawn(async_query(
 					arc_core,
-					"MITRE".to_owned(),
+					"dummy".to_owned(),
 					"rand_data".to_owned(),
 					"rand_data".to_owned(),
 					serde_json::json!(i),
@@ -639,7 +639,7 @@ fn cmd_plugin(args: PluginArgs) {
 		});
 	} else {
 		let res = engine.query(
-			"MITRE".to_owned(),
+			"dummy".to_owned(),
 			"rand_data".to_owned(),
 			"rand_data".to_owned(),
 			serde_json::json!(1),

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -9,7 +9,7 @@ mod supported_arch;
 mod types;
 
 use crate::error::Result;
-pub use crate::plugin::{manager::*, plugin_id::PluginId, types::*};
+pub use crate::plugin::{get_plugin_key, manager::*, plugin_id::PluginId, types::*};
 pub use download_manifest::{ArchiveFormat, DownloadManifest, HashAlgorithm, HashWithDigest};
 pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
 pub use retrieval::retrieve_plugins;

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -620,3 +620,7 @@ impl From<Query> for PluginResponse {
 		}
 	}
 }
+
+pub fn get_plugin_key(publisher: &str, plugin: &str) -> String {
+	format!("{publisher}/{plugin}")
+}

--- a/plugins/dummy_rand_data/src/main.rs
+++ b/plugins/dummy_rand_data/src/main.rs
@@ -37,7 +37,7 @@ pub async fn handle_rand_data(mut session: QuerySession, key: u64) -> Result<()>
 
 	let sha_req = Query {
 		direction: QueryDirection::Request,
-		publisher: "MITRE".to_owned(),
+		publisher: "dummy".to_owned(),
 		plugin: "sha256".to_owned(),
 		query: "sha256".to_owned(),
 		key: json!(vec![sha_input]),


### PR DESCRIPTION
update `HcEngine` interface queries to use proper plugin key

update `hc plugin` dummy plugins to have `dummy` publisher