### PR TITLE
chore (doc): Adds date and time information to Plugin RFD

### DIFF
--- a/hipcheck/src/policy_exprs/env.rs
+++ b/hipcheck/src/policy_exprs/env.rs
@@ -527,7 +527,7 @@ fn divz(env: &Env, args: &[Expr]) -> Result<Expr> {
 	binary_primitive_op(name, env, args, op)
 }
 
-// Finds the difference in time between two datetimes, in units of hours (chosen for comparision safety)
+// Finds the difference in time between two datetimes, in units no larger than hours (chosen for comparision safety)
 fn duration(env: &Env, args: &[Expr]) -> Result<Expr> {
 	let name = "duration";
 

--- a/hipcheck/src/policy_exprs/expr.rs
+++ b/hipcheck/src/policy_exprs/expr.rs
@@ -63,10 +63,10 @@ pub enum Primitive {
 
 	/// Span of time using the [jiff] crate, which uses a modified version of ISO8601.
 	///
-	/// Can include weeks, days, hours, minutes, and seconds (including decimal fractions of a second).
+	/// Can include weeks, days, hours, minutes, and seconds. The smallest provided unit of time (but not weeks or days) can have a decimal fraction.
 	/// While spans with months, years, or both are valid under IS08601 and supported by [jiff] in general, we do not allow them in Hipcheck policy expressions.
 	/// This is because spans greater than a day require additional zoned datetime information in [jiff] (to determine e.g. how many days are in a year or month)
-	/// before we can do time arithematic with them.
+	/// before we can do time arithmetic with them.
 	/// We *do* allows spans with weeks, even though [jiff] has similar issues with those units.
 	/// We take care of this by converting a week to a period of seven 24-hour days that [jiff] can handle in arithematic without zoned datetime information.
 	///
@@ -342,10 +342,10 @@ mod tests {
 
 	#[test]
 	fn parse_span() {
-		let input = "P2W4DT1H30M";
+		let input = "P2W4DT1H30.5M";
 		let result = parse(input).unwrap();
 
-		let raw_span: Span = "P18DT1H30M".parse().unwrap();
+		let raw_span: Span = "P18DT1H30.5M".parse().unwrap();
 		let expected = span(raw_span).into_expr();
 
 		assert_eq!(result, expected);

--- a/hipcheck/src/policy_exprs/token.rs
+++ b/hipcheck/src/policy_exprs/token.rs
@@ -46,7 +46,7 @@ pub enum Token {
 
 	// In the future this regex *could* be made more specific to reduce collision
 	// with Ident, or we could introduce a special prefix character like '@' or '#'
-	#[regex(r"PT?[0-9]+[a-zA-Z][^\s\)]*", lex_span)]
+	#[regex(r"PT?[0-9.]+[a-zA-Z][^\s\)]*", lex_span)]
 	Span(Box<Span>),
 
 	// Prioritize over span regex, which starts with a 'P'


### PR DESCRIPTION
Adds information about using `DateTime` and `Span` plugin primitives and their operations to RFD4. Changes some internal documentation and testing to be more explicit about what kinds of `Spans` are allowed.