### PR TITLE
chore: Update devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": {
-    "module-deps": "npm install -g module-deps@6.2 --no-audit --no-fund",
-    "openssl": "sudo apt-get install libssl-dev"
+    "openssl": "sudo apt-get install libssl-dev protobuf-compiler"
   }
 }


### PR DESCRIPTION
This commit does two things:

- Removes `module-deps` as an NPM dependency, since we no longer need/use it.
- Adds `protobuf-compiler` as an Apt dependency, since we need it to build our gRPC server definition.