### PR TITLE
fix: hipcheck site now pointing to 3.6.3 (latest)

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -66,5 +66,5 @@ footer = [
 
 # Set an announcement for the site navigation bar.
 [extra.announce]
-url = "https://github.com/mitre/hipcheck/releases/tag/hipcheck-v3.5.0"
-text = "Introducing Hipcheck 3.5.0"
+url = "https://github.com/mitre/hipcheck/releases/tag/hipcheck-v3.6.3"
+text = "Introducing Hipcheck 3.6.3"


### PR DESCRIPTION
The website is pointing to `3.5.0` not `3.6.3` (latest)

![image](https://github.com/user-attachments/assets/8232e4c0-c566-438f-8e53-29a40d3538cb)

