### PR TITLE
fix: fix issue building Docker image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ COPY Cargo.toml Cargo.lock ./
 
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y build-essential perl-base && \
+    apt-get install -y build-essential perl-base protobuf-compiler && \
     cargo build --release
 
 #============================================================================
@@ -29,7 +29,7 @@ COPY config/ config/
 
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y npm git protobuf-compiler && \
+    apt-get install -y npm git && \
     apt-get clean && \
     npm install -g module-deps@6.2 --no-audit --no-fund && \
     adduser --disabled-password hc_user && \


### PR DESCRIPTION
I believe this is the issue that prevented `3.6.*` images from publishing to Dockerhub, but I have not yet tested building the image locally. I am updating my VM to ubuntu 22.04, and then I will attempt to build with `podman`, but I have been have certificate issues building it locally with `docker`

I also noticed that https://github.com/mitre/hipcheck/actions/runs/10764246899 failed 2 days ago and went unnoticed. Maybe we could figure out a way to have an issue be added to the backlog if that pipeline fails, or maybe building the docker image on each commit would be better? 