### PR TITLE
chore: Add GitHub privacy policy to website footer

### DIFF
--- a/site/templates/partials/footer.tera.html
+++ b/site/templates/partials/footer.tera.html
@@ -1,7 +1,7 @@
 
 <div class="max-w-6xl mx-auto mt-32" id="footer">
     <div class="pb-16 px-4 lg:px-0">
-        <div class="lg:flex gap-8 dark:text-zinc-400">
+        <div class="lg:flex gap-8 dark:text-zinc-400 mb-10">
 
             <div class="lg:basis-1/4 text-lg my-8 lg:my-0">
                 <a href="{{ get_url(path="@/_index.md") }}" class="hover:text-green-600 font-semibold">
@@ -38,6 +38,9 @@
                     </ul>
                 </div>
             {% endfor %}
+        </div>
+        <div class="lg:flex">
+            <p class="lg:basis-3/4 ml-auto pl-2 text-xs text-gray-400">Website served by GitHub Pages (<a class="underline hover:text-gray-500" href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">Privacy Policy</a>).</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Closes #376

The site is served by GitHub Pages, which has a privacy policy that controls what data they collect when people browse to GitHub Pages sites, and how that data is used. This updates our site to now link to this policy in the footer on each page.