### PR TITLE
feat: added preliminary SDK support to "rand_data" plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dummy_rand_data_sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hipcheck-sdk",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "dummy_sha256"
 version = "0.1.0"
 dependencies = [
@@ -1237,6 +1248,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.75",
+]
+
+[[package]]
+name = "hipcheck-sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "indexmap 2.5.0",
+ "prost",
+ "rand",
+ "schemars",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ members = [
     "hipcheck",
     "hipcheck-macros",
     "xtask",
+    "plugins/dummy_rand_data_sdk",
     "plugins/dummy_rand_data",
     "plugins/dummy_sha256",
+    "sdk/rust",
 ]
 
 # Make sure Hipcheck is run with `cargo run`.
@@ -34,7 +36,12 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -926,6 +926,8 @@ impl TryFrom<Vec<String>> for RepoCacheDeleteScope {
 pub struct PluginArgs {
 	#[arg(long = "async")]
 	pub asynch: bool,
+	#[arg(long = "sdk")]
+	pub sdk: bool,
 }
 
 /// The format to report results in.

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -547,7 +547,15 @@ fn cmd_plugin(args: PluginArgs) {
 	use tokio::task::JoinSet;
 
 	let tgt_dir = "./target/debug";
-	let entrypoint1 = pathbuf![tgt_dir, "dummy_rand_data"];
+
+	let entrypoint1 = match args.sdk {
+		true => {
+			pathbuf![tgt_dir, "dummy_rand_data_sdk"]
+		}
+		false => {
+			pathbuf![tgt_dir, "dummy_rand_data"]
+		}
+	};
 	let entrypoint2 = pathbuf![tgt_dir, "dummy_sha256"];
 	let plugin1 = Plugin {
 		name: "dummy/rand_data".to_owned(),

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -71,17 +71,22 @@ impl ActivePlugin {
 
 	pub async fn query(&self, name: String, key: Value) -> Result<PluginResponse> {
 		let id = self.get_unique_id().await;
+
+		// TODO: remove this unwrap
+		let (publisher, plugin) = self.channel.name().split_once('/').unwrap();
+
 		// @Todo - check name+key valid for schema
 		let query = Query {
 			id,
 			request: true,
-			publisher: "".to_owned(),
-			plugin: self.channel.name().to_owned(),
+			publisher: publisher.to_owned(),
+			plugin: plugin.to_owned(),
 			query: name,
 			key,
 			output: serde_json::json!(null),
 			concerns: vec![],
 		};
+
 		Ok(self.channel.query(query).await?.into())
 	}
 

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -478,6 +478,7 @@ impl PluginTransport {
 
 		// Send the query
 		let query: PluginQuery = query.try_into()?;
+
 		let id = query.id;
 		self.tx
 			.send(query)
@@ -499,6 +500,8 @@ impl PluginTransport {
 			while matches!(state, ReplyInProgress) {
 				// We expect another message. Pull it off the existing queue,
 				// or get a new one if we have run out
+				eprintln!("In progress");
+
 				let next = match msg_chunks.pop_front() {
 					Some(msg) => msg,
 					None => {

--- a/plugins/dummy_rand_data_sdk/Cargo.toml
+++ b/plugins/dummy_rand_data_sdk/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dummy_rand_data_sdk"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.87"
+clap = { version = "4.5.16", features = ["derive"] }
+hipcheck-sdk = { path = "../../sdk/rust" }
+rand = "0.8.5"
+tokio = { version = "1.40.0", features = ["rt"] }

--- a/plugins/dummy_rand_data_sdk/schema/query_schema_get_rand.json
+++ b/plugins/dummy_rand_data_sdk/schema/query_schema_get_rand.json
@@ -1,0 +1,3 @@
+{
+    "type": "integer"
+}

--- a/plugins/dummy_rand_data_sdk/src/main.rs
+++ b/plugins/dummy_rand_data_sdk/src/main.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use hipcheck_sdk::{
+	deps::{async_trait, from_str, JsonSchema, Value},
+	error::Error,
+	plugin_engine::PluginEngine,
+	plugin_server::PluginServer,
+	NamedQuery, Plugin, Query,
+};
+
+static GET_RAND_KEY_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");
+static GET_RAND_OUTPUT_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");
+
+fn reduce(input: u64) -> u64 {
+	input % 7
+}
+
+/// Plugin that queries hipcheck takes a `Value::Number` as input and performs following steps:
+/// - ensures input is u64
+/// - % 7 of input
+/// - queries `hipcheck` for sha256 of (% 7 of input)
+/// - returns `Value::Number`, where Number is the first `u8` in the sha256
+///
+/// Goals of this plugin
+/// - Verify `salsa` memoization is working (there should only ever be 7 queries made to `hipcheck`)
+/// - Verify plugins are able to query `hipcheck` for additional information
+#[derive(Clone, Debug)]
+struct RandDataPlugin;
+
+#[async_trait]
+impl Query for RandDataPlugin {
+	fn input_schema(&self) -> JsonSchema {
+		from_str(GET_RAND_KEY_SCHEMA).unwrap()
+	}
+
+	fn output_schema(&self) -> JsonSchema {
+		from_str(GET_RAND_OUTPUT_SCHEMA).unwrap()
+	}
+
+	async fn run(
+		&self,
+		engine: &mut PluginEngine,
+		input: Value,
+	) -> hipcheck_sdk::error::Result<Value> {
+		let Value::Number(num_size) = input else {
+			return Err(Error::UnexpectedPluginQueryDataFormat);
+		};
+
+		let Some(size) = num_size.as_u64() else {
+			return Err(Error::UnexpectedPluginQueryDataFormat);
+		};
+
+		let reduced_num = reduce(size);
+
+		let value = engine
+			.query("dummy/sha256/sha256", vec![reduced_num])
+			.await?;
+
+		let Value::Array(mut sha256) = value else {
+			return Err(Error::UnexpectedPluginQueryDataFormat);
+		};
+
+		let Value::Number(num) = sha256.pop().unwrap() else {
+			return Err(Error::UnexpectedPluginQueryDataFormat);
+		};
+
+		match num.as_u64() {
+			Some(val) => return Ok(Value::Number(val.into())),
+			None => {
+				return Err(Error::UnexpectedPluginQueryDataFormat);
+			}
+		}
+	}
+}
+
+impl Plugin for RandDataPlugin {
+	const PUBLISHER: &'static str = "dummy";
+	const NAME: &'static str = "rand_data";
+
+	fn set_config(
+		&self,
+		_config: Value,
+	) -> std::result::Result<(), hipcheck_sdk::error::ConfigError> {
+		Ok(())
+	}
+
+	fn default_policy_expr(&self) -> hipcheck_sdk::error::Result<String> {
+		Ok("".to_owned())
+	}
+
+	fn explain_default_query(&self) -> hipcheck_sdk::error::Result<Option<String>> {
+		Ok(Some("generate random data".to_owned()))
+	}
+
+	fn queries(&self) -> impl Iterator<Item = hipcheck_sdk::NamedQuery> {
+		vec![NamedQuery {
+			name: "rand_data",
+			inner: Box::new(RandDataPlugin),
+		}]
+		.into_iter()
+	}
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), hipcheck_sdk::error::Error> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(RandDataPlugin)
+		.listen(args.port)
+		.await
+}

--- a/plugins/dummy_rand_data_sdk/src/main.rs
+++ b/plugins/dummy_rand_data_sdk/src/main.rs
@@ -2,13 +2,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use hipcheck_sdk::{
-	deps::{async_trait, from_str, JsonSchema, Value},
-	error::Error,
-	plugin_engine::PluginEngine,
-	plugin_server::PluginServer,
-	NamedQuery, Plugin, Query,
-};
+use hipcheck_sdk::prelude::*;
 
 static GET_RAND_KEY_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");
 static GET_RAND_OUTPUT_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");

--- a/plugins/dummy_sha256/src/main.rs
+++ b/plugins/dummy_sha256/src/main.rs
@@ -36,10 +36,10 @@ fn sha256(content: &[u8]) -> Vec<u8> {
 }
 
 async fn handle_sha256(session: QuerySession, key: &[u8]) -> Result<()> {
-	println!("Key: {key:02x?}");
+	eprintln!("Key: {key:02x?}");
 	let res = sha256(key);
 
-	println!("Hash: {res:02x?}");
+	eprintln!("Hash: {res:02x?}");
 	let output = serde_json::to_value(res)?;
 
 	let resp = Query {

--- a/proto/hipcheck/v1/messages/default_policy_expr_request.proto
+++ b/proto/hipcheck/v1/messages/default_policy_expr_request.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "empty.proto";
+
+/**
+ * Getting the default policy expression has no params, so we just wrap
+ * the empty message for maximal forward compatibility.
+ */
+message DefaultPolicyExprRequest {
+    Empty empty = 1;
+}

--- a/proto/hipcheck/v1/messages/default_policy_expr_response.proto
+++ b/proto/hipcheck/v1/messages/default_policy_expr_response.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+/**
+ * The response from the DefaultPolicyExpr RPC call.
+ */
+message DefaultPolicyExprResponse {
+    /**
+     * A policy expression, if the plugin has a default policy.
+     * This MUST be filled in with any default values pulled from the plugin's
+     * configuration. Hipcheck will only request the default policy _after_
+     * configuring the plugin.
+     */
+    string policy_expression = 1;
+}

--- a/proto/hipcheck/v1/messages/empty.proto
+++ b/proto/hipcheck/v1/messages/empty.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+/**
+ * An empty message.
+ */
+message Empty {}

--- a/proto/hipcheck/v1/messages/explain_default_query_request.proto
+++ b/proto/hipcheck/v1/messages/explain_default_query_request.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "empty.proto";
+
+message ExplainDefaultQueryRequest {
+    Empty empty = 1;
+}

--- a/proto/hipcheck/v1/messages/explain_default_query_response.proto
+++ b/proto/hipcheck/v1/messages/explain_default_query_response.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+/**
+ * The response from the ExplainDefaultQuery RPC call.
+ */
+message ExplainDefaultQueryResponse {
+    /**
+     * An unstructured description of the default query.
+     */
+    string explanation = 1;
+}

--- a/proto/hipcheck/v1/messages/query.proto
+++ b/proto/hipcheck/v1/messages/query.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "query_state.proto";
+
+message Query {
+    // The ID of the request, used to associate requests and replies.
+    // Odd numbers = initiated by `hc`.
+    // Even numbers = initiated by a plugin.
+    int32 id = 1;
+
+    // The state of the query, indicating if this is a request or a reply,
+    // and if it's a reply whether it's the end of the reply.
+    QueryState state = 2;
+
+    // Publisher name and plugin name, when sent from Hipcheck to a plugin
+    // to initiate a fresh query, are used by the receiving plugin to validate
+    // that the query was intended for them.
+    //
+    // When a plugin is making a query to another plugin through Hipcheck, it's
+    // used to indicate the destination plugin, and to indicate the plugin that
+    // is replying when Hipcheck sends back the reply.
+    string publisher_name = 3;
+    string plugin_name = 4;
+
+    // The name of the query being made, so the responding plugin knows what
+    // to do with the provided data.
+    string query_name = 5;
+
+    // The key for the query, as a JSON object. This is the data that Hipcheck's
+    // incremental computation system will use to cache the response.
+    string key = 6;
+
+    // The response for the query, as a JSON object. This will be cached by
+    // Hipcheck for future queries matching the publisher name, plugin name,
+    // query name, and key.
+    string output = 7;
+
+    // Any "concerns" reported by a query. Concerns are *not* provided to
+    // other plugins calling a query, and are _only_ used by Hipcheck itself
+    // to provide the end-user with additional information about issues found
+    // during analysis.
+    //
+    // Concern chunking is the same as other fields.
+    repeated string concern = 8;
+}

--- a/proto/hipcheck/v1/messages/query_request.proto
+++ b/proto/hipcheck/v1/messages/query_request.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "query.proto";
+
+message QueryRequest {
+    Query query = 1;
+}

--- a/proto/hipcheck/v1/messages/query_response.proto
+++ b/proto/hipcheck/v1/messages/query_response.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "query.proto";
+
+message QueryResponse {
+    Query query = 1;
+}

--- a/proto/hipcheck/v1/messages/query_schemas_request.proto
+++ b/proto/hipcheck/v1/messages/query_schemas_request.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "empty.proto";
+
+message QuerySchemasRequest {
+    Empty empty = 1;
+}

--- a/proto/hipcheck/v1/messages/query_schemas_response.proto
+++ b/proto/hipcheck/v1/messages/query_schemas_response.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+message QuerySchemasResponse {
+    // The name of the query being described by the schemas provided.
+    //
+    // If either the key and/or output schemas result in a message which is
+    // too big, they may be chunked across multiple replies in the stream.
+    // Replies with matching query names should have their fields concatenated
+    // in the order received to reconstruct the chunks.
+    string query_name = 1;
+
+    // The key schema, in JSON Schema format.
+    string key_schema = 2;
+
+    // The output schema, in JSON Schema format.
+    string output_schema = 3;
+}

--- a/proto/hipcheck/v1/messages/query_state.proto
+++ b/proto/hipcheck/v1/messages/query_state.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+enum QueryState {
+    // Something has gone wrong.
+    QUERY_STATE_UNSPECIFIED = 0;
+
+    // We are submitting a new query.
+    QUERY_STATE_SUBMIT = 1;
+
+    // We are replying to a query and expect more chunks.
+    QUERY_STATE_REPLY_IN_PROGRESS = 2;
+
+    // We are closing a reply to a query. If a query response is in one chunk,
+    // just send this. If a query is in more than one chunk, send this with
+    // the last message in the reply. This tells the receiver that all chunks
+    // have been received.
+    QUERY_STATE_REPLY_COMPLETE = 3;
+}

--- a/proto/hipcheck/v1/messages/set_config_request.proto
+++ b/proto/hipcheck/v1/messages/set_config_request.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+message SetConfigRequest {
+    // JSON string containing configuration data expected by the plugin,
+    // pulled from the user's policy file.
+    string configuration = 1;
+}

--- a/proto/hipcheck/v1/messages/set_config_response.proto
+++ b/proto/hipcheck/v1/messages/set_config_response.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "empty.proto";
+
+message SetConfigResponse {
+    // No actual data returned. Errors handled with normal gRPC error system.
+    Empty empty = 1;
+}

--- a/proto/hipcheck/v1/plugin_service.proto
+++ b/proto/hipcheck/v1/plugin_service.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+package hipcheck.v1;
+
+import "messages/query_schemas_request.proto";
+import "messages/query_schemas_response.proto";
+import "messages/set_config_request.proto";
+import "messages/set_config_response.proto";
+import "messages/default_policy_expr_request.proto";
+import "messages/default_policy_expr_response.proto";
+import "messages/explain_default_query_request.proto";
+import "messages/explain_default_query_response.proto";
+import "messages/query_request.proto";
+import "messages/query_response.proto";
+
+/**
+ * Defines a Hipcheck plugin, able to interact with Hipcheck to provide
+ * support for additional analyses and sources of data.
+ */
+service PluginService {
+    /**
+     * Get schemas for all supported queries by the plugin.
+     *
+     * This is used by Hipcheck to validate that:
+     *
+     * - The plugin supports a default query taking a `target` type if used
+     *   as a top-level plugin in the user's policy file.
+     * - That requests sent to the plugin and data returned by the plugin
+     *   match the schema during execution.
+     */
+    rpc QuerySchemas (QuerySchemasRequest) returns (stream QuerySchemasResponse);
+
+    /**
+     * Hipcheck sends all child nodes for the plugin from the user's policy
+     * file to configure the plugin.
+     */
+    rpc SetConfig (SetConfigRequest) returns (SetConfigResponse);
+
+    /**
+     * Get the default policy for a plugin, which may additionally depend on
+     * the plugin's configuration.
+     */
+    rpc DefaultPolicyExpr (DefaultPolicyExprRequest) returns (DefaultPolicyExprResponse);
+
+    /**
+     * Get an explanation of what the default query returns, to use when
+     * reporting analysis results to users.
+     *
+     * Note that, because users can specify their own policy expression, this
+     * explanation *should not* assume the user has used the default policy
+     * expression, if one is provided by the plugin.
+     */
+    rpc ExplainDefaultQuery (ExplainDefaultQueryRequest)
+        returns (ExplainDefaultQueryResponse);
+
+    /**
+     * Open a bidirectional streaming RPC to enable a request/response
+     * protocol between Hipcheck and a plugin, where Hipcheck can issue
+     * queries to the plugin, and the plugin may issue queries to _other_
+     * plugins through Hipcheck.
+     *
+     * Queries are cached by the publisher name, plugin name, query name,
+     * and key, and if a match is found for those four values, then
+     * Hipcheck will respond with the cached result of that prior matching
+     * query rather than running the query again.
+     */
+    rpc Query (stream QueryRequest) returns (stream QueryResponse);
+}

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hipcheck-sdk"
+license = "Apache-2.0"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = "1.0.63"
+futures = "0.3.30"
+indexmap = "2.4.0"
+prost = "0.13.1"
+rand = "0.8.5"
+serde_json = "1.0.125"
+tokio = { version = "1.39.2", features = ["rt"] }
+tokio-stream = "0.1.15"
+tonic = "0.12.1"
+schemars = "0.8.21"
+
+[build-dependencies]
+anyhow = "1.0.86"
+tonic-build = "0.12.1"

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() -> anyhow::Result<()> {
+	tonic_build::compile_protos("../../hipcheck/proto/hipcheck/v1/hipcheck.proto")?;
+	Ok(())
+}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::proto::{ConfigurationStatus, InitiateQueryProtocolResponse, SetConfigurationResponse};
+use std::{convert::Infallible, ops::Not, result::Result as StdResult};
+use tokio::sync::mpsc::error::SendError as TokioMpscSendError;
+use tonic::Status as TonicStatus;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("unknown error; query is in an unspecified state")]
+	UnspecifiedQueryState,
+
+	#[error("unexpected ReplyInProgress state for query")]
+	UnexpectedReplyInProgress,
+
+	#[error("invalid JSON in query key")]
+	InvalidJsonInQueryKey(#[source] serde_json::Error),
+
+	#[error("invalid JSON in query output")]
+	InvalidJsonInQueryOutput(#[source] serde_json::Error),
+
+	#[error("session channel closed unexpectedly")]
+	SessionChannelClosed,
+
+	#[error("failed to send query from session to server")]
+	FailedToSendQueryFromSessionToServer(
+		#[source] TokioMpscSendError<StdResult<InitiateQueryProtocolResponse, TonicStatus>>,
+	),
+
+	#[error("plugin sent QueryReply when server was expecting a request")]
+	ReceivedReplyWhenExpectingRequest,
+
+	#[error("plugin sent QuerySubmit when server was expecting a reply chunk")]
+	ReceivedSubmitWhenExpectingReplyChunk,
+
+	#[error("received additional message for ID '{id}' after query completion")]
+	MoreAfterQueryComplete { id: usize },
+
+	#[error("failed to start server")]
+	FailedToStartServer(#[source] tonic::transport::Error),
+
+	#[error("unexpected JSON value from plugin")]
+	UnexpectedPluginQueryDataFormat,
+
+	#[error("could not determine which plugin query to run")]
+	UnknownPluginQuery,
+
+	#[error("invalid format for QueryTarget")]
+	InvalidQueryTarget,
+}
+
+// this will never happen, but is needed to enable passing QueryTarget to PluginEngine::query
+impl From<Infallible> for Error {
+	fn from(_value: Infallible) -> Self {
+		Error::UnspecifiedQueryState
+	}
+}
+
+pub type Result<T> = StdResult<T, Error>;
+
+#[derive(Debug)]
+pub enum ConfigError {
+	InvalidConfigValue {
+		field_name: String,
+		value: String,
+		reason: String,
+	},
+
+	MissingRequiredConfig {
+		field_name: String,
+		field_type: String,
+		possible_values: Vec<String>,
+	},
+
+	UnrecognizedConfig {
+		field_name: String,
+		field_value: String,
+		possible_confusables: Vec<String>,
+	},
+
+	Unspecified {
+		message: String,
+	},
+}
+
+impl From<ConfigError> for SetConfigurationResponse {
+	fn from(value: ConfigError) -> Self {
+		match value {
+			ConfigError::InvalidConfigValue {
+				field_name,
+				value,
+				reason,
+			} => SetConfigurationResponse {
+				status: ConfigurationStatus::InvalidConfigurationValue as i32,
+				message: format!("invalid value '{value}' for '{field_name}', reason: '{reason}'"),
+			},
+			ConfigError::MissingRequiredConfig {
+				field_name,
+				field_type,
+				possible_values,
+			} => SetConfigurationResponse {
+				status: ConfigurationStatus::MissingRequiredConfiguration as i32,
+				message: {
+					let mut message = format!(
+						"missing required config item '{field_name}' of type '{field_type}'"
+					);
+
+					if possible_values.is_empty().not() {
+						message.push_str("; possible values: ");
+						message.push_str(&possible_values.join(", "));
+					}
+
+					message
+				},
+			},
+			ConfigError::UnrecognizedConfig {
+				field_name,
+				field_value,
+				possible_confusables,
+			} => SetConfigurationResponse {
+				status: ConfigurationStatus::UnrecognizedConfiguration as i32,
+				message: {
+					let mut message =
+						format!("unrecognized field '{field_name}' with value '{field_value}'");
+
+					if possible_confusables.is_empty().not() {
+						message.push_str("; possible field names: ");
+						message.push_str(&possible_confusables.join(", "));
+					}
+
+					message
+				},
+			},
+			ConfigError::Unspecified { message } => SetConfigurationResponse {
+				status: ConfigurationStatus::Unspecified as i32,
+				message: format!("unknown error; {message}"),
+			},
+		}
+	}
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-mod proto {
-	include!(concat!(env!("OUT_DIR"), "/hipcheck.v1.rs"));
-}
-
-pub mod error;
-pub mod plugin_engine;
-pub mod plugin_server;
-
 use crate::error::Error;
 use crate::error::Result;
 use error::ConfigError;
@@ -17,6 +9,22 @@ use serde_json::Value as JsonValue;
 use std::result::Result as StdResult;
 use std::str::FromStr;
 
+mod proto {
+	include!(concat!(env!("OUT_DIR"), "/hipcheck.v1.rs"));
+}
+
+pub mod error;
+pub mod plugin_engine;
+pub mod plugin_server;
+
+// utility module, so users can write `use hipcheck_sdk::prelude::*` and have everything they need to write a plugin
+pub mod prelude {
+	pub use crate::deps::*;
+	pub use crate::error::{ConfigError, Error, Result};
+	pub use crate::plugin_engine::PluginEngine;
+	pub use crate::plugin_server::{PluginServer, QueryResult};
+	pub use crate::{DynQuery, NamedQuery, Plugin, Query, QuerySchema, QueryTarget};
+}
 
 // re-export of user facing third party dependencies
 pub mod deps {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod proto {
+	include!(concat!(env!("OUT_DIR"), "/hipcheck.v1.rs"));
+}
+
+pub mod error;
+pub mod plugin_engine;
+pub mod plugin_server;
+
+use crate::error::Error;
+use crate::error::Result;
+use error::ConfigError;
+use plugin_engine::PluginEngine;
+use schemars::schema::SchemaObject as JsonSchema;
+use serde_json::Value as JsonValue;
+use std::result::Result as StdResult;
+use std::str::FromStr;
+
+
+// re-export of user facing third party dependencies
+pub mod deps {
+	pub use schemars::schema::SchemaObject as JsonSchema;
+	pub use serde_json::{from_str, Value};
+	pub use tonic::async_trait;
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryTarget {
+	pub publisher: String,
+	pub plugin: String,
+	pub query: Option<String>,
+}
+
+impl FromStr for QueryTarget {
+	type Err = Error;
+
+	fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+		let parts: Vec<&str> = s.split('/').collect();
+		match parts.as_slice() {
+			[publisher, plugin, query] => Ok(Self {
+				publisher: publisher.to_string(),
+				plugin: plugin.to_string(),
+				query: Some(query.to_string()),
+			}),
+			[publisher, plugin] => Ok(Self {
+				publisher: publisher.to_string(),
+				plugin: plugin.to_string(),
+				query: None,
+			}),
+			_ => Err(Error::InvalidQueryTarget),
+		}
+	}
+}
+
+impl TryInto<QueryTarget> for &str {
+	type Error = Error;
+	fn try_into(self) -> StdResult<QueryTarget, Self::Error> {
+		QueryTarget::from_str(self)
+	}
+}
+
+pub struct QuerySchema {
+	/// The name of the query being described.
+	query_name: &'static str,
+
+	/// The query's input schema.
+	input_schema: JsonSchema,
+
+	/// The query's output schema.
+	output_schema: JsonSchema,
+}
+
+/// Query trait object.
+pub type DynQuery = Box<dyn Query>;
+
+pub struct NamedQuery {
+	/// The name of the query.
+	pub name: &'static str,
+
+	/// The query object.
+	pub inner: DynQuery,
+}
+
+impl NamedQuery {
+	/// Is the current query the default query?
+	fn is_default(&self) -> bool {
+		self.name.is_empty()
+	}
+}
+
+/// Defines a single query for the plugin.
+#[tonic::async_trait]
+pub trait Query: Send {
+	/// Get the input schema for the query.
+	fn input_schema(&self) -> JsonSchema;
+
+	/// Get the output schema for the query.
+	fn output_schema(&self) -> JsonSchema;
+
+	/// Run the plugin, optionally making queries to other plugins.
+	async fn run(&self, engine: &mut PluginEngine, input: JsonValue) -> Result<JsonValue>;
+}
+
+pub trait Plugin: Send + Sync + 'static {
+	/// The name of the publisher of the pl∂ugin.
+	const PUBLISHER: &'static str;
+
+	/// The name of the plugin.
+	const NAME: &'static str;
+
+	/// Handles setting configuration.
+	fn set_config(&self, config: JsonValue) -> StdResult<(), ConfigError>;
+
+	/// Gets the plugin's default policy expression.
+	fn default_policy_expr(&self) -> Result<String>;
+
+	/// Gets a description of what is returned by the plugin's default query.
+	fn explain_default_query(&self) -> Result<Option<String>>;
+
+	/// Get all the queries supported by the plugin.
+	fn queries(&self) -> impl Iterator<Item = NamedQuery>;
+
+	/// Get the plugin's default query, if it has one.
+	fn default_query(&self) -> Option<DynQuery> {
+		self.queries()
+			.find_map(|named| named.is_default().then_some(named.inner))
+	}
+
+	/// Get all schemas for queries provided by the plugin.
+	fn schemas(&self) -> impl Iterator<Item = QuerySchema> {
+		self.queries().map(|query| QuerySchema {
+			query_name: query.name,
+			input_schema: query.inner.input_schema(),
+			output_schema: query.inner.output_schema(),
+		})
+	}
+}

--- a/sdk/rust/src/plugin_engine.rs
+++ b/sdk/rust/src/plugin_engine.rs
@@ -1,47 +1,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proto::{
-	InitiateQueryProtocolRequest, InitiateQueryProtocolResponse, Query as PluginQuery, QueryState,
+use crate::proto::QueryState;
+use crate::{
+	error::{Error, Result},
+	proto::{
+		self, InitiateQueryProtocolRequest, InitiateQueryProtocolResponse, Query as PluginQuery,
+	},
+	QueryTarget,
 };
-use anyhow::{anyhow, Result};
+use crate::{JsonValue, Plugin};
 use futures::Stream;
-use serde_json::Value;
+use serde_json::{json, Value};
+use std::sync::Arc;
 use std::{
 	collections::{HashMap, VecDeque},
 	future::poll_fn,
-	ops::Not as _,
+	ops::Not,
 	pin::Pin,
+	result::Result as StdResult,
 };
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tonic::Status;
 
+impl From<Status> for Error {
+	fn from(_value: Status) -> Error {
+		// TODO: higher-fidelity handling?
+		Error::SessionChannelClosed
+	}
+}
+
 #[derive(Debug)]
-pub struct Query {
-	pub direction: QueryDirection,
-	pub publisher: String,
-	pub plugin: String,
-	pub query: String,
-	pub key: Value,
-	pub output: Value,
-	pub concerns: Vec<String>,
+struct Query {
+	direction: QueryDirection,
+	publisher: String,
+	plugin: String,
+	query: String,
+	key: Value,
+	output: Value,
+	concerns: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum QueryDirection {
+enum QueryDirection {
 	Request,
 	Response,
 }
 
 impl TryFrom<QueryState> for QueryDirection {
-	type Error = anyhow::Error;
+	type Error = Error;
 
 	fn try_from(value: QueryState) -> std::result::Result<Self, Self::Error> {
 		match value {
-			QueryState::Unspecified => {
-				Err(anyhow!("unspecified error; query is in an invalid state"))
-			}
+			QueryState::Unspecified => Err(Error::UnspecifiedQueryState),
 			QueryState::Submit => Ok(QueryDirection::Request),
-			QueryState::ReplyInProgress => Err(anyhow!("invalid state QueryReplyInProgress")),
+			QueryState::ReplyInProgress => Err(Error::UnexpectedReplyInProgress),
 			QueryState::ReplyComplete => Ok(QueryDirection::Response),
 		}
 	}
@@ -57,7 +69,7 @@ impl From<QueryDirection> for QueryState {
 }
 
 impl TryFrom<PluginQuery> for Query {
-	type Error = anyhow::Error;
+	type Error = Error;
 
 	fn try_from(value: PluginQuery) -> Result<Query> {
 		Ok(Query {
@@ -65,8 +77,9 @@ impl TryFrom<PluginQuery> for Query {
 			publisher: value.publisher_name,
 			plugin: value.plugin_name,
 			query: value.query_name,
-			key: serde_json::from_str(value.key.as_str())?,
-			output: serde_json::from_str(value.output.as_str())?,
+			key: serde_json::from_str(value.key.as_str()).map_err(Error::InvalidJsonInQueryKey)?,
+			output: serde_json::from_str(value.output.as_str())
+				.map_err(Error::InvalidJsonInQueryOutput)?,
 			concerns: value.concern,
 		})
 	}
@@ -74,16 +87,48 @@ impl TryFrom<PluginQuery> for Query {
 
 type SessionTracker = HashMap<i32, mpsc::Sender<Option<PluginQuery>>>;
 
-pub struct QuerySession {
+pub struct PluginEngine {
 	id: usize,
-	tx: mpsc::Sender<Result<InitiateQueryProtocolResponse, Status>>,
+	tx: mpsc::Sender<StdResult<InitiateQueryProtocolResponse, Status>>,
 	rx: mpsc::Receiver<Option<PluginQuery>>,
 	// So that we can remove ourselves when we get dropped
 	drop_tx: mpsc::Sender<i32>,
 }
 
-impl QuerySession {
-	pub fn id(&self) -> usize {
+impl PluginEngine {
+	pub async fn query<T, V>(&mut self, target: T, input: V) -> Result<JsonValue>
+	where
+		T: TryInto<QueryTarget, Error: Into<Error>>,
+		V: Into<JsonValue>,
+	{
+		let input: JsonValue = input.into();
+		let query_target: QueryTarget = target.try_into().map_err(|e| e.into())?;
+
+		async fn query_inner(
+			engine: &mut PluginEngine,
+			target: QueryTarget,
+			input: JsonValue,
+		) -> Result<JsonValue> {
+			let query = Query {
+				direction: QueryDirection::Request,
+				publisher: target.publisher,
+				plugin: target.plugin,
+				query: target.query.unwrap_or_else(|| "".to_owned()),
+				key: input,
+				output: json!(Value::Null),
+				concerns: vec![],
+			};
+			engine.send(query).await?;
+			let response = engine.recv().await?;
+			match response {
+				Some(response) => Ok(response.output),
+				None => Err(Error::SessionChannelClosed),
+			}
+		}
+		query_inner(self, query_target, input).await
+	}
+
+	fn id(&self) -> usize {
 		self.id
 	}
 
@@ -91,8 +136,9 @@ impl QuerySession {
 	// comes from the QuerySession
 	fn convert(&self, value: Query) -> Result<PluginQuery> {
 		let state: QueryState = value.direction.into();
-		let key = serde_json::to_string(&value.key)?;
-		let output = serde_json::to_string(&value.output)?;
+		let key = serde_json::to_string(&value.key).map_err(Error::InvalidJsonInQueryKey)?;
+		let output =
+			serde_json::to_string(&value.output).map_err(Error::InvalidJsonInQueryOutput)?;
 
 		Ok(PluginQuery {
 			id: self.id() as i32,
@@ -109,25 +155,18 @@ impl QuerySession {
 	async fn recv_raw(&mut self) -> Result<Option<VecDeque<PluginQuery>>> {
 		let mut out = VecDeque::new();
 
-		eprintln!("RAND-session: awaiting raw rx recv");
+		eprintln!("SDK: awaiting raw rx recv");
 
-		let opt_first = self
-			.rx
-			.recv()
-			.await
-			.ok_or(anyhow!("session channel closed unexpectedly"))?;
+		let opt_first = self.rx.recv().await.ok_or(Error::SessionChannelClosed)?;
 
 		let Some(first) = opt_first else {
 			// Underlying gRPC channel closed
 			return Ok(None);
 		};
-		eprintln!("RAND-session: got first msg");
 		out.push_back(first);
 
 		// If more messages in the queue, opportunistically read more
 		loop {
-			eprintln!("RAND-session: trying to get additional msg");
-
 			match self.rx.try_recv() {
 				Ok(Some(msg)) => {
 					out.push_back(msg);
@@ -142,39 +181,37 @@ impl QuerySession {
 				}
 			}
 		}
-
-		eprintln!("RAND-session: got {} msgs", out.len());
 		Ok(Some(out))
 	}
 
-	pub async fn send(&self, query: Query) -> Result<()> {
-		eprintln!("RAND-session: sending query");
-
+	/// Send a gRPC query from plugin to the hipcheck server
+	async fn send(&self, query: Query) -> Result<()> {
 		let query = InitiateQueryProtocolResponse {
 			query: Some(self.convert(query)?),
 		};
-
-		self.tx.send(Ok(query)).await?;
-
+		self.tx
+			.send(Ok(query))
+			.await
+			.map_err(Error::FailedToSendQueryFromSessionToServer)?;
 		Ok(())
 	}
 
-	pub async fn recv(&mut self) -> Result<Option<Query>> {
-		use QueryState::*;
-
-		eprintln!("RAND-session: calling recv_raw");
+	async fn recv(&mut self) -> Result<Option<Query>> {
 		let Some(mut msg_chunks) = self.recv_raw().await? else {
 			return Ok(None);
 		};
 
-		let mut raw = msg_chunks.pop_front().unwrap();
-		eprintln!("RAND-session: recv got raw {raw:?}");
+		let mut raw: PluginQuery = msg_chunks.pop_front().unwrap();
+		// eprintln!("SDK: recv got raw {raw:?}");
 
-		let mut state: QueryState = raw.state.try_into()?;
+		let mut state: QueryState = raw
+			.state
+			.try_into()
+			.map_err(|_| Error::UnspecifiedQueryState)?;
 
 		// If response is the first of a set of chunks, handle
-		if matches!(state, ReplyInProgress) {
-			while matches!(state, ReplyInProgress) {
+		if matches!(state, QueryState::ReplyInProgress) {
+			while matches!(state, QueryState::ReplyInProgress) {
 				// We expect another message. Pull it off the existing queue,
 				// or get a new one if we have run out
 				let next = match msg_chunks.pop_front() {
@@ -194,15 +231,14 @@ impl QuerySession {
 				};
 
 				// By now we have our "next" message
-				state = next.state.try_into()?;
+				state = next
+					.state
+					.try_into()
+					.map_err(|_| Error::UnspecifiedQueryState)?;
 				match state {
-					Unspecified => return Err(anyhow!("unspecified error from plugin")),
-					Submit => {
-						return Err(anyhow!(
-							"plugin sent QuerySubmit state when reply chunk expected"
-						))
-					}
-					ReplyInProgress | ReplyComplete => {
+					QueryState::Unspecified => return Err(Error::UnspecifiedQueryState),
+					QueryState::Submit => return Err(Error::ReceivedSubmitWhenExpectingReplyChunk),
+					QueryState::ReplyInProgress | QueryState::ReplyComplete => {
 						raw.output.push_str(next.output.as_str());
 						raw.concern.extend_from_slice(next.concern.as_slice());
 					}
@@ -211,18 +247,61 @@ impl QuerySession {
 
 			// Sanity check - after we've left this loop, there should be no left over message
 			if msg_chunks.is_empty().not() {
-				return Err(anyhow!(
-					"received additional messages for id '{}' after QueryComplete status message",
-					self.id
-				));
+				return Err(Error::MoreAfterQueryComplete { id: self.id });
 			}
 		}
 
 		raw.try_into().map(Some)
 	}
+
+	async fn handle_session<P>(&mut self, plugin: Arc<P>) -> crate::error::Result<()>
+	where
+		P: Plugin,
+	{
+		let Some(query) = self.recv().await? else {
+			return Err(Error::SessionChannelClosed);
+		};
+
+		if query.direction == QueryDirection::Response {
+			return Err(Error::ReceivedSubmitWhenExpectingReplyChunk);
+		}
+
+		let name = query.query;
+		let key = query.key;
+
+		// if we find the plugin by name, run it
+		// if not, check if there is a default plugin and run that one
+		// otherwise error out
+		let query = plugin
+			.queries()
+			.map(|x| x.inner)
+			.next()
+			.or_else(|| plugin.default_query())
+			.ok_or_else(|| Error::UnknownPluginQuery)?;
+
+		let value = query.run(self, key).await?;
+
+		let query = proto::Query {
+			id: self.id() as i32,
+			state: QueryState::ReplyComplete as i32,
+			publisher_name: P::PUBLISHER.to_owned(),
+			plugin_name: P::NAME.to_owned(),
+			query_name: name,
+			key: json!(Value::Null).to_string(),
+			output: value.to_string(),
+			concern: vec![],
+		};
+
+		self.tx
+			.send(Ok(InitiateQueryProtocolResponse { query: Some(query) }))
+			.await
+			.map_err(Error::FailedToSendQueryFromSessionToServer)?;
+
+		Ok(())
+	}
 }
 
-impl Drop for QuerySession {
+impl Drop for PluginEngine {
 	// Notify to have self removed from session tracker
 	fn drop(&mut self) {
 		while let Err(e) = self.drop_tx.try_send(self.id as i32) {
@@ -236,11 +315,12 @@ impl Drop for QuerySession {
 	}
 }
 
-type PluginQueryStream =
-	Box<dyn Stream<Item = Result<InitiateQueryProtocolRequest, Status>> + Send + Unpin + 'static>;
+type PluginQueryStream = Box<
+	dyn Stream<Item = StdResult<InitiateQueryProtocolRequest, Status>> + Send + Unpin + 'static,
+>;
 
-pub struct HcSessionSocket {
-	tx: mpsc::Sender<Result<InitiateQueryProtocolResponse, Status>>,
+pub(crate) struct HcSessionSocket {
+	tx: mpsc::Sender<StdResult<InitiateQueryProtocolResponse, Status>>,
 	rx: PluginQueryStream,
 	drop_tx: mpsc::Sender<i32>,
 	drop_rx: mpsc::Receiver<i32>,
@@ -262,14 +342,13 @@ impl std::fmt::Debug for HcSessionSocket {
 }
 
 impl HcSessionSocket {
-	pub fn new(
-		tx: mpsc::Sender<Result<InitiateQueryProtocolResponse, Status>>,
-		rx: impl Stream<Item = Result<InitiateQueryProtocolRequest, Status>> + Send + Unpin + 'static,
+	pub(crate) fn new(
+		tx: mpsc::Sender<StdResult<InitiateQueryProtocolResponse, Status>>,
+		rx: impl Stream<Item = StdResult<InitiateQueryProtocolRequest, Status>> + Send + Unpin + 'static,
 	) -> Self {
 		// channel for QuerySession objects to notify us they dropped
-		// @Todo - make this configurable
+		// TODO: make this configurable
 		let (drop_tx, drop_rx) = mpsc::channel(10);
-
 		Self {
 			tx,
 			rx: Box::new(rx),
@@ -291,7 +370,7 @@ impl HcSessionSocket {
 		}
 	}
 
-	async fn message(&mut self) -> Result<Option<PluginQuery>, Status> {
+	async fn message(&mut self) -> StdResult<Option<PluginQuery>, Status> {
 		let fut = poll_fn(|cx| Pin::new(&mut *self.rx).poll_next(cx));
 
 		match fut.await {
@@ -301,11 +380,9 @@ impl HcSessionSocket {
 		}
 	}
 
-	pub async fn listen(&mut self) -> Result<Option<QuerySession>> {
+	pub(crate) async fn listen(&mut self) -> Result<Option<PluginEngine>> {
 		loop {
-			eprintln!("RAND: listening");
-
-			let Some(raw) = self.message().await? else {
+			let Some(raw) = self.message().await.map_err(Error::from)? else {
 				return Ok(None);
 			};
 			let id = raw.id;
@@ -318,7 +395,7 @@ impl HcSessionSocket {
 
 			match self.decide_action(&raw) {
 				Ok(HandleAction::ForwardMsgToExistingSession(tx)) => {
-					eprintln!("RAND-listen: forwarding message to session {id}");
+					eprintln!("SDK: forwarding message to session {id}");
 
 					if let Err(_e) = tx.send(Some(raw)).await {
 						eprintln!("Error forwarding msg to session {id}");
@@ -326,12 +403,12 @@ impl HcSessionSocket {
 					};
 				}
 				Ok(HandleAction::CreateSession) => {
-					eprintln!("RAND-listen: creating new session {id}");
+					eprintln!("SDK: creating new session {id}");
 
 					let (in_tx, rx) = mpsc::channel::<Option<PluginQuery>>(10);
 					let tx = self.tx.clone();
 
-					let session = QuerySession {
+					let session = PluginEngine {
 						id: id as usize,
 						tx,
 						rx,
@@ -361,10 +438,34 @@ impl HcSessionSocket {
 			return Ok(HandleAction::CreateSession);
 		}
 
-		Err(anyhow!(
-			"Got query with id {}, does not match existing session and is not new QuerySubmit",
-			query.id
-		))
+		Err(Error::ReceivedReplyWhenExpectingRequest)
+	}
+
+	pub(crate) async fn run<P>(&mut self, plugin: Arc<P>) -> Result<()>
+	where
+		P: Plugin,
+	{
+		loop {
+			eprintln!("SHA256: Looping");
+
+			let Some(mut engine) = self
+				.listen()
+				.await
+				.map_err(|_| Error::SessionChannelClosed)?
+			else {
+				eprintln!("Channel closed by remote");
+				break;
+			};
+
+			let cloned_plugin = plugin.clone();
+			tokio::spawn(async move {
+				if let Err(e) = engine.handle_session(cloned_plugin).await {
+					panic!("handle_session failed: {e}");
+				};
+			});
+		}
+
+		Ok(())
 	}
 }
 

--- a/sdk/rust/src/plugin_server.rs
+++ b/sdk/rust/src/plugin_server.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	error::{Error, Result},
+	plugin_engine::HcSessionSocket,
+	proto::{
+		plugin_service_server::{PluginService, PluginServiceServer},
+		ConfigurationStatus, ExplainDefaultQueryRequest as ExplainDefaultQueryReq,
+		ExplainDefaultQueryResponse as ExplainDefaultQueryResp,
+		GetDefaultPolicyExpressionRequest as GetDefaultPolicyExpressionReq,
+		GetDefaultPolicyExpressionResponse as GetDefaultPolicyExpressionResp,
+		GetQuerySchemasRequest as GetQuerySchemasReq,
+		GetQuerySchemasResponse as GetQuerySchemasResp,
+		InitiateQueryProtocolRequest as InitiateQueryProtocolReq,
+		InitiateQueryProtocolResponse as InitiateQueryProtocolResp,
+		SetConfigurationRequest as SetConfigurationReq,
+		SetConfigurationResponse as SetConfigurationResp,
+	},
+	Plugin, QuerySchema,
+};
+use std::{result::Result as StdResult, sync::Arc};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream as RecvStream;
+use tonic::{transport::Server, Code, Request as Req, Response as Resp, Status, Streaming};
+
+/// Runs the Hipcheck plugin protocol based on the user's plugin definition.
+///
+/// The key idea is that this implements the gRPC mechanics and handles all
+/// the details of the query protocol, so that the user doesn't need to do
+/// anything more than define queries as asynchronous functions with associated
+/// input and output schemas.
+pub struct PluginServer<P> {
+	plugin: Arc<P>,
+}
+
+impl<P: Plugin> PluginServer<P> {
+	/// Create a new plugin server for the provided plugin.
+	pub fn register(plugin: P) -> PluginServer<P> {
+		PluginServer {
+			plugin: Arc::new(plugin),
+		}
+	}
+
+	/// Run the plugin server on the provided port.
+	pub async fn listen(self, port: u16) -> Result<()> {
+		let service = PluginServiceServer::new(self);
+		let host = format!("127.0.0.1:{}", port).parse().unwrap();
+
+		Server::builder()
+			.add_service(service)
+			.serve(host)
+			.await
+			.map_err(Error::FailedToStartServer)?;
+
+		Ok(())
+	}
+}
+
+/// The result of running a query.
+pub type QueryResult<T> = StdResult<T, Status>;
+
+#[tonic::async_trait]
+impl<P: Plugin> PluginService for PluginServer<P> {
+	type GetQuerySchemasStream = RecvStream<QueryResult<GetQuerySchemasResp>>;
+	type InitiateQueryProtocolStream = RecvStream<QueryResult<InitiateQueryProtocolResp>>;
+
+	async fn set_configuration(
+		&self,
+		req: Req<SetConfigurationReq>,
+	) -> QueryResult<Resp<SetConfigurationResp>> {
+		let config = serde_json::from_str(&req.into_inner().configuration)
+			.map_err(|e| Status::from_error(Box::new(e)))?;
+		match self.plugin.set_config(config) {
+			Ok(_) => Ok(Resp::new(SetConfigurationResp {
+				status: ConfigurationStatus::None as i32,
+				message: "".to_owned(),
+			})),
+			Err(e) => Ok(Resp::new(e.into())),
+		}
+	}
+
+	async fn get_default_policy_expression(
+		&self,
+		_req: Req<GetDefaultPolicyExpressionReq>,
+	) -> QueryResult<Resp<GetDefaultPolicyExpressionResp>> {
+		// The request is empty, so we do nothing.
+		match self.plugin.default_policy_expr() {
+			Ok(policy_expression) => Ok(Resp::new(GetDefaultPolicyExpressionResp {
+				policy_expression,
+			})),
+			Err(e) => Err(Status::new(
+				tonic::Code::NotFound,
+				format!(
+					"Error determining default policy expr for {}/{}: {}",
+					P::PUBLISHER,
+					P::NAME,
+					e
+				),
+			)),
+		}
+	}
+
+	async fn explain_default_query(
+		&self,
+		_req: Req<ExplainDefaultQueryReq>,
+	) -> QueryResult<Resp<ExplainDefaultQueryResp>> {
+		match self.plugin.default_policy_expr() {
+			Ok(explanation) => Ok(Resp::new(ExplainDefaultQueryResp { explanation })),
+			Err(e) => Err(Status::new(
+				tonic::Code::NotFound,
+				format!(
+					"Error explaining default query expr for {}/{}: {}",
+					P::PUBLISHER,
+					P::NAME,
+					e
+				),
+			)),
+		}
+	}
+
+	async fn get_query_schemas(
+		&self,
+		_req: Req<GetQuerySchemasReq>,
+	) -> QueryResult<Resp<Self::GetQuerySchemasStream>> {
+		// Ignore the input, it's empty.
+		let query_schemas = self.plugin.schemas().collect::<Vec<QuerySchema>>();
+		// TODO: does this need to be configurable?
+		let (tx, rx) = mpsc::channel(10);
+		tokio::spawn(async move {
+			for x in query_schemas {
+				let input_schema = serde_json::to_string(&x.input_schema);
+				let output_schema = serde_json::to_string(&x.output_schema);
+
+				let schema_resp = match (input_schema, output_schema) {
+					(Ok(input_schema), Ok(output_schema)) => Ok(GetQuerySchemasResp {
+						query_name: x.query_name.to_string(),
+						key_schema: input_schema,
+						output_schema,
+					}),
+					(Ok(_), Err(e)) => Err(Status::new(
+						Code::FailedPrecondition,
+						format!("Error converting output schema to String: {}", e),
+					)),
+					(Err(_), Ok(e)) => Err(Status::new(
+						Code::FailedPrecondition,
+						format!("Error converting input schema to String: {}", e),
+					)),
+					(Err(e1), Err(e2)) => Err(Status::new(
+						Code::FailedPrecondition,
+						format!(
+							"Error converting input and output schema to String: {} {}",
+							e1, e2
+						),
+					)),
+				};
+
+				if tx.send(schema_resp).await.is_err() {
+					// TODO: handle this?
+					panic!();
+				}
+			}
+		});
+		Ok(Resp::new(RecvStream::new(rx)))
+	}
+
+	async fn initiate_query_protocol(
+		&self,
+		req: Req<Streaming<InitiateQueryProtocolReq>>,
+	) -> QueryResult<Resp<Self::InitiateQueryProtocolStream>> {
+		let rx = req.into_inner();
+		// TODO: - make channel size configurable
+		let (tx, out_rx) = mpsc::channel::<QueryResult<InitiateQueryProtocolResp>>(10);
+
+		let cloned_plugin = self.plugin.clone();
+
+		tokio::spawn(async move {
+			let mut channel = HcSessionSocket::new(tx, rx);
+			if let Err(e) = channel.run(cloned_plugin).await {
+				panic!("Error: {e}");
+			}
+		});
+		Ok(Resp::new(RecvStream::new(out_rx)))
+	}
+}


### PR DESCRIPTION
This pull request is the first pass at using the `hipcheck-sdk` crate to make a plugin for `hipcheck`

The goal of the SDK is to make it as easy as possible for plugin authors to write new plugins for hipcheck!

The hidden `hc plugin` command no accepts another flag `--sdk` that will use the `dummy_rand_data_sdk` plugin, rather than the `dummy_rand_data` plugin

There are some outstanding issues that still need to be addressed, whether in this issue, or in another issue in the future:
- How are we handling third-party dependencies that are exposed in public facing types (`serde_json::Value`, `schemars::schema::SchemaObject`, ...)
- How much documentation should be present in the `hipcheck-sdk` crate
- How do we test the `hipcheck-sdk` crate to ensure it is producing the desired behaviors and integrates cleanly with what `hipcheck` is expecting
- Does it make sense to add a `prelude` module so a user would be able to `use hipcheck_sdk::prelude::*` and have the most common imports?