### PR TITLE
feat: add "mock_engine" feature to SDK to allow offline query testing

### DIFF
--- a/plugins/dummy_rand_data_sdk/Cargo.toml
+++ b/plugins/dummy_rand_data_sdk/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [dependencies]
 anyhow = "1.0.87"
 clap = { version = "4.5.18", features = ["derive"] }
-hipcheck-sdk = { path = "../../sdk/rust" }
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros"] }
 rand = "0.8.5"
 tokio = { version = "1.40.0", features = ["rt"] }
+
+[dev-dependencies]
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros", "mock_engine"] }

--- a/plugins/dummy_rand_data_sdk/schema/query_schema_get_rand.json
+++ b/plugins/dummy_rand_data_sdk/schema/query_schema_get_rand.json
@@ -1,3 +1,0 @@
-{
-    "type": "integer"
-}

--- a/plugins/dummy_rand_data_sdk/src/main.rs
+++ b/plugins/dummy_rand_data_sdk/src/main.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use clap::Parser;
 use hipcheck_sdk::prelude::*;
-
-static GET_RAND_KEY_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");
-static GET_RAND_OUTPUT_SCHEMA: &str = include_str!("../schema/query_schema_get_rand.json");
+#[cfg(test)]
+use std::result::Result as StdResult;
 
 fn reduce(input: u64) -> u64 {
 	input % 7
@@ -23,50 +21,23 @@ fn reduce(input: u64) -> u64 {
 #[derive(Clone, Debug)]
 struct RandDataPlugin;
 
-#[async_trait]
-impl Query for RandDataPlugin {
-	fn input_schema(&self) -> JsonSchema {
-		from_str(GET_RAND_KEY_SCHEMA).unwrap()
-	}
+#[query(default = false)]
+async fn rand_data(engine: &mut PluginEngine, size: u64) -> Result<u64> {
+	let reduced_num = reduce(size);
 
-	fn output_schema(&self) -> JsonSchema {
-		from_str(GET_RAND_OUTPUT_SCHEMA).unwrap()
-	}
+	let value = engine
+		.query("dummy/sha256/sha256", vec![reduced_num])
+		.await?;
 
-	async fn run(
-		&self,
-		engine: &mut PluginEngine,
-		input: Value,
-	) -> hipcheck_sdk::error::Result<Value> {
-		let Value::Number(num_size) = input else {
-			return Err(Error::UnexpectedPluginQueryInputFormat);
-		};
+	let Value::Array(mut sha256) = value else {
+		return Err(Error::UnexpectedPluginQueryInputFormat);
+	};
 
-		let Some(size) = num_size.as_u64() else {
-			return Err(Error::UnexpectedPluginQueryInputFormat);
-		};
+	let Value::Number(num) = sha256.pop().unwrap() else {
+		return Err(Error::UnexpectedPluginQueryInputFormat);
+	};
 
-		let reduced_num = reduce(size);
-
-		let value = engine
-			.query("dummy/sha256/sha256", vec![reduced_num])
-			.await?;
-
-		let Value::Array(mut sha256) = value else {
-			return Err(Error::UnexpectedPluginQueryInputFormat);
-		};
-
-		let Value::Number(num) = sha256.pop().unwrap() else {
-			return Err(Error::UnexpectedPluginQueryInputFormat);
-		};
-
-		match num.as_u64() {
-			Some(val) => return Ok(Value::Number(val.into())),
-			None => {
-				return Err(Error::UnexpectedPluginQueryInputFormat);
-			}
-		}
-	}
+	num.as_u64().ok_or(Error::UnexpectedPluginQueryOutputFormat)
 }
 
 impl Plugin for RandDataPlugin {
@@ -88,13 +59,7 @@ impl Plugin for RandDataPlugin {
 		Ok(Some("generate random data".to_owned()))
 	}
 
-	fn queries(&self) -> impl Iterator<Item = hipcheck_sdk::NamedQuery> {
-		vec![NamedQuery {
-			name: "rand_data",
-			inner: Box::new(RandDataPlugin),
-		}]
-		.into_iter()
-	}
+	queries! {}
 }
 
 #[derive(Parser, Debug)]
@@ -104,9 +69,27 @@ struct Args {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), hipcheck_sdk::error::Error> {
+async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
 	PluginServer::register(RandDataPlugin)
 		.listen(args.port)
 		.await
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	fn mock_responses() -> StdResult<MockResponses, Error> {
+		// when calling into query 1, Value::Array(vec![1]) gets passed to `sha256`, lets assume it returns 1
+		Ok(MockResponses::new().insert("dummy/sha256/sha256", vec![1], Ok(vec![1]))?)
+	}
+
+	#[tokio::test]
+	async fn test_sha256() {
+		let mut engine = PluginEngine::mock(mock_responses().unwrap());
+		let output = rand_data(&mut engine, 8).await;
+		// 8 % 7 = 1
+		assert!(matches!(output, Ok(1)));
+	}
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -22,4 +22,5 @@ anyhow = "1.0.86"
 tonic-build = "0.12.1"
 
 [features]
-macros = ["hipcheck-sdk-macros"]
+macros = ["dep:hipcheck-sdk-macros"]
+mock_engine = []

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -17,6 +17,7 @@ mod proto {
 }
 
 pub mod error;
+mod mock;
 pub mod plugin_engine;
 pub mod plugin_server;
 
@@ -31,6 +32,9 @@ pub mod prelude {
 	// Re-export macros
 	#[cfg(feature = "macros")]
 	pub use hipcheck_sdk_macros::{queries, query};
+
+	#[cfg(feature = "mock_engine")]
+	pub use crate::mock::MockResponses;
 }
 
 /// re-export of user-facing third-party dependencies
@@ -45,7 +49,7 @@ pub mod deps {
 /// endpoint as the "default", hence why the `query` field is of type Option. QueryTarget
 /// implements `FromStr`, taking strings of the format `"publisher/plugin[/query]"` where the
 /// bracketed substring is optional.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryTarget {
 	pub publisher: String,
 	pub plugin: String,

--- a/sdk/rust/src/mock.rs
+++ b/sdk/rust/src/mock.rs
@@ -1,0 +1,40 @@
+use crate::{JsonValue, QueryTarget, Result};
+use std::collections::HashMap;
+
+pub struct MockResponses(pub(crate) HashMap<(QueryTarget, JsonValue), Result<JsonValue>>);
+
+impl MockResponses {
+	pub fn new() -> Self {
+		Self(HashMap::new())
+	}
+}
+
+#[cfg(feature = "mock_engine")]
+impl MockResponses {
+	fn inner_insert(
+		mut self,
+		query_target: QueryTarget,
+		query_value: JsonValue,
+		query_response: Result<JsonValue>,
+	) -> Result<Self> {
+		self.0.insert((query_target, query_value), query_response);
+		Ok(self)
+	}
+
+	pub fn insert<T, V, W>(
+		self,
+		query_target: T,
+		query_value: V,
+		query_response: Result<W>,
+	) -> Result<Self>
+	where
+		T: TryInto<QueryTarget, Error: Into<crate::Error>>,
+		V: Into<JsonValue>,
+		W: Into<JsonValue>,
+	{
+		let query_target: QueryTarget = query_target.try_into().map_err(|e| e.into())?;
+		let query_value: JsonValue = query_value.into();
+		let query_response = query_response.map(|v| v.into());
+		self.inner_insert(query_target, query_value, query_response)
+	}
+}


### PR DESCRIPTION
Resolves #431 .

Adds a feature flag to the Rust SDK called `"mock_engine"` that gates `PluginEngine` functionality and some imports. 

Adds a field to the `PluginEngine` called `mock_responses` that contains a lookup table. When `query()` is called, if the `"mock_engine"` feature is enabled, it will use that table instead of querying out to the Hipcheck core. This allows us to test query logic without spinning up a whole Hipcheck analysis. 

The SDK version of the `rand_data` plugin is updated to use the SDK macro system, and a test case has been added to demonstrate how plugins can be tested locally with `mock_responses`.

The `cfg` compiler flags have been carefully applied to ensure no "unused" warnings whether running with `"mock_engine"` or not.

I've temporarily left the commits split between what @patrickjcasey had done before he went on leave and what I have since added.