### PR TITLE
fix: Fix broken `Containerfile`

### DIFF
--- a/dist/Containerfile
+++ b/dist/Containerfile
@@ -8,14 +8,17 @@ WORKDIR /app
 
 RUN set -eux \
     && apt-get update \
-    && apt-get install -y git curl \
+    && apt-get install --no-install-recommends -y git curl xz-utils \
     && rm -rf /var/lib/apt/lists/* \
     && adduser --disabled-password hc_user \
-    && chown -R hc_user /app \
-    && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mitre/hipcheck/releases/download/hipcheck-v${HC_VERSION}/hipcheck-installer.sh | sh
+    && chown -R hc_user /app
 
 USER hc_user
-COPY config/ config/
-ENV HC_CONFIG=./config
-ENTRYPOINT ["./hc"]
-CMD ["help"]
+
+RUN set -eux \
+    && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mitre/hipcheck/releases/download/hipcheck-v${HC_VERSION}/hipcheck-installer.sh | sh \
+    && $HOME/.cargo/bin/hc setup
+
+ENV HC_CONFIG="$HOME/.config/hipcheck"
+ENTRYPOINT "$HOME/.cargo/bin/hc"
+CMD "help"


### PR DESCRIPTION
It turns out the prior version of the `Containerfile` was broken, as the install script for Hipcheck wouldn't actually work due to a missing `xz-utils` package. This was obscured by my own networking issues, causing me to inadequately test the prior change.

One other change this makes is that it splits the `RUN` commands up with a `USER` command, so the first `RUN` is done as root to set up the system, and the second `RUN` is done as `hc_user` to install Hipcheck.