### PR TITLE
chore: extend API doc comments for Rust SDK

### DIFF
--- a/plugins/dummy_rand_data_sdk/src/main.rs
+++ b/plugins/dummy_rand_data_sdk/src/main.rs
@@ -39,11 +39,11 @@ impl Query for RandDataPlugin {
 		input: Value,
 	) -> hipcheck_sdk::error::Result<Value> {
 		let Value::Number(num_size) = input else {
-			return Err(Error::UnexpectedPluginQueryDataFormat);
+			return Err(Error::UnexpectedPluginQueryInputFormat);
 		};
 
 		let Some(size) = num_size.as_u64() else {
-			return Err(Error::UnexpectedPluginQueryDataFormat);
+			return Err(Error::UnexpectedPluginQueryInputFormat);
 		};
 
 		let reduced_num = reduce(size);
@@ -53,17 +53,17 @@ impl Query for RandDataPlugin {
 			.await?;
 
 		let Value::Array(mut sha256) = value else {
-			return Err(Error::UnexpectedPluginQueryDataFormat);
+			return Err(Error::UnexpectedPluginQueryInputFormat);
 		};
 
 		let Value::Number(num) = sha256.pop().unwrap() else {
-			return Err(Error::UnexpectedPluginQueryDataFormat);
+			return Err(Error::UnexpectedPluginQueryInputFormat);
 		};
 
 		match num.as_u64() {
 			Some(val) => return Ok(Value::Number(val.into())),
 			None => {
-				return Err(Error::UnexpectedPluginQueryDataFormat);
+				return Err(Error::UnexpectedPluginQueryInputFormat);
 			}
 		}
 	}

--- a/sdk/rust/src/plugin_server.rs
+++ b/sdk/rust/src/plugin_server.rs
@@ -23,12 +23,9 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream as RecvStream;
 use tonic::{transport::Server, Code, Request as Req, Response as Resp, Status, Streaming};
 
-/// Runs the Hipcheck plugin protocol based on the user's plugin definition.
+/// Runs the Hipcheck plugin protocol based on the user's implementation of the `Plugin` trait.
 ///
-/// The key idea is that this implements the gRPC mechanics and handles all
-/// the details of the query protocol, so that the user doesn't need to do
-/// anything more than define queries as asynchronous functions with associated
-/// input and output schemas.
+/// This struct implements the underlying gRPC protocol that is not exposed to the plugin author.
 pub struct PluginServer<P> {
 	plugin: Arc<P>,
 }
@@ -56,7 +53,7 @@ impl<P: Plugin> PluginServer<P> {
 	}
 }
 
-/// The result of running a query.
+/// The result of running a query, where the error is of the type `tonic::Status`.
 pub type QueryResult<T> = StdResult<T, Status>;
 
 #[tonic::async_trait]


### PR DESCRIPTION
Added and expanded API doc comments, renamed a couple of SDK `Error` enum variants for clarity.