### PR TITLE
feat: add divz policy-expr func and fix some policies in legacy config file conversion

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -34,8 +34,8 @@ analyze {
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
 				langs-file "./config/Langs.toml"
-			}
-            analysis "mitre/churn" policy="(eq 0 (count (filter (gt 8.0) $)))" {
+	 		}
+            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
 				langs-file "./config/Langs.toml"
 			}
         }

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -122,7 +122,7 @@ fn parse_activity(
 		// Cap the weight at 65,533
 		let weight = activity.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = activity.week_count_threshold;
-		let expression = format!("(lte {} $/weeks)", threshold);
+		let expression = format!("(lte $ {})", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
@@ -228,7 +228,7 @@ fn parse_identity(
 		// Cap the weight at 65,533
 		let weight = identity.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = identity.percent_threshold;
-		let expression = format!("(lte {} $/pct_match)", threshold);
+		let expression = format!("(lte $ {})", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
@@ -265,7 +265,7 @@ fn parse_review(
 		// Cap the weight at 65,533
 		let weight = review.weight.try_into().unwrap_or(u16::MAX);
 		let threshold = review.percent_threshold;
-		let expression = format!("(lte {} $/pct_reviewed)", threshold);
+		let expression = format!("(lte $ {})", threshold);
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
@@ -380,8 +380,8 @@ fn parse_churn(plugins: &mut PolicyPluginList, commit: &mut PolicyCategory, chur
 		let value_threshold = churn.value_threshold;
 		let percent_threshold = churn.percent_threshold;
 		let expression = format!(
-			"(eq {} (count (filter (gt {}) $)))",
-			percent_threshold, value_threshold
+			"(lte (divz (count (filter (gt {}) $)) (count $)) {})",
+			value_threshold, percent_threshold,
 		);
 
 		// Add the plugin

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -14,11 +14,11 @@ analyze {
     investigate policy="(gt 0.5 $)"
 
     category "practices" weight=1 {
-        analysis "mitre/activity" policy="(lte 71 $/weeks)" weight=1
+        analysis "mitre/activity" policy="(lte $ 71)" weight=1
         analysis "mitre/binary" policy="(eq 0 (count $))" weight=1
         analysis "mitre/fuzz" policy="(eq #t $)" weight=1
-        analysis "mitre/identity" policy="(lte 0.2 $/pct_match)" weight=1
-        analysis "mitre/review" policy="(lte 0.05 $/pct_reviewed)" weight=1
+        analysis "mitre/identity" policy="(lte $ 0.2)" weight=1
+        analysis "mitre/review" policy="(lte $ 0.05)" weight=1
     }
 
     category "attacks" weight=1 {
@@ -31,7 +31,7 @@ analyze {
                 orgs-file "./config/Orgs.toml"
             }
 
-            analysis "mitre/churn" policy="(eq 0.02 (count (filter (gt 3) $)))" weight=1
+            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" weight=1
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 10) $)))" weight=1
         }
     }

--- a/hipcheck/src/policy_exprs/env.rs
+++ b/hipcheck/src/policy_exprs/env.rs
@@ -52,6 +52,7 @@ impl<'parent> Env<'parent> {
 		// Math functions.
 		env.add_fn("add", add);
 		env.add_fn("sub", sub);
+		env.add_fn("divz", divz);
 
 		// Logical functions.
 		env.add_fn("and", and);
@@ -389,6 +390,31 @@ fn sub(env: &Env, args: &[Expr]) -> Result<Expr> {
 	let op = |arg_1, arg_2| match (arg_1, arg_2) {
 		(Int(arg_1), Int(arg_2)) => Ok(Int(arg_1 - arg_2)),
 		(Float(arg_1), Float(arg_2)) => Ok(Float(arg_1 - arg_2)),
+		(Bool(_), Bool(_)) => Err(Error::BadType(name)),
+		_ => unreachable!(),
+	};
+
+	binary_primitive_op(name, env, args, op)
+}
+
+// Attempts to divide the numbers, returning a float. If
+// the divisor is zero, returns 0 instead
+fn divz(env: &Env, args: &[Expr]) -> Result<Expr> {
+	let name = "divz";
+
+	let op = |arg_1, arg_2| match (arg_1, arg_2) {
+		(Int(arg_1), Int(arg_2)) => Ok(if arg_2 == 0 {
+			Float(F64::new(0.0)?)
+		} else {
+			let f_arg_1 = arg_1 as f64;
+			let f_arg_2 = arg_2 as f64;
+			Float(F64::new(f_arg_1 / f_arg_2)?)
+		}),
+		(Float(arg_1), Float(arg_2)) => Ok(if arg_2 == 0.0 {
+			Float(arg_2)
+		} else {
+			Float(arg_1 / arg_2)
+		}),
 		(Bool(_), Bool(_)) => Err(Error::BadType(name)),
 		_ => unreachable!(),
 	};

--- a/hipcheck/src/policy_exprs/mod.rs
+++ b/hipcheck/src/policy_exprs/mod.rs
@@ -96,6 +96,50 @@ mod tests {
 	}
 
 	#[test]
+	fn eval_divz_int_zero() {
+		let program = "(divz 1 0)";
+		let context = Value::Null;
+		let result = Executor::std().parse_and_eval(program, &context).unwrap();
+		assert_eq!(
+			result,
+			Expr::Primitive(Primitive::Float(F64::new(0.0).unwrap()))
+		);
+	}
+
+	#[test]
+	fn eval_divz_int() {
+		let program = "(divz 1 2)";
+		let context = Value::Null;
+		let result = Executor::std().parse_and_eval(program, &context).unwrap();
+		assert_eq!(
+			result,
+			Expr::Primitive(Primitive::Float(F64::new(0.5).unwrap()))
+		);
+	}
+
+	#[test]
+	fn eval_divz_float() {
+		let program = "(divz 1.0 2.0)";
+		let context = Value::Null;
+		let result = Executor::std().parse_and_eval(program, &context).unwrap();
+		assert_eq!(
+			result,
+			Expr::Primitive(Primitive::Float(F64::new(0.5).unwrap()))
+		);
+	}
+
+	#[test]
+	fn eval_divz_float_zero() {
+		let program = "(divz 1.0 0.0)";
+		let context = Value::Null;
+		let result = Executor::std().parse_and_eval(program, &context).unwrap();
+		assert_eq!(
+			result,
+			Expr::Primitive(Primitive::Float(F64::new(0.0).unwrap()))
+		);
+	}
+
+	#[test]
 	fn eval_bools() {
 		let program = "(neq 1 2)";
 		let context = Value::Null;

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -216,12 +216,10 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 		match &stored.response {
 			Ok(res) => {
 				let deps = {
-					let Value::Number(opt_deps) = &res.value else {
+					let Value::Array(opt_deps) = &res.value else {
 						return Err(hc_error!("typo analysis has a non-numeric value"));
 					};
-					opt_deps
-						.as_u64()
-						.ok_or(hc_error!("typo analysis has a non-u64 value"))?
+					opt_deps.len() as u64
 				};
 				let analysis = Analysis::typo(deps, stored.policy.clone(), stored.passed);
 				builder.add_analysis(analysis, res.concerns.clone())?;


### PR DESCRIPTION
Fixed some policies used in the legacy config file conversion. To be able to express legacy churn pass/fail computation in policy expressions, needed to add a `divz` function, which will divide two ints/floats or return 0 if the divisor is 0.