### PR TITLE
feat: allow use of unknown arches through commandline

### DIFF
--- a/hipcheck/build.rs
+++ b/hipcheck/build.rs
@@ -5,8 +5,18 @@ use pathbuf::pathbuf;
 use tonic_build::compile_protos;
 
 fn main() -> Result<()> {
+	// Compile the Hipcheck gRPC protocol spec to an .rs file
 	let root = env!("CARGO_MANIFEST_DIR");
 	let path = pathbuf![root, "proto", "hipcheck", "v1", "hipcheck.proto"];
 	compile_protos(path)?;
+
+	// Make the target available as a compile-time env var for plugin arch
+	// resolution
+	println!(
+		"cargo:rustc-env=TARGET={}",
+		std::env::var("TARGET").unwrap()
+	);
+	println!("cargo:rerun-if-changed-env=TARGET");
+
 	Ok(())
 }

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -7,7 +7,7 @@ use crate::{
 	error::Context,
 	error::Result,
 	hc_error,
-	plugin::SupportedArch,
+	plugin::Arch,
 	session::pm,
 	shell::{color_choice::ColorChoice, verbosity::Verbosity},
 	source,
@@ -19,7 +19,10 @@ use crate::{
 use clap::{Parser as _, ValueEnum};
 use hipcheck_macros as hc;
 use pathbuf::pathbuf;
-use std::path::{Path, PathBuf};
+use std::{
+	path::{Path, PathBuf},
+	str::FromStr,
+};
 use url::Url;
 
 /// Automatated supply chain risk assessment of software packages.
@@ -417,8 +420,8 @@ pub struct CheckArgs {
 	#[clap(subcommand)]
 	command: Option<CheckCommand>,
 
-	#[arg(long = "arch")]
-	pub arch: Option<SupportedArch>,
+	#[arg(long = "arch", value_parser = Arch::from_str)]
+	pub arch: Option<Arch>,
 
 	#[arg(short = 't', long = "target")]
 	pub target_type: Option<TargetType>,

--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -5,8 +5,8 @@ use crate::{
 	cache::plugin::HcPluginCache,
 	hc_error,
 	plugin::{
-		get_plugin_key, retrieve_plugins, try_get_current_arch, Plugin, PluginManifest,
-		PluginResponse, QueryResult,
+		get_current_arch, get_plugin_key, retrieve_plugins, Plugin, PluginManifest, PluginResponse,
+		QueryResult,
 	},
 	policy::PolicyFile,
 	util::fs::{find_file_by_name, read_string},
@@ -230,7 +230,8 @@ pub fn start_plugins(
 		/* jitter_percent */ 10,
 	)?;
 
-	let current_arch = try_get_current_arch()?;
+	let current_arch = get_current_arch();
+	println!("CURRENT ARCH: {}", current_arch);
 
 	// retrieve, verify and extract all required plugins
 	let required_plugin_names = retrieve_plugins(&policy_file.plugins.0, plugin_cache)?;
@@ -248,7 +249,7 @@ pub fn start_plugins(
 		let contents = read_string(&plugin_kdl)?;
 		let plugin_manifest = PluginManifest::from_str(contents.as_str())?;
 		let entrypoint = plugin_manifest
-			.get_entrypoint(current_arch)
+			.get_entrypoint(&current_arch)
 			.ok_or_else(|| {
 				hc_error!(
 					"Could not find {} entrypoint for {}/{} {}",

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> ExitCode {
 /// Run the `check` command.
 fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
 	// Before we do any analysis, set the user-provided arch
-	if let Some(arch) = args.arch {
+	if let Some(arch) = &args.arch {
 		if let Err(e) = try_set_arch(arch) {
 			Shell::print_error(&e, Format::Human);
 			return ExitCode::FAILURE;

--- a/hipcheck/src/plugin/arch.rs
+++ b/hipcheck/src/plugin/arch.rs
@@ -9,7 +9,7 @@ use std::{fmt::Display, result::Result as StdResult, str::FromStr, sync::OnceLoc
 /// Officially supported target triples, as of RFD #0004
 ///
 /// NOTE: these architectures correspond to the offically supported Rust platforms
-pub enum SupportedArch {
+pub enum KnownArch {
 	/// Used for macOS running on "Apple Silicon" running on a 64-bit ARM Instruction Set Architecture (ISA)
 	Aarch64AppleDarwin,
 	/// Used for macOS running on the Intel 64-bit ISA
@@ -18,22 +18,34 @@ pub enum SupportedArch {
 	X86_64PcWindowsMsvc,
 	/// Used for Linux operating systems running on the Intel 64-bit ISA with a GNU toolchain for compilation
 	X86_64UnknownLinuxGnu,
+	/// Used for Linux operating systems running on a 64-bit ARM ISA
+	Aarch64UnknownLinuxGnu,
 }
 
-pub const DETECTED_ARCH: Option<SupportedArch> = {
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Arch {
+	Known(KnownArch),
+	Unknown(String),
+}
+
+pub const DETECTED_ARCH_STR: &str = env!("TARGET");
+
+pub const DETECTED_ARCH: Option<KnownArch> = {
 	if cfg!(target_arch = "x86_64") {
 		if cfg!(target_os = "macos") {
-			Some(SupportedArch::X86_64AppleDarwin)
+			Some(KnownArch::X86_64AppleDarwin)
 		} else if cfg!(target_os = "linux") {
-			Some(SupportedArch::X86_64UnknownLinuxGnu)
+			Some(KnownArch::X86_64UnknownLinuxGnu)
 		} else if cfg!(target_os = "windows") {
-			Some(SupportedArch::X86_64PcWindowsMsvc)
+			Some(KnownArch::X86_64PcWindowsMsvc)
 		} else {
 			None
 		}
 	} else if cfg!(target_arch = "aarch64") {
 		if cfg!(target_os = "macos") {
-			Some(SupportedArch::Aarch64AppleDarwin)
+			Some(KnownArch::Aarch64AppleDarwin)
+		} else if cfg!(target_os = "linux") {
+			Some(KnownArch::Aarch64UnknownLinuxGnu)
 		} else {
 			None
 		}
@@ -42,34 +54,24 @@ pub const DETECTED_ARCH: Option<SupportedArch> = {
 	}
 };
 
-pub static USER_PROVIDED_ARCH: OnceLock<SupportedArch> = OnceLock::new();
+pub static USER_PROVIDED_ARCH: OnceLock<Arch> = OnceLock::new();
 
 /// Get the target architecture for plugins. If the user provided a target,
 /// return that. Otherwise, if the `hc` binary was compiled for a supported
 /// architecture, return that. Otherwise return None.
-pub fn get_current_arch() -> Option<SupportedArch> {
+pub fn get_current_arch() -> Arch {
 	if let Some(arch) = USER_PROVIDED_ARCH.get() {
-		Some(*arch)
-	} else if DETECTED_ARCH.is_some() {
-		DETECTED_ARCH
+		arch.clone()
+	} else if let Some(known_arch) = DETECTED_ARCH {
+		Arch::Known(known_arch)
 	} else {
-		None
+		Arch::Unknown(DETECTED_ARCH_STR.to_owned())
 	}
 }
 
-/// Like `get_current_arch()`, but returns an error message suggesting the
-/// user specifies a target on the CLI
-pub fn try_get_current_arch() -> Result<SupportedArch> {
-	if let Some(arch) = get_current_arch() {
-		Ok(arch)
-	} else {
-		Err(hc_error!("Could not resolve the current machine to one of the Hipcheck supported architectures. Please specify --arch on the commandline."))
-	}
-}
-
-pub fn try_set_arch(arch: SupportedArch) -> Result<()> {
-	let set_arch = USER_PROVIDED_ARCH.get_or_init(|| arch);
-	if *set_arch == arch {
+pub fn try_set_arch(arch: &Arch) -> Result<()> {
+	let set_arch = USER_PROVIDED_ARCH.get_or_init(|| arch.clone());
+	if set_arch == arch {
 		Ok(())
 	} else {
 		Err(hc_error!(
@@ -80,12 +82,13 @@ pub fn try_set_arch(arch: SupportedArch) -> Result<()> {
 	}
 }
 
-impl FromStr for SupportedArch {
+impl FromStr for KnownArch {
 	type Err = crate::Error;
 
 	fn from_str(s: &str) -> StdResult<Self, Self::Err> {
 		match s {
 			"aarch64-apple-darwin" => Ok(Self::Aarch64AppleDarwin),
+			"aarch64-unknown-linux-gnu" => Ok(Self::Aarch64UnknownLinuxGnu),
 			"x86_64-apple-darwin" => Ok(Self::X86_64AppleDarwin),
 			"x86_64-pc-windows-msvc" => Ok(Self::X86_64PcWindowsMsvc),
 			"x86_64-unknown-linux-gnu" => Ok(Self::X86_64UnknownLinuxGnu),
@@ -94,14 +97,36 @@ impl FromStr for SupportedArch {
 	}
 }
 
-impl Display for SupportedArch {
+impl Display for KnownArch {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let target_triple = match self {
-			SupportedArch::Aarch64AppleDarwin => "aarch64-apple-darwin",
-			SupportedArch::X86_64AppleDarwin => "x86_64-apple-darwin",
-			SupportedArch::X86_64PcWindowsMsvc => "x86_64-pc-windows-msvc",
-			SupportedArch::X86_64UnknownLinuxGnu => "x86_64-unknown-linux-gnu",
+			KnownArch::Aarch64AppleDarwin => "aarch64-apple-darwin",
+			KnownArch::Aarch64UnknownLinuxGnu => "aarch64-unknown-linux-gnu",
+			KnownArch::X86_64AppleDarwin => "x86_64-apple-darwin",
+			KnownArch::X86_64PcWindowsMsvc => "x86_64-pc-windows-msvc",
+			KnownArch::X86_64UnknownLinuxGnu => "x86_64-unknown-linux-gnu",
 		};
 		write!(f, "{}", target_triple)
+	}
+}
+
+impl FromStr for Arch {
+	type Err = std::convert::Infallible;
+
+	fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+		if let Ok(known_arch) = FromStr::from_str(s) {
+			Ok(Arch::Known(known_arch))
+		} else {
+			Ok(Arch::Unknown(s.to_owned()))
+		}
+	}
+}
+
+impl Display for Arch {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Arch::Known(known_arch) => known_arch.fmt(f),
+			Arch::Unknown(arch_str) => arch_str.fmt(f),
+		}
 	}
 }

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod arch;
 mod download_manifest;
 mod manager;
 mod plugin_id;
 mod plugin_manifest;
 mod retrieval;
-mod supported_arch;
 mod types;
 
 use crate::error::Result;
 pub use crate::plugin::{get_plugin_key, manager::*, plugin_id::PluginId, types::*};
+pub use arch::{get_current_arch, try_set_arch, Arch};
 pub use download_manifest::{ArchiveFormat, DownloadManifest, HashAlgorithm, HashWithDigest};
 pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
 pub use retrieval::retrieve_plugins;
 use serde_json::Value;
 use std::collections::HashMap;
-pub use supported_arch::{try_get_current_arch, try_set_arch, SupportedArch};
 use tokio::sync::Mutex;
 
 pub async fn initialize_plugins(


### PR DESCRIPTION
This replaces `SupportedArch` with an `Arch` enum, which is further subdivided into `Unknown(String)` and the `KnownArch` enum.

Currently `DETECTED_ARCH` is `Option<KnownArch>`, but we could expand it to be just `Arch`, and try to get the target triple at compile time as a string to fill the `Arch::Unknown` variant. Without doing this, right now you'll be forced to specify `--arch` on the command line even if you build and run on the same arch, assuming its not one of the `KnownArch` types.