### PR TITLE
feat: Adds operators for datetime and span policy expression primitives

### DIFF
--- a/hipcheck/src/policy_exprs/error.rs
+++ b/hipcheck/src/policy_exprs/error.rs
@@ -118,6 +118,9 @@ pub enum Error {
 		value: serde_json::Value,
 		context: serde_json::Value,
 	},
+
+	#[error("Datetime error: {0}")]
+	Datetime(String),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Resolves #401 

Adds comparison and basic arithmetic operators for `DateTime` and `Span` policy expression primitives.

To handle comparing `Spans` without erroring or needing to provide a datetime for each span, `Spans` must now not include years or months as units. `Spans` may include weeks as units, even though `jiff` normally has issues with comparing raw `Spans` with weeks, because we convert all weeks to seven 24-hour days during parsing.