### PR TITLE
fix: update target json desc from RootSchema to SchemaObject

### DIFF
--- a/sdk/rust/schema/hipcheck_target_schema.json
+++ b/sdk/rust/schema/hipcheck_target_schema.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Target",
   "type": "object",
   "required": [
     "local",
@@ -13,37 +11,6 @@
     },
     "local": {
       "description": "The path to the local repository.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/LocalGitRepo"
-        }
-      ]
-    },
-    "remote": {
-      "description": "The url of the remote repository, if any.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RemoteGitRepo"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "package": {
-      "description": "The package associated with the target, if any.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Package"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "LocalGitRepo": {
       "type": "object",
       "required": [
         "git_ref",
@@ -60,93 +27,103 @@
         }
       }
     },
-    "RemoteGitRepo": {
-      "type": "object",
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
-        "known_remote": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/KnownRemote"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
-    "KnownRemote": {
-      "oneOf": [
+    "remote": {
+      "description": "The url of the remote repository, if any.",
+      "anyOf": [
         {
           "type": "object",
           "required": [
-            "GitHub"
+            "url"
           ],
           "properties": {
-            "GitHub": {
-              "type": "object",
-              "required": [
-                "owner",
-                "repo"
-              ],
-              "properties": {
-                "owner": {
-                  "type": "string"
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "known_remote": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "GitHub"
+                      ],
+                      "properties": {
+                        "GitHub": {
+                          "type": "object",
+                          "required": [
+                            "owner",
+                            "repo"
+                          ],
+                          "properties": {
+                            "owner": {
+                              "type": "string"
+                            },
+                            "repo": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
                 },
-                "repo": {
-                  "type": "string"
+                {
+                  "type": "null"
                 }
-              }
+              ]
             }
-          },
-          "additionalProperties": false
+          }
+        },
+        {
+          "type": "null"
         }
       ]
     },
-    "Package": {
-      "type": "object",
-      "required": [
-        "host",
-        "name",
-        "purl",
-        "version"
-      ],
-      "properties": {
-        "purl": {
-          "description": "A package url for the package.",
-          "type": "string",
-          "format": "uri"
-        },
-        "name": {
-          "description": "The package name",
-          "type": "string"
-        },
-        "version": {
-          "description": "The package version",
-          "type": "string"
-        },
-        "host": {
-          "description": "What host the package is from.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/PackageHost"
+    "package": {
+      "description": "The package associated with the target, if any.",
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "host",
+            "name",
+            "purl",
+            "version"
+          ],
+          "properties": {
+            "purl": {
+              "description": "A package url for the package.",
+              "type": "string",
+              "format": "uri"
+            },
+            "name": {
+              "description": "The package name",
+              "type": "string"
+            },
+            "version": {
+              "description": "The package version",
+              "type": "string"
+            },
+            "host": {
+              "description": "What host the package is from.",
+              "allOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Npm",
+                    "PyPI"
+                  ]
+                }
+              ]
             }
-          ]
+          }
+        },
+        {
+          "type": "null"
         }
-      }
-    },
-    "PackageHost": {
-      "type": "string",
-      "enum": [
-        "Npm",
-        "PyPI"
       ]
     }
   }


### PR DESCRIPTION
Resolves #453 .

In the Issue, I suggested that we would need to switch our use of `schemars::SchemaObject` to `RootSchema`, because just emitting the `schema_for!(Target).schema` for `Target` results in a definition with `#ref`s to objects that are not included in the document. 

I couldn't find a way through `schemars` native to emit a `SchemaObject` from a RootSchema with all the refs replaces with the definitions themselves, so I manually edited the resulting `.json` file. I ensured that deserializing this to a `schemars::SchemaObject` still works. 