### PR TITLE
feat(xtask): Added 'buf' xtask subcommand

### DIFF
--- a/.buf.yaml
+++ b/.buf.yaml
@@ -1,5 +1,5 @@
 version: v2
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   rpc_allow_same_request_response: true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> ExitCode {
 		.init();
 
 	let result = match args.command {
+		Commands::Buf => task::buf::run(),
 		Commands::Check => task::check::run(),
 		Commands::Ci => task::ci::run(),
 		Commands::Changelog(args) => task::changelog::run(args),
@@ -60,6 +61,8 @@ enum Commands {
 	Rfd(RfdArgs),
 	/// Work with the Hipcheck website.
 	Site(SiteArgs),
+	/// Lint the Hipcheck plugin gRPC definition.
+	Buf,
 }
 
 #[derive(Debug, clap::Args)]

--- a/xtask/src/task/buf.rs
+++ b/xtask/src/task/buf.rs
@@ -1,0 +1,19 @@
+use crate::workspace;
+use anyhow::{Context, Result};
+use pathbuf::pathbuf;
+use which::which;
+use xshell::{cmd, Shell};
+
+/// Run the `buf lint` command
+pub fn run() -> Result<()> {
+	let sh = Shell::new().context("could not init shell")?;
+	which("buf").context("could not find 'buf'")?;
+
+	let root = workspace::root()?;
+	let config = pathbuf![&root, ".buf.yaml"];
+	let target = pathbuf![&root, "hipcheck", "proto"];
+
+	cmd!(sh, "buf lint --config {config} {target}").run()?;
+
+	Ok(())
+}

--- a/xtask/src/task/mod.rs
+++ b/xtask/src/task/mod.rs
@@ -2,6 +2,7 @@
 
 //! Commands supported by 'xtask'
 
+pub mod buf;
 pub mod changelog;
 pub mod check;
 pub mod ci;


### PR DESCRIPTION
This subcommand checks that you have the tool `buf` installed, and then uses it to lint against our protobuf definition files. This is intended to make it easier to lint these definitions in the future.