### PR TITLE
feat: add placeholder for JSON pointer late-binding in policy expr

### DIFF
--- a/hipcheck/src/policy_exprs/expr.rs
+++ b/hipcheck/src/policy_exprs/expr.rs
@@ -30,6 +30,9 @@ pub enum Expr {
 
 	/// Stores the name of the input variable, followed by the lambda body.
 	Lambda(Ident, Box<Expr>),
+
+	/// Stores a late-binding for a JSON value.
+	JsonPointer(JsonPointer),
 }
 
 /// Primitive data.
@@ -52,6 +55,13 @@ pub enum Primitive {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ident(pub String);
 
+/// A late-binding for a JSON pointer
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonPointer {
+	pointer: String,
+	value: Option<serde_json::Value>,
+}
+
 /// A non-NaN 64-bit floating point number.
 pub type F64 = NotNan<f64>;
 
@@ -67,6 +77,7 @@ impl Display for Expr {
 				write!(f, "({} {})", ident, args)
 			}
 			Expr::Lambda(arg, body) => write!(f, "(lambda ({}) {}", arg, body),
+			Expr::JsonPointer(pointer) => write!(f, "${}", pointer.pointer),
 		}
 	}
 }

--- a/hipcheck/src/policy_exprs/mod.rs
+++ b/hipcheck/src/policy_exprs/mod.rs
@@ -67,6 +67,7 @@ pub(crate) fn eval(env: &Env, program: &Expr) -> Result<Expr> {
 			}
 		}
 		Expr::Lambda(_, body) => Ok((**body).clone()),
+		Expr::JsonPointer(_) => unreachable!(),
 	};
 
 	log::debug!("input: {program:?}, output: {output:?}");


### PR DESCRIPTION
Idea is that `value: Option` will hold `None` until we are ready to evaluate. 