### PR TITLE
chore: add hipcheck::target::Target schema to Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -100,11 +100,7 @@ rustls = { version = "0.23.10", default-features = false, features = [
 ] }
 rustls-native-certs = "0.8.0"
 salsa = "0.16.1"
-schemars = { version = "0.8.21", default-features = false, features = [
-    "derive",
-    "preserve_order",
-    "chrono",
-] }
+schemars = { version = "0.8.21", default-features = false, features = ["derive", "preserve_order", "chrono", "url"] }
 semver = "1.0.9"
 serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_derive = "1.0.137"
@@ -130,7 +126,7 @@ ureq = { version = "2.10.1", default-features = false, features = [
     "json",
     "tls",
 ] }
-url = { version = "2.5.1", features = ["serde"] }
+url = { version = "2.5.2", features = ["serde"] }
 walkdir = "2.5.0"
 which = { version = "6.0.3", default-features = false }
 xml-rs = "0.8.22"

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
+use schemars::JsonSchema;
 use serde::Serialize;
 use std::{
 	fmt,
@@ -9,7 +10,7 @@ use std::{
 };
 use url::Url;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct Target {
 	/// The original specifier provided by the user.
 	pub specifier: String,
@@ -24,18 +25,18 @@ pub struct Target {
 	pub package: Option<Package>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct RemoteGitRepo {
 	pub url: Url,
 	pub known_remote: Option<KnownRemote>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub enum KnownRemote {
 	GitHub { owner: String, repo: String },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct LocalGitRepo {
 	/// The path to the repo.
 	pub path: PathBuf,
@@ -43,7 +44,7 @@ pub struct LocalGitRepo {
 	/// The Git ref we're referring to.
 	pub git_ref: String,
 }
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct Package {
 	/// A package url for the package.
 	pub purl: Url,
@@ -66,13 +67,13 @@ impl Package {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct MavenPackage {
 	/// The Maven url
 	pub url: Url,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 // Maven as a possible host is ommitted because a MavenPackage is currently its own struct without a host field
 pub enum PackageHost {
 	Npm,
@@ -88,7 +89,7 @@ impl Display for PackageHost {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct Sbom {
 	/// The path to the SBOM file
 	pub path: PathBuf,
@@ -97,7 +98,7 @@ pub struct Sbom {
 	pub standard: SbomStandard,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub enum SbomStandard {
 	Spdx,
 	CycloneDX,

--- a/sdk/rust/schema/hipcheck_target_schema.json
+++ b/sdk/rust/schema/hipcheck_target_schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Target",
+  "type": "object",
+  "required": [
+    "local",
+    "specifier"
+  ],
+  "properties": {
+    "specifier": {
+      "description": "The original specifier provided by the user.",
+      "type": "string"
+    },
+    "local": {
+      "description": "The path to the local repository.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/LocalGitRepo"
+        }
+      ]
+    },
+    "remote": {
+      "description": "The url of the remote repository, if any.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RemoteGitRepo"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "package": {
+      "description": "The package associated with the target, if any.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Package"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "LocalGitRepo": {
+      "type": "object",
+      "required": [
+        "git_ref",
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "description": "The path to the repo.",
+          "type": "string"
+        },
+        "git_ref": {
+          "description": "The Git ref we're referring to.",
+          "type": "string"
+        }
+      }
+    },
+    "RemoteGitRepo": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "known_remote": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/KnownRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "KnownRemote": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "GitHub"
+          ],
+          "properties": {
+            "GitHub": {
+              "type": "object",
+              "required": [
+                "owner",
+                "repo"
+              ],
+              "properties": {
+                "owner": {
+                  "type": "string"
+                },
+                "repo": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Package": {
+      "type": "object",
+      "required": [
+        "host",
+        "name",
+        "purl",
+        "version"
+      ],
+      "properties": {
+        "purl": {
+          "description": "A package url for the package.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "description": "The package name",
+          "type": "string"
+        },
+        "version": {
+          "description": "The package version",
+          "type": "string"
+        },
+        "host": {
+          "description": "What host the package is from.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PackageHost"
+            }
+          ]
+        }
+      }
+    },
+    "PackageHost": {
+      "type": "string",
+      "enum": [
+        "Npm",
+        "PyPI"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Resolves #444 .

Add a `.json` file to the Rust SDK crate folder so that developers of top-level plugins that receive serialized `Target`s can see what they look like. 

This doesn't do anything like make the contents of the JSON file available as a const string in the SDK so it can be accessed programatically, maybe that's something to consider doing.