### PR TITLE
feat: Make `xtask rfd new` include title in RFD file

### DIFF
--- a/xtask/src/task/buf.rs
+++ b/xtask/src/task/buf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::workspace;
 use anyhow::{Context, Result};
 use pathbuf::pathbuf;


### PR DESCRIPTION
Previously when making a new RFD, the `xtask` command would generate one without a YAML frontmatter, which would cause compilation with `zola` to fail. This fixes that, now including a YAML frontmatter with a `title` field filled with the title the user provided on the CLI.

Closes #425. 