### PR TITLE
chore: Revert 'cargo-dist' workaround

### DIFF
--- a/.github/workflows/mac-build-custom-setup.yml
+++ b/.github/workflows/mac-build-custom-setup.yml
@@ -1,3 +1,0 @@
-- name: Install protobuf on mac
-  if: runner.os == 'macOS'
-  run: brew install protobuf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: "Install protobuf on mac"
-        if: "runner.os == 'macOS'"
-        run: "brew install protobuf"
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,14 @@ install-updater = true
 include = ["config/", "scripts/"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
-github-build-setup = "mac-build-custom-setup.yml"
 
 # Ubuntu build dependencies for `cargo-dist`
 [workspace.metadata.dist.dependencies.apt]
 protobuf-compiler = "*"
+
+# macOS build dependencies for 'cargo-dist'
+[workspace.metadata.dist.dependencies.homebrew]
+protobuf = "*"
 
 # Windows build dependencies for `cargo-dist`
 [workspace.metadata.dist.dependencies.chocolatey]


### PR DESCRIPTION
We hit a bug in 'cargo-dist' yesterday that it turns out was already fixed in the latest version, but before we figured that out we implemented a workaround to enable us to get 3.6.2 out the door. Now that we know the latest 'cargo-dist' version doesn't need the workaround, we can revert it and use 0.22.1.