### PR TITLE
feat(refactor): created plugin version of github api queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1037,6 +1037,25 @@ dependencies = [
  "log",
  "openssl-probe",
  "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "github_api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "graphql_client",
+ "hipcheck-sdk",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "ureq",
  "url",
 ]
 
@@ -2441,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "log",
  "once_cell",
@@ -2479,15 +2498,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "plugins/dummy_sha256_sdk",
     "sdk/rust",
     "hipcheck-sdk-macros",
+	"plugins/github_api",
 ]
 
 # Make sure Hipcheck is run with `cargo run`.

--- a/plugins/github_api/Cargo.toml
+++ b/plugins/github_api/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "github_api"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.89"
+clap = { version = "4.5.19", features = ["derive"] }
+graphql_client = "0.14.0"
+hipcheck-sdk = { version = "0.1.0", path = "../../sdk/rust", features = ["macros"] }
+log = "0.4.22"
+# Exactly matching the version of rustls used by ureq
+# Get rid of default features since we don't use the AWS backed crypto
+# provider (we use ring) and it breaks stuff on windows.
+rustls = { version = "0.23.10", default-features = false, features = [
+    "logging",
+    "std",
+    "tls12",
+    "ring",
+] }
+rustls-native-certs = "0.8.0"
+schemars = { version = "0.8.21", features = ["url"] }
+serde = "1.0.210"
+serde_json = "1.0.128"
+tokio = { version = "1.40.0", features = ["rt"] }
+ureq = { version = "2.10.1", default-features = false, features = [
+    "json",
+    "tls",
+] }
+url = { version = "2.5.2", features = ["serde"] }

--- a/plugins/github_api/src/code_search.rs
+++ b/plugins/github_api/src/code_search.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::authenticated_agent::AuthenticatedAgent;
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+const GH_API_V4_SEARCH: &str = "https://api.github.com/search/code";
+
+/// Make a request to the GitHub Code Search API.
+pub fn search_code_request(
+	agent: &AuthenticatedAgent<'_>,
+	repo: impl AsRef<String>,
+) -> Result<bool> {
+	// Example query will look like this:
+	//     https://api.github.com/search/code?q=github.com%20assimp%20assimp+in:file+filename:project.yaml+repo:google/oss-fuzz
+	//
+	// Logic based on these docs:
+	//     https://docs.github.com/en/search-github/searching-on-github/searching-code#considerations-for-code-search
+	//
+	// Breaking repo out in to more easily searchable string since full
+	// GitHub repo urls were not working for a few fuzzed urls.
+
+	let repo_query = repo
+		.as_ref()
+		.replace("https://", "")
+		.replace("http://", "")
+		.replace('/', "%20");
+
+	let sub_query = format!(
+		"{}+in:file+filename:project.yaml+repo:google/oss-fuzz",
+		repo_query
+	);
+
+	let query = format!("{}?q={}", GH_API_V4_SEARCH.to_owned(), sub_query);
+
+	// Make the get request.
+	let json = get_request(agent, query).map_err(|_| anyhow!("unable to query fuzzing info"))?;
+
+	match &json["total_count"].to_string().parse::<u64>() {
+		Ok(count) => Ok(count > &0),
+		_ => Err(anyhow!("unable to get fuzzing status")),
+	}
+}
+
+/// Get call using agent
+fn get_request(agent: &AuthenticatedAgent<'_>, query: String) -> Result<Value> {
+	let response = agent.get(&query).call()?.into_json()?;
+	Ok(response)
+}

--- a/plugins/github_api/src/data.rs
+++ b/plugins/github_api/src/data.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	code_search::search_code_request, graphql::get_all_reviews, types::GitHubPullRequest,
+	util::authenticated_agent::AuthenticatedAgent,
+};
+use anyhow::{Context, Result};
+use std::rc::Rc;
+
+pub struct GitHub<'a> {
+	owner: &'a str,
+	repo: &'a str,
+	agent: AuthenticatedAgent<'a>,
+}
+
+impl<'a> GitHub<'a> {
+	pub fn new(owner: &'a str, repo: &'a str, token: &'a str) -> Result<GitHub<'a>> {
+		Ok(GitHub {
+			owner,
+			repo,
+			agent: AuthenticatedAgent::new(token),
+		})
+	}
+
+	pub fn fuzz_check(&self, repo_uri: Rc<String>) -> Result<bool> {
+		search_code_request(&self.agent, repo_uri).context("unable to search fuzzing information; please check the HC_GITHUB_TOKEN system environment variable")
+	}
+
+	pub fn get_reviews_for_pr(&self) -> Result<Vec<GitHubPullRequest>> {
+		get_all_reviews(&self.agent, self.owner, self.repo)
+	}
+}

--- a/plugins/github_api/src/gh_query.graphql
+++ b/plugins/github_api/src/gh_query.graphql
@@ -1,0 +1,60 @@
+
+query Reviews($owner:String!, $repo:String!, $cursor:String) {
+    repository(owner: $owner, name: $repo) {
+        pullRequests(first: 100, after: $cursor, states: MERGED) {
+            pageInfo {
+                hasNextPage,
+                endCursor
+            },
+            nodes {
+                number,
+                reviews(first: 100, states: APPROVED) {
+                    nodes {
+                        databaseId
+                    }
+                }
+            }
+        }
+    }
+}
+
+query Review($owner:String!, $repo:String!, $number:Int!, $cursor:String) {
+    repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+            commits(first: 100, after: $cursor) {
+                pageInfo {
+                    hasNextPage,
+                    endCursor
+                }
+                nodes {
+                    commit {
+                        oid,
+                        author {
+                            name,
+                            email
+                        }
+                        authoredDate,
+                        committer {
+                            name,
+                            email
+                        },
+                        committedDate,
+                        signature {
+                            isValid,
+                            signature,
+                            signer {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+            number,
+            reviews {
+                nodes {
+                    databaseId
+                }
+            }
+        }
+    }
+}

--- a/plugins/github_api/src/gh_schema.graphql
+++ b/plugins/github_api/src/gh_schema.graphql
@@ -1,0 +1,318 @@
+
+schema {
+  query: Query
+}
+
+"""
+The query root of GitHub's GraphQL interface.
+"""
+type Query {
+  """
+  Lookup a given repository by the owner and repository name.
+  """
+  repository(
+    """
+    The name of the repository
+    """
+    name: String!
+
+    """
+    The login field of a user or organization
+    """
+    owner: String!
+  ): Repository
+}
+
+"""
+A repository contains the content for a project.
+"""
+type Repository {  """
+  A list of pull requests that have been opened in the repository.
+  """
+  pullRequests(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    A list of states to filter the pull requests by.
+    """
+    states: [PullRequestState!]
+  ): PullRequestConnection!
+
+  # urlRequests(
+  #   url: URI
+  # ): PullRequestConnection!
+  pullRequest(
+    number: Int
+  ): PullRequest
+}
+
+"""
+The connection type for PullRequest.
+"""
+type PullRequestConnection {
+  """
+  A list of nodes.
+  """
+  nodes: [PullRequest]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+A repository pull request.
+"""
+type PullRequest {
+  """
+  A list of commits present in this pull request's head branch not present in the base branch.
+  """
+  commits(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+  ): PullRequestCommitConnection
+  
+  """
+  Identifies the pull request number.
+  """
+  number: Int!
+
+  url: URI!
+  """
+  A list of reviews associated with the pull request.
+  """
+  reviews(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    A list of states to filter the reviews.
+    """
+    states: [PullRequestReviewState!]
+  ): PullRequestReviewConnection
+
+  #link: String
+}
+
+"""
+The possible states of a pull request.
+"""
+enum PullRequestState {
+  """
+  A pull request that has been closed without being merged.
+  """
+  CLOSED
+
+  """
+  A pull request that has been closed by being merged.
+  """
+  MERGED
+
+  """
+  A pull request that is still open.
+  """
+  OPEN
+}
+
+"""
+The connection type for PullRequestReview.
+"""
+type PullRequestReviewConnection {
+  """
+  A list of nodes.
+  """
+  nodes: [PullRequestReview]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+A review object for a given pull request.
+"""
+type PullRequestReview {
+  """
+  Identifies the primary key from the database.
+  """
+  databaseId: Int
+}
+
+"""
+The possible states of a pull request review.
+"""
+enum PullRequestReviewState {
+  """
+  A review allowing the pull request to merge.
+  """
+  APPROVED
+
+  """
+  A review blocking the pull request from merging.
+  """
+  CHANGES_REQUESTED
+
+  """
+  An informational review.
+  """
+  COMMENTED
+
+  """
+  A review that has been dismissed.
+  """
+  DISMISSED
+
+  """
+  A review that has not yet been submitted.
+  """
+  PENDING
+}
+
+"""
+The connection type for PullRequestCommit.
+"""
+type PullRequestCommitConnection {
+    """
+  A list of nodes.
+  """
+  nodes: [PullRequestCommit]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+Represents a Git commit part of a pull request.
+"""
+type PullRequestCommit {
+  """
+  The Git commit object.
+  """
+  commit: Commit!
+}
+
+"""
+Represents a Git commit.
+"""
+type Commit {
+  """
+  Authorship details of the commit.
+  """
+  author: GitActor
+
+  """
+  The datetime when this commit was authored.
+  """
+  authoredDate: String!
+
+  """
+  The datetime when this commit was committed.
+  """
+  committedDate: String!
+
+  """
+  Committer details of the commit.
+  """
+  committer: GitActor
+
+  """
+  The Git object ID.
+  """
+  oid: String!
+  
+  """
+  Commit signing information, if present.
+  """
+  signature: GitSignature
+}
+
+"""
+Represents an actor in a Git commit (ie. an author or committer).
+"""
+type GitActor {
+  """
+  The email in the Git commit.
+  """
+  email: String
+
+  """
+  The name in the Git commit.
+  """
+  name: String
+}
+
+"""
+Information about a signature (GPG or S/MIME) on a Commit or Tag.
+"""
+type GitSignature {
+  """
+  True if the signature is valid and verified by GitHub.
+  """
+  isValid: Boolean!
+
+  """
+  ASCII-armored signature header from object.
+  """
+  signature: String!
+
+  """
+  GitHub user corresponding to the email signing this commit.
+  """
+  signer: User
+}
+
+"""
+A user is an individual's account on GitHub that owns repositories and can make new content.
+"""
+type User{
+  """
+  The user's public profile name.
+  """
+  name: String
+}
+
+"""
+Information about pagination in a connection.
+"""
+type PageInfo {
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+}
+
+"""
+Scalar type for URLs
+"""
+scalar URI

--- a/plugins/github_api/src/graphql.rs
+++ b/plugins/github_api/src/graphql.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryInto;
+
+use self::reviews::{ResponseData, ReviewsRepositoryPullRequestsNodes as RawPull, Variables};
+use crate::{types::*, util::authenticated_agent::AuthenticatedAgent};
+use anyhow::{anyhow, Result};
+use graphql_client::{GraphQLQuery, QueryBody, Response};
+use serde_json::{from_value as from_json_value, to_value as to_json_value};
+
+/// The URL of the GitHub GraphQL API.
+const GH_API_V4: &str = "https://api.github.com/graphql";
+
+/// Defines the query being made against the GitHub API.
+#[derive(GraphQLQuery)]
+#[graphql(
+	schema_path = "src/gh_schema.graphql",
+	query_path = "src/gh_query.graphql",
+	response_derives = "Debug"
+)]
+pub struct Reviews;
+
+/// Query the GitHub GraphQL API for reviews performed on PRs for a repo.
+pub fn get_all_reviews(
+	agent: &AuthenticatedAgent<'_>,
+	owner: &str,
+	repo: &str,
+) -> Result<Vec<GitHubPullRequest>> {
+	let vars = Vars::new(owner, repo);
+
+	let mut data = Vec::new();
+	let mut cursor = None;
+
+	// Keep making requests so long as there's cursor data indicating more
+	// requests need to be made.
+	while let new_cursor @ Some(_) = get_reviews(agent, vars.with_cursor(cursor), &mut data)? {
+		cursor = new_cursor;
+	}
+
+	Ok(data)
+}
+
+/// Convenience struct for creating the `Variables` struct needed for a query.
+struct Vars<'a> {
+	owner: &'a str,
+	repo: &'a str,
+}
+
+impl<'a> Vars<'a> {
+	/// Construct a new `Vars` for the given owner and repo.
+	fn new(owner: &'a str, repo: &'a str) -> Vars<'a> {
+		Vars { owner, repo }
+	}
+
+	/// Generate `Variables` with the given cursor.
+	fn with_cursor(&self, cursor: Option<String>) -> Variables {
+		Variables {
+			owner: self.owner.to_owned(),
+			repo: self.repo.to_owned(),
+			cursor,
+		}
+	}
+}
+
+/// Convenient shorthand for a cursor from the GitHub API.
+type Cursor = Option<String>;
+
+/// Query the GitHub GraphQL API for reviews performed on PRs for a repo.
+fn get_reviews(
+	agent: &AuthenticatedAgent<'_>,
+	variables: Variables,
+	data: &mut Vec<GitHubPullRequest>,
+) -> Result<Cursor> {
+	// Setup the query.
+	let query = Reviews::build_query(variables);
+
+	// Make the request.
+	let body = make_request(agent, query)?;
+
+	// Get the cursor, if there is one.
+	let cursor = get_cursor(&body);
+
+	// Process and collect all the PRs.
+	data.extend(get_prs(body)?.into_iter().map(process_pr));
+
+	Ok(cursor)
+}
+
+/// Make a request to the GitHub API.
+fn make_request(
+	agent: &AuthenticatedAgent<'_>,
+	query: QueryBody<Variables>,
+) -> Result<Response<ResponseData>> {
+	let response = agent.post(GH_API_V4).send_json(to_json_value(query)?)?;
+	if response.status() == 200 {
+		return Ok(from_json_value(response.into_json()?)?);
+	}
+	Err(anyhow!(
+		"request to GitHub API returned the following HTTP status: {} {}",
+		response.status(),
+		response.status_text()
+	))
+}
+
+/// Get the cursor, if there is one.
+fn get_cursor(body: &Response<ResponseData>) -> Cursor {
+	let page_info = &body
+		.data
+		.as_ref()?
+		.repository
+		.as_ref()?
+		.pull_requests
+		.page_info;
+
+	if page_info.has_next_page {
+		page_info.end_cursor.clone()
+	} else {
+		None
+	}
+}
+
+/// Extract any PRs from the GitHub API response data.
+fn get_prs(body: Response<ResponseData>) -> Result<Vec<RawPull>> {
+	// Get the repo info from the response.
+	let prs = body
+		.data
+		.ok_or_else(|| anyhow!("missing response data from GitHub"))?
+		.repository
+		.ok_or_else(|| anyhow!("repository not found on GitHub"))?
+		.pull_requests
+		.nodes;
+
+	match prs {
+		None => Ok(Vec::new()),
+		// Convert Vec<Option<_>> into Option<Vec<_>>.
+		Some(prs) => match prs.into_iter().collect() {
+			None => Ok(Vec::new()),
+			Some(prs) => Ok(prs),
+		},
+	}
+}
+
+/// Convert a single RawPull to a GitHubPullRequest
+fn process_pr(pr: RawPull) -> GitHubPullRequest {
+	let number: u64 = pr.number.try_into().unwrap();
+	let reviews: u64 = match pr.reviews {
+		None => 0,
+		Some(reviews) => match reviews.nodes {
+			None => 0,
+			Some(reviews) => reviews.len(),
+		},
+	}
+	.try_into()
+	.unwrap();
+
+	GitHubPullRequest { number, reviews }
+}

--- a/plugins/github_api/src/main.rs
+++ b/plugins/github_api/src/main.rs
@@ -1,0 +1,159 @@
+mod code_search;
+mod data;
+mod graphql;
+mod types;
+mod util;
+
+use crate::data::GitHub;
+use clap::Parser;
+use hipcheck_sdk::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+use std::result::Result as StdResult;
+use std::sync::OnceLock;
+
+struct Config {
+	pub api_token: String,
+}
+
+#[derive(Deserialize)]
+struct RawConfig {
+	api_token_var: Option<String>,
+}
+
+impl TryFrom<RawConfig> for Config {
+	type Error = ConfigError;
+	fn try_from(value: RawConfig) -> StdResult<Config, ConfigError> {
+		if let Some(atv) = value.api_token_var {
+			let api_token =
+				std::env::var(atv.as_str()).map_err(|_e| ConfigError::InvalidConfigValue {
+					field_name: "api_token_var".to_owned(),
+					value: atv,
+					reason: "could not find an env var with that name".to_owned(),
+				})?;
+			Ok(Config { api_token })
+		} else {
+			Err(ConfigError::MissingRequiredConfig {
+				field_name: "api_token_var".to_owned(),
+				field_type: "name of env var containing GitHub API token".to_owned(),
+				possible_values: vec![],
+			})
+		}
+	}
+}
+
+static CONFIG: OnceLock<Config> = OnceLock::new();
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct PullRequest {
+	pub id: u64,
+	pub reviews: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct RemoteGitRepo {
+	pub url: url::Url,
+	pub known_remote: Option<KnownRemote>,
+}
+
+fn get_github_agent<'a>(owner: &'a str, repo: &'a str) -> Result<GitHub<'a>> {
+	GitHub::new(
+		owner,
+		repo,
+		CONFIG
+			.get()
+			.ok_or_else(|| {
+				log::error!("tried to access config before set by Hipcheck core!");
+				Error::UnspecifiedQueryState
+			})?
+			.api_token
+			.as_str(),
+	)
+	.map_err(|e| {
+		log::error!("{}", e);
+		Error::UnspecifiedQueryState
+	})
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum KnownRemote {
+	GitHub { owner: String, repo: String },
+}
+
+#[query]
+async fn pr_reviews(_engine: &mut PluginEngine, key: KnownRemote) -> Result<Vec<PullRequest>> {
+	let (owner, repo) = match &key {
+		KnownRemote::GitHub { owner, repo } => (owner, repo),
+	};
+	let results = get_github_agent(owner, repo)?
+		.get_reviews_for_pr()
+		.map_err(|e| {
+			log::error!("{}", e);
+			Error::UnspecifiedQueryState
+		})?
+		.into_iter()
+		.map(|pr| PullRequest {
+			id: pr.number,
+			reviews: pr.reviews,
+		})
+		.collect();
+
+	Ok(results)
+}
+
+#[query(default)]
+async fn has_fuzz(_engine: &mut PluginEngine, key: RemoteGitRepo) -> Result<bool> {
+	let (owner, repo) = match &key.known_remote {
+		Some(KnownRemote::GitHub { owner, repo }) => (owner.as_str(), repo.as_str()),
+		None => ("", ""),
+	};
+	let url = Rc::new(key.url.to_string());
+	get_github_agent(owner, repo)?.fuzz_check(url).map_err(|e| {
+		log::error!("{}", e);
+		Error::UnspecifiedQueryState
+	})
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[derive(Clone, Debug)]
+struct GitlabAPIPlugin {}
+
+impl Plugin for GitlabAPIPlugin {
+	const PUBLISHER: &'static str = "mitre";
+	const NAME: &'static str = "gitlab_api";
+
+	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
+		let conf: Config = serde_json::from_value::<RawConfig>(config)
+			.map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?
+			.try_into()?;
+		CONFIG.set(conf).map_err(|_e| ConfigError::Unspecified {
+			message: "config was already set".to_owned(),
+		})
+	}
+
+	fn default_policy_expr(&self) -> Result<String> {
+		Ok("".to_owned())
+	}
+
+	fn explain_default_query(&self) -> Result<Option<String>> {
+		Ok(None)
+	}
+
+	queries! {}
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(GitlabAPIPlugin {})
+		.listen(args.port)
+		.await
+}

--- a/plugins/github_api/src/types.rs
+++ b/plugins/github_api/src/types.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubPullRequest {
+	pub number: u64,
+	pub reviews: u64,
+}

--- a/plugins/github_api/src/util/agent.rs
+++ b/plugins/github_api/src/util/agent.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Globally defined agent containing system TLS Certs.
+
+use rustls::{ClientConfig, RootCertStore};
+use std::sync::{Arc, OnceLock};
+use ureq::{Agent, AgentBuilder};
+
+/// Global static holding the agent with the appropriate TLS certs.
+static AGENT: OnceLock<Agent> = OnceLock::new();
+
+/// Get or initialize the global static agent used in making http(s) requests for hipcheck.
+///
+/// # Panics
+/// - If native certs cannot be loaded the first time this function is called.
+pub fn agent() -> &'static Agent {
+	AGENT.get_or_init(|| {
+		// Retrieve system certs
+		let mut roots = RootCertStore::empty();
+		let native_certs =
+			rustls_native_certs::load_native_certs().expect("should load native certs");
+		roots.add_parsable_certificates(native_certs);
+
+		// Add certs to connection configuration
+		let tls_config = ClientConfig::builder()
+			.with_root_certificates(roots)
+			.with_no_client_auth();
+
+		// Construct agent
+		AgentBuilder::new().tls_config(Arc::new(tls_config)).build()
+	})
+}

--- a/plugins/github_api/src/util/authenticated_agent.rs
+++ b/plugins/github_api/src/util/authenticated_agent.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Defines an authenticated [`Agent`] type that adds token auth to all requests.
+
+use crate::util::{agent, redacted::Redacted};
+use ureq::{Agent, Request};
+
+/// An [`Agent`] which authenticates requests with token auth.
+///
+/// This wrapper is used to work around the fact that `ureq` removed functionality
+/// to do this as part of the [`Agent`] type directly.
+pub struct AuthenticatedAgent<'token> {
+	/// The agent used to make the request.
+	agent: &'static Agent,
+
+	/// The token to use with each request.
+	token: Redacted<&'token str>,
+}
+
+impl<'token> AuthenticatedAgent<'token> {
+	/// Construct a new authenticated agent.
+	pub fn new(token: &'token str) -> AuthenticatedAgent<'token> {
+		AuthenticatedAgent {
+			agent: agent::agent(),
+			token: Redacted::new(token),
+		}
+	}
+
+	/// Make an authenticated GET request.
+	pub fn get(&self, path: &str) -> Request {
+		self.agent.get(path).token_auth(self.token.as_ref())
+	}
+
+	/// Make an authenticated POST request.
+	pub fn post(&self, path: &str) -> Request {
+		self.agent.post(path).token_auth(self.token.as_ref())
+	}
+}
+
+/// The key to use for the authorization HTTP header.
+const AUTH_KEY: &str = "Authorization";
+
+/// Extension trait to add a convenient "token auth" method.
+trait TokenAuth {
+	/// Sets a token authentication header on a request.
+	fn token_auth(self, token: &str) -> Self;
+}
+
+impl TokenAuth for Request {
+	fn token_auth(self, token: &str) -> Self {
+		self.set(AUTH_KEY, &format!("token {}", token))
+	}
+}

--- a/plugins/github_api/src/util/mod.rs
+++ b/plugins/github_api/src/util/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod agent;
+pub mod authenticated_agent;
+pub mod redacted;

--- a/plugins/github_api/src/util/redacted.rs
+++ b/plugins/github_api/src/util/redacted.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Utility type for hiding data from the user when printed in a debug message.
+
+use std::fmt::{Debug, Formatter, Result as FmtResult};
+
+/// Helper container to ensure a value isn't printed.
+pub struct Redacted<T>(T);
+
+impl<T> Redacted<T> {
+	/// Construct a new redacted value.
+	pub fn new(val: T) -> Redacted<T> {
+		Redacted(val)
+	}
+}
+
+impl<T> AsRef<T> for Redacted<T> {
+	fn as_ref(&self) -> &T {
+		&self.0
+	}
+}
+
+impl<T> AsMut<T> for Redacted<T> {
+	fn as_mut(&mut self) -> &mut T {
+		&mut self.0
+	}
+}
+
+impl<T> Debug for Redacted<T> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+		write!(f, "<redacted>")
+	}
+}


### PR DESCRIPTION
Resolves #474 .

I plan to continue @patrickjcasey 's work next to make it easier to test these API endpoints.

Aside from the content of `main.rs`, this is mostly just copying extant code from `hipcheck/src/data/{mod.rs, github::*}`