### PR TITLE
fix: policy expr type errors due to X.0 floating points in JSON being treated as ints

### DIFF
--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -231,7 +231,6 @@ pub fn start_plugins(
 	)?;
 
 	let current_arch = get_current_arch();
-	println!("CURRENT ARCH: {}", current_arch);
 
 	// retrieve, verify and extract all required plugins
 	let required_plugin_names = retrieve_plugins(&policy_file.plugins.0, plugin_cache)?;

--- a/hipcheck/src/policy_exprs/expr.rs
+++ b/hipcheck/src/policy_exprs/expr.rs
@@ -17,6 +17,9 @@ use nom::{
 use ordered_float::NotNan;
 use std::{fmt::Display, ops::Deref};
 
+#[cfg(test)]
+use jiff::civil::Date;
+
 /// A `deke` expression to evaluate.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expr {
@@ -318,8 +321,20 @@ mod tests {
 		let input = "2024-09-17T09:30:00-05";
 		let result = parse(input).unwrap();
 
-		let ts: Timestamp = "2024-09-17T09:30:00-05".parse().unwrap();
+		let ts: Timestamp = input.parse().unwrap();
 		let dt = Zoned::new(ts, TimeZone::UTC);
+		let expected = datetime(dt).into_expr();
+
+		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn parse_simple_datetime() {
+		let input = "2024-09-17";
+		let result = parse(input).unwrap();
+
+		let ts: Date = input.parse().unwrap();
+		let dt = ts.to_zoned(TimeZone::UTC).unwrap();
 		let expected = datetime(dt).into_expr();
 
 		assert_eq!(result, expected);
@@ -331,6 +346,17 @@ mod tests {
 		let result = parse(input).unwrap();
 
 		let raw_span: Span = "P18DT1H30M".parse().unwrap();
+		let expected = span(raw_span).into_expr();
+
+		assert_eq!(result, expected);
+	}
+
+	#[test]
+	fn parse_simple_span() {
+		let input = "P2w";
+		let result = parse(input).unwrap();
+
+		let raw_span: Span = "P14d".parse().unwrap();
 		let expected = span(raw_span).into_expr();
 
 		assert_eq!(result, expected);

--- a/hipcheck/src/policy_exprs/mod.rs
+++ b/hipcheck/src/policy_exprs/mod.rs
@@ -203,4 +203,37 @@ mod tests {
 			])
 		);
 	}
+
+	#[test]
+	fn eval_upcasted_int() {
+		let program_and_expected = vec![
+			("(lte 3 3.0)", Expr::Primitive(Primitive::Bool(true))),
+			(
+				"(add 3 5.5)",
+				Expr::Primitive(Primitive::Float(F64::new(8.5).unwrap())),
+			),
+		];
+		let context = Value::Null;
+		for (program, expected) in program_and_expected.into_iter() {
+			let result = Executor::std().parse_and_eval(program, &context).unwrap();
+			assert_eq!(result, expected);
+		}
+	}
+
+	#[test]
+	fn eval_datetime_span_add() {
+		let date = "2024-09-26";
+		let span = "P1w";
+		let eval_fmt = "(add {} {})";
+		let context = Value::Null;
+		let expected = parse("2024-10-03").unwrap();
+		let result1 = Executor::std()
+			.parse_and_eval(format!("(add {} {})", date, span).as_str(), &context)
+			.unwrap();
+		assert_eq!(expected, result1);
+		let result2 = Executor::std()
+			.parse_and_eval(format!("(add {} {})", span, date).as_str(), &context)
+			.unwrap();
+		assert_eq!(expected, result2);
+	}
 }


### PR DESCRIPTION
Resolves #449 .

Pernicious bug in policy expression code. JSON has only "Number" type, doesn't distinguish between float and int. When a float that ends in `.0` gets serialized then injected into a policy expression, it is treated as an integer. Our policy expression evaluation logic for arithmetic/comparison requires operands be `int + int` or `float + float`, so when this bug occurs we get a type error because we do `int + float`. 

This fix updates `binary_primitive_op` to detect when the operands are `int+float` or `float+int` and implicitly upcasts the `int` to a `float`. It also removes other type checking from `binary_primitive_op`, as it was bad design. For example, although we updated `fn add` to allow `DateTime + Span`, the type checking in `binary_primitive_op` did not allow this to occur and we had not tested to encounter this bug before.

Added tests to ensure int+float arithmetic/comparisons return floats, and ensure `(add datetime span)` does not error.

In a more correct AST design, we would do a first-pass eval of the AST and insert "cast" nodes around integer primitives to make them floats. This fix approach works but doesn't afford per-op control, highlighting the need for #387 .