### PR TITLE
refactor PolicyExpr to use Visitor Pattern

### DIFF
--- a/hipcheck/src/policy_exprs/json_pointer.rs
+++ b/hipcheck/src/policy_exprs/json_pointer.rs
@@ -3,7 +3,7 @@
 use crate::policy_exprs::{
 	error,
 	error::{Error, Result},
-	expr::{Expr, Primitive},
+	expr::{Array, Expr, Primitive},
 };
 use ordered_float::NotNan;
 use regex::{Captures, Regex, RegexBuilder};
@@ -116,7 +116,7 @@ fn json_to_policy_expr(val: &Value, pointer: &str, context: &Value) -> Result<Ex
 				.collect::<Result<Vec<Primitive>>>()?;
 			// NOTE that no checking is done to confirm that all Primitives are the same type.
 			// That would be a type error in the Policy Expr language.
-			Ok(Expr::Array(primitives))
+			Ok(Array::new(primitives).into())
 		}
 		// Strings cannot (currently) be represented in the Policy Expr language.
 		Value::String(_) => Err(Error::JSONPointerUnrepresentableType {

--- a/hipcheck/src/policy_exprs/pass.rs
+++ b/hipcheck/src/policy_exprs/pass.rs
@@ -1,0 +1,63 @@
+use crate::policy_exprs::{
+	env::Env,
+	error::{Error, Result},
+	expr::*,
+};
+
+pub trait ExprVisitor<T> {
+	fn visit_primitive(&self, prim: &Primitive) -> T;
+	fn visit_array(&self, arr: &Array) -> T;
+	fn visit_function(&self, func: &Function) -> T;
+	fn visit_lambda(&self, func: &Lambda) -> T;
+	fn visit_json_pointer(&self, func: &JsonPointer) -> T;
+	fn visit_expr(&self, expr: &Expr) -> T {
+		match expr {
+			Expr::Primitive(a) => self.visit_primitive(a),
+			Expr::Array(a) => self.visit_array(a),
+			Expr::Function(a) => self.visit_function(a),
+			Expr::Lambda(a) => self.visit_lambda(a),
+			Expr::JsonPointer(a) => self.visit_json_pointer(a),
+		}
+	}
+	fn run(&self, expr: &Expr) -> T {
+		self.visit_expr(expr)
+	}
+}
+
+pub trait ExprMutator {
+	fn visit_primitive(&self, prim: Primitive) -> Result<Expr> {
+		Ok(prim.into())
+	}
+	fn visit_array(&self, arr: Array) -> Result<Expr> {
+		Ok(arr.into())
+	}
+	fn visit_function(&self, func: Function) -> Result<Expr> {
+		let mut func = func;
+		func.args = func
+			.args
+			.into_iter()
+			.map(|a| self.visit_expr(a))
+			.collect::<Result<Vec<Expr>>>()?;
+		Ok(func.into())
+	}
+	fn visit_lambda(&self, lamb: Lambda) -> Result<Expr> {
+		let mut lamb = lamb;
+		lamb.body = Box::new(self.visit_expr(*lamb.body.clone())?);
+		Ok(lamb.into())
+	}
+	fn visit_json_pointer(&self, jp: JsonPointer) -> Result<Expr> {
+		Ok(jp.into())
+	}
+	fn visit_expr(&self, expr: Expr) -> Result<Expr> {
+		match expr {
+			Expr::Primitive(a) => self.visit_primitive(a),
+			Expr::Array(a) => self.visit_array(a),
+			Expr::Function(a) => self.visit_function(a),
+			Expr::Lambda(a) => self.visit_lambda(a),
+			Expr::JsonPointer(a) => self.visit_json_pointer(a),
+		}
+	}
+	fn run(&self, expr: Expr) -> Result<Expr> {
+		self.visit_expr(expr)
+	}
+}


### PR DESCRIPTION
Resolves #457 .

This is also a portion of the proposed changes in #456 RFD8 .

1. Updates some `Expr` variants to have their own proper structs so we can have `visit_X` patterns on them
2. Add `Into<Expr>` for each Expr sub-type to make it easier to turn a proper struct into its `Expr` variant
3. Added `ExprVisitor` pattern
4. Implemented `ExprVisitor` to perform policy expr execution, replaced `pub(crate) eval()` func

Currently `ExprVisitor` is implemented on `Env<'_>`, but as is mentioned in the RFD, we might want other "visitors" on an Expr tree. In a subsequent PR as it becomes relevant, I recommend changing it so `Executor` implments `ExprVisitor` and the `env.rs` functions like `binary_primitive_op` are changed to take a `&Executor`. This way, additional structs that take an `Env` can be created to `impl ExprVisitor` to do different behavior.