### PR TITLE
feat: Allow any `Expr` at the top level of a Policy Expression

### DIFF
--- a/hipcheck/src/policy_exprs/expr.rs
+++ b/hipcheck/src/policy_exprs/expr.rs
@@ -183,7 +183,7 @@ fn parse_function(input: Input<'_>) -> IResult<Input<'_>, Expr> {
 
 pub fn parse(input: &str) -> Result<Expr> {
 	let tokens = Tokens::new(input);
-	let mut parser = all_consuming(parse_function);
+	let mut parser = all_consuming(parse_expr);
 
 	match parser(tokens).finish() {
 		Ok((rest, expr)) if rest.is_empty() => Ok(expr),
@@ -236,6 +236,14 @@ mod tests {
 
 	fn array(vals: Vec<Primitive>) -> Expr {
 		Expr::Array(vals)
+	}
+
+	#[test]
+	fn parse_bool() {
+		let input = "#t";
+		let expected = boolean(true).into_expr();
+		let result = parse(input).unwrap();
+		assert_eq!(result, expected);
 	}
 
 	#[test]

--- a/hipcheck/src/policy_exprs/mod.rs
+++ b/hipcheck/src/policy_exprs/mod.rs
@@ -81,6 +81,14 @@ mod tests {
 	use test_log::test;
 
 	#[test]
+	fn run_bool() {
+		let program = "#t";
+		let context = Value::Null;
+		let is_true = Executor::std().run(program, &context).unwrap();
+		assert!(is_true);
+	}
+
+	#[test]
 	fn run_basic() {
 		let program = "(eq (add 1 2) 3)";
 		let context = Value::Null;


### PR DESCRIPTION
The existing parsing code requires that the top level expression is always a function call. I'm not sure if this is intentional or an oversight, but the evaluation code seems to have no problem evaluating other expressions at the top level.

This change allows any expression type at all in the parser.

This will enable testing policy expressions with a plain `#t` or `#f` to force success or failure, as well as permit a JSON Pointer at the top level.