### PR TITLE
feat(refactor): Created plugin version of git queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "git_sdk"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hipcheck-sdk",
+ "jiff",
+ "log",
+ "nom",
+ "once_cell",
+ "schemars",
+ "semver",
+ "serde",
+ "tokio",
+ "which",
+]
+
+[[package]]
 name = "github_api"
 version = "0.1.0"
 dependencies = [
@@ -1571,6 +1589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
 dependencies = [
  "jiff-tzdb-platform",
+ "serde",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ members = [
     "plugins/dummy_sha256_sdk",
     "sdk/rust",
     "hipcheck-sdk-macros",
-    "plugins/github_api",
+    "plugins/git",
+	"plugins/github_api",
 ]
 
 # Make sure Hipcheck is run with `cargo run`.

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "git_sdk"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.89"
+clap = { version = "4.5.18", features = ["derive"] }
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros"]}
+jiff = { version = "0.1.13", features = ["serde"] }
+log = "0.4.22"
+nom = "7.1.3"
+once_cell = "1.10.0"
+schemars = { version = "0.8.21", features = ["url"] }
+semver = "1.0.9"
+serde = { version = "1.0.210", features = ["derive", "rc"] }
+tokio = { version = "1.40.0", features = ["rt"] }
+which = { version = "6.0.3", default-features = false }

--- a/plugins/git/src/data.rs
+++ b/plugins/git/src/data.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{
+	fmt::{self, Display, Formatter},
+	hash::Hash,
+	sync::Arc,
+};
+
+/// Commits as they come directly out of `git log`.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct RawCommit {
+	pub hash: String,
+
+	pub author: Contributor,
+	pub written_on: Result<String, String>,
+
+	pub committer: Contributor,
+	pub committed_on: Result<String, String>,
+}
+
+/// Commits as understood in Hipcheck's data model.
+/// The `written_on` and `committed_on` datetime fields contain Strings that are created from `jiff:Timestamps`.
+/// Because `Timestamp` does not `impl JsonSchema`, we display the datetimes as Strings for passing out of this plugin.
+/// Other plugins that expect a `Timestamp`` should parse the provided Strings into `Timestamps` as needed.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
+pub struct Commit {
+	pub hash: String,
+
+	pub written_on: Result<String, String>,
+
+	pub committed_on: Result<String, String>,
+}
+
+impl Display for Commit {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "{}", self.hash)
+	}
+}
+
+/// Authors or committers of a commit.
+#[derive(
+	Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash, PartialOrd, Ord, JsonSchema,
+)]
+pub struct Contributor {
+	pub name: String,
+	pub email: String,
+}
+
+impl Display for Contributor {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "{} <{}>", self.name, self.email)
+	}
+}
+
+/// "Join struct" for commits and contributors.
+#[derive(Debug, PartialEq, Eq, Serialize, Clone)]
+pub struct CommitContributor {
+	// Index of commit cache
+	pub commit_id: usize,
+	// Indices of contributor cache
+	pub author_id: usize,
+	pub committer_id: usize,
+}
+
+/// Temporary data structure for looking up the contributors of a commit
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, JsonSchema)]
+pub struct CommitContributorView {
+	pub commit: Commit,
+	pub author: Contributor,
+	pub committer: Contributor,
+}
+
+/// Temporary data structure for looking up the commits associated with a contributor
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, JsonSchema)]
+pub struct ContributorView {
+	pub contributor: Contributor,
+	pub commits: Vec<Commit>,
+}
+
+/// View into commits and diffs joined together.
+#[derive(Debug, Serialize, PartialEq, Eq, JsonSchema)]
+pub struct CommitDiff {
+	pub commit: Commit,
+	pub diff: Diff,
+}
+
+impl Display for CommitDiff {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(
+			f,
+			"{} +{} -{}",
+			self.commit,
+			self.diff
+				.additions
+				.map(|n| n.to_string())
+				.as_deref()
+				.unwrap_or("<unknown>"),
+			self.diff
+				.deletions
+				.map(|n| n.to_string())
+				.as_deref()
+				.unwrap_or("<unknown>")
+		)
+	}
+}
+
+/// A set of changes in a commit.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+pub struct Diff {
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub file_diffs: Vec<FileDiff>,
+}
+
+/// A set of changes to a specific file in a commit.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+pub struct FileDiff {
+	pub file_name: Arc<String>,
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub patch: String,
+}

--- a/plugins/git/src/main.rs
+++ b/plugins/git/src/main.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+mod data;
+mod parse;
+mod util;
+
+use crate::{
+	data::{
+		Commit, CommitContributor, CommitContributorView, CommitDiff, Contributor, ContributorView,
+		Diff,
+	},
+	util::git_command::{get_commits, get_commits_from_date, get_diffs},
+};
+use clap::Parser;
+use hipcheck_sdk::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// A locally stored git repo, with optional additional details
+/// The details will vary based on the query (e.g. a date, a committer e-mail address, a commit hash)
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GitRepo {
+	/// The path to the repo.
+	pub path: PathBuf,
+
+	/// The Git ref we're referring to.
+	pub git_ref: String,
+
+	/// Optional additional information for the query
+	pub details: Option<String>,
+}
+
+/// Returns the date of the most recent commit to a Git repo as `jiff:Timestamp` displayed as a String
+/// (Which means that anything expecting a `Timestamp` must parse the output of this query appropriately)
+#[query]
+async fn last_commit_date(_engine: &mut PluginEngine, repo: GitRepo) -> Result<String> {
+	let path = &repo.path;
+	let commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let first = commits.first().ok_or_else(|| {
+		log::error!("no commits");
+		Error::UnspecifiedQueryState
+	})?;
+
+	first.written_on.clone().map_err(|e| {
+		log::error!("{}", e);
+		Error::UnspecifiedQueryState
+	})
+}
+
+/// Returns all diffs extracted from the repository
+#[query]
+async fn diffs(_engine: &mut PluginEngine, repo: GitRepo) -> Result<Vec<Diff>> {
+	let path = &repo.path;
+	let diffs = get_diffs(path).map_err(|e| {
+		log::error!("{}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	Ok(diffs)
+}
+
+/// Returns all commits extracted from the repository
+#[query]
+async fn commits(_engine: &mut PluginEngine, repo: GitRepo) -> Result<Vec<Commit>> {
+	let path = &repo.path;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let commits = raw_commits
+		.iter()
+		.map(|raw| Commit {
+			hash: raw.hash.to_owned(),
+			written_on: raw.written_on.to_owned(),
+			committed_on: raw.committed_on.to_owned(),
+		})
+		.collect();
+
+	Ok(commits)
+}
+
+/// Returns all commits extracted from the repository for a date given in the `details` field
+/// The provided date must be of the form "YYYY-MM-DD"
+#[query]
+async fn commits_from_date(_engine: &mut PluginEngine, repo: GitRepo) -> Result<Vec<Commit>> {
+	let path = &repo.path;
+	let date = match repo.details {
+		Some(date) => date,
+		None => {
+			log::error!("No date provided");
+			return Err(Error::UnspecifiedQueryState);
+		}
+	};
+	// The called function will return an error if the date is not formatted correctly, so we do not need to check for ahead of time
+	let raw_commits_from_date = get_commits_from_date(path, &date).map_err(|e| {
+		log::error!("failed to get raw commits from date: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let commits = raw_commits_from_date
+		.iter()
+		.map(|raw| Commit {
+			hash: raw.hash.to_owned(),
+			written_on: raw.written_on.to_owned(),
+			committed_on: raw.committed_on.to_owned(),
+		})
+		.collect();
+
+	Ok(commits)
+}
+
+/// Returns all contributors to the repository
+#[query]
+async fn contributors(_engine: &mut PluginEngine, repo: GitRepo) -> Result<Vec<Contributor>> {
+	let path = &repo.path;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let mut contributors: Vec<_> = raw_commits
+		.iter()
+		.flat_map(|raw| [raw.author.to_owned(), raw.committer.to_owned()])
+		.collect();
+
+	contributors.sort();
+	contributors.dedup();
+
+	Ok(contributors)
+}
+
+/// Returns all commit-diff pairs
+#[query]
+async fn commit_diffs(engine: &mut PluginEngine, repo: GitRepo) -> Result<Vec<CommitDiff>> {
+	let commits = commits(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let diffs = diffs(engine, repo).await.map_err(|e| {
+		log::error!("failed to get diffs: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let commit_diffs = Iterator::zip(commits.iter(), diffs.iter())
+		.map(|(commit, diff)| CommitDiff {
+			commit: commit.clone(),
+			diff: diff.clone(),
+		})
+		.collect();
+
+	Ok(commit_diffs)
+}
+
+/// Returns the commits associated with a given contributor (identified by e-mail address in the `details` value)
+#[query]
+async fn commits_for_contributor(
+	engine: &mut PluginEngine,
+	repo: GitRepo,
+) -> Result<ContributorView> {
+	let email = match repo.details {
+		Some(ref email) => email.clone(),
+		None => {
+			log::error!("No contributor e-maill address provided");
+			return Err(Error::UnspecifiedQueryState);
+		}
+	};
+
+	let all_commits = commits(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let contributors = contributors(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get contributors: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let commit_contributors = commit_contributors(engine, repo.clone())
+		.await
+		.map_err(|e| {
+			log::error!("failed to get join table: {}", e);
+			Error::UnspecifiedQueryState
+		})?;
+
+	// Get the index of the contributor
+	let contributor_id = contributors
+		.iter()
+		.position(|c| c.email == email)
+		.ok_or_else(|| {
+			log::error!("failed to find contributor");
+			Error::UnspecifiedQueryState
+		})?;
+
+	// Get the contributor
+	let contributor = contributors[contributor_id].clone();
+
+	// Find commits that have that contributor
+	let commits = commit_contributors
+		.iter()
+		.filter_map(|com_con| {
+			if com_con.author_id == contributor_id || com_con.committer_id == contributor_id {
+				// SAFETY: This index is guaranteed to be valid in
+				// `all_commits` because of how it and `commit_contributors`
+				// are constructed from `db.raw_commits()`
+				Some(all_commits[com_con.commit_id].clone())
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	Ok(ContributorView {
+		contributor,
+		commits,
+	})
+}
+
+/// Returns the contributor view for a given commit (idenftied by hash in the `details` field)
+#[query]
+async fn contributors_for_commit(
+	engine: &mut PluginEngine,
+	repo: GitRepo,
+) -> Result<CommitContributorView> {
+	let hash = match repo.details {
+		Some(ref hash) => hash.clone(),
+		None => {
+			log::error!("No commit hash provided");
+			return Err(Error::UnspecifiedQueryState);
+		}
+	};
+
+	let commits = commits(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let contributors = contributors(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get contributors: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let commit_contributors = commit_contributors(engine, repo.clone())
+		.await
+		.map_err(|e| {
+			log::error!("failed to get join table: {}", e);
+			Error::UnspecifiedQueryState
+		})?;
+
+	// Get the index of the commit
+	let commit_id = commits.iter().position(|c| c.hash == hash).ok_or_else(|| {
+		log::error!("failed to find contributor");
+		Error::UnspecifiedQueryState
+	})?;
+
+	// Get the commit
+	let commit = commits[commit_id].clone();
+
+	// Find the author and committer for that commit
+	commit_contributors
+		.iter()
+		.find(|com_con| com_con.commit_id == commit_id)
+		.map(|com_con| {
+			// SAFETY: These indices are guaranteed to be valid in
+			// `contributors` because of how `commit_contributors` is
+			// constructed from it.
+			let author = contributors[com_con.author_id].clone();
+			let committer = contributors[com_con.committer_id].clone();
+
+			CommitContributorView {
+				commit,
+				author,
+				committer,
+			}
+		})
+		.ok_or_else(|| {
+			log::error!("failed to find contributor info");
+			Error::UnspecifiedQueryState
+		})
+}
+
+/// Internal use function that returns a join table of contributors by commit
+async fn commit_contributors(
+	engine: &mut PluginEngine,
+	repo: GitRepo,
+) -> Result<Vec<CommitContributor>> {
+	let path = &repo.path;
+	let contributors = contributors(engine, repo.clone()).await.map_err(|e| {
+		log::error!("failed to get contributors: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let commit_contributors = raw_commits
+		.iter()
+		.enumerate()
+		.map(|(commit_id, raw)| {
+			// SAFETY: These `position` calls are guaranteed to return `Some`
+			// given how `contributors` is constructed from `db.raw_commits()`
+			let author_id = contributors.iter().position(|c| c == &raw.author).unwrap();
+			let committer_id = contributors
+				.iter()
+				.position(|c| c == &raw.committer)
+				.unwrap();
+
+			CommitContributor {
+				commit_id,
+				author_id,
+				committer_id,
+			}
+		})
+		.collect();
+
+	Ok(commit_contributors)
+}
+
+#[derive(Clone, Debug)]
+struct GitPlugin;
+
+impl Plugin for GitPlugin {
+	const PUBLISHER: &'static str = "mitre";
+
+	const NAME: &'static str = "git";
+
+	fn set_config(&self, _config: Value) -> std::result::Result<(), ConfigError> {
+		Ok(())
+	}
+
+	fn default_policy_expr(&self) -> hipcheck_sdk::prelude::Result<String> {
+		Ok("".to_owned())
+	}
+
+	fn explain_default_query(&self) -> hipcheck_sdk::prelude::Result<Option<String>> {
+		Ok(None)
+	}
+
+	queries! {}
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(GitPlugin {}).listen(args.port).await
+}

--- a/plugins/git/src/parse.rs
+++ b/plugins/git/src/parse.rs
@@ -1,0 +1,1195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+use crate::data::{Contributor, Diff, FileDiff, RawCommit};
+use anyhow::{Context as _, Error, Result};
+use jiff::Timestamp;
+use nom::{
+	branch::alt,
+	character::complete::{char as character, digit1, not_line_ending, one_of, space1},
+	combinator::{opt, peek, recognize},
+	error::{Error as NomError, ErrorKind},
+	multi::{fold_many0, many0, many1, many_m_n},
+	sequence::{preceded, terminated, tuple},
+	IResult,
+};
+use std::{iter::Iterator, result::Result as StdResult, sync::Arc};
+
+const HEX_CHARS: &str = "0123456789abcdef";
+const GIT_HASH_MIN_LEN: usize = 5;
+const GIT_HASH_MAX_LEN: usize = 40;
+
+/// Parse a complete git log.
+pub fn git_log(input: &str) -> Result<Vec<RawCommit>> {
+	let (_, commits) = commits(input)
+		.map_err(|e| Error::msg(e.to_string()))
+		.context("can't parse git log")?;
+	log::trace!("parsed git commits [commits='{:#?}']", commits);
+	Ok(commits)
+}
+
+/// Parse a complete set of git diffs.
+pub fn git_diff(input: &str) -> Result<Vec<Diff>> {
+	let (_, diffs) = diffs(input)
+		.map_err(|e| Error::msg(e.to_string()))
+		.context("can't parse git diff")?;
+	log::trace!("parsed git diffs [diffs='{:#?}']", diffs);
+	Ok(diffs)
+}
+
+/// Parse a complete set of GitHub diffs.
+pub fn github_diff(input: &str) -> Result<Vec<Diff>> {
+	let (_, diffs) = gh_diffs(input)
+		.map_err(|e| Error::msg(e.to_string()))
+		.context("can't parse GitHub diff")?;
+	log::trace!("parsed GitHub diffs [diffs='{:#?}']", diffs);
+	Ok(diffs)
+}
+
+fn hash(input: &str) -> IResult<&str, &str> {
+	recognize(many_m_n(GIT_HASH_MIN_LEN, GIT_HASH_MAX_LEN, hex_char))(input)
+}
+
+fn hex_char(input: &str) -> IResult<&str, char> {
+	one_of(HEX_CHARS)(input)
+}
+
+fn date(input: &str) -> StdResult<String, String> {
+	let ts: StdResult<Timestamp, String> = input.parse().map_err(|e| {
+		format!(
+			"Could not parse git commit timestamp as RFC3339: '{}'\
+			\nCaused by: {}",
+			input, e
+		)
+	});
+	ts.map(|t| t.to_string())
+}
+
+fn commit(input: &str) -> IResult<&str, RawCommit> {
+	let (input, hash_str) = line(input)?;
+	let (input, author_name) = line(input)?;
+	let (input, author_email) = line(input)?;
+	let (input, written_on_str) = line(input)?;
+	let (input, committer_name) = line(input)?;
+	let (input, committer_email) = line(input)?;
+	let (input, committed_on_str) = line(input)?;
+	// There is always an empty line here; ignore it
+	let (input, _empty_line) = line(input)?;
+
+	let (_, hash) = hash(hash_str).map_err(|e| {
+		log::error!("failed to parse git commit hash [err='{}']", e);
+		e
+	})?;
+
+	let written_on = date(written_on_str);
+	let committed_on = date(committed_on_str);
+
+	let short_hash = &hash[..8];
+
+	if let Err(e) = &written_on {
+		log::error!(
+			"git commit has invalid written_on timestamp [commit={}, error=\"{}\"]",
+			short_hash,
+			e
+		);
+	}
+
+	if let Err(e) = &committed_on {
+		log::error!(
+			"git commit has invalid committed_on timestamp [commit={}, error=\"{}\"]",
+			short_hash,
+			e
+		);
+	}
+
+	let commit = RawCommit {
+		hash: hash.to_owned(),
+		author: Contributor {
+			name: author_name.to_owned(),
+			email: author_email.to_owned(),
+		},
+		written_on,
+		committer: Contributor {
+			name: committer_name.to_owned(),
+			email: committer_email.to_owned(),
+		},
+		committed_on,
+	};
+
+	Ok((input, commit))
+}
+
+fn commits(input: &str) -> IResult<&str, Vec<RawCommit>> {
+	many0(commit)(input)
+}
+
+fn line_ending(input: &str) -> IResult<&str, &str> {
+	recognize(alt((
+		recognize(character('\n')),
+		recognize(tuple((character('\r'), character('\n')))),
+	)))(input)
+}
+
+fn line(input: &str) -> IResult<&str, &str> {
+	terminated(not_line_ending, line_ending)(input)
+}
+
+fn num(input: &str) -> IResult<&str, i64> {
+	digit1(input).map(|(input, output)| {
+		// Unwrap here is fine because we know it's only going to be
+		// a bunch of digits. Overflow is possible but we're choosing
+		// not to worry about it for now, because if a commit is large
+		// enough that the number of lines added or deleted
+		// in a single file overflows an i64 we have bigger problems.
+		(input, output.parse().unwrap())
+	})
+}
+
+fn stat(input: &str) -> IResult<&str, Stat<'_>> {
+	tuple((num, space1, num, space1, line))(input).map(
+		|(i, (lines_added, _, lines_deleted, _, file_name))| {
+			let stat = Stat {
+				lines_added,
+				lines_deleted,
+				file_name,
+			};
+
+			(i, stat)
+		},
+	)
+}
+
+fn stats(input: &str) -> IResult<&str, Vec<Stat<'_>>> {
+	many0(stat)(input)
+}
+
+fn diff(input: &str) -> IResult<&str, Diff> {
+	log::trace!("input is {:#?}", input);
+	tuple((stats, line, patches))(input).map(|(i, (stats, _, patches))| {
+		log::trace!("patches are {:#?}", patches);
+		let mut additions = Some(0);
+		let mut deletions = Some(0);
+
+		let file_diffs = Iterator::zip(stats.into_iter(), patches)
+			.map(|(stat, patch)| {
+				log::trace!(
+					"stat is {:#?} added and {:#?} deleted",
+					stat.lines_added,
+					stat.lines_deleted
+				);
+				additions = additions.map(|a| a + stat.lines_added);
+				deletions = deletions.map(|d| d + stat.lines_deleted);
+
+				FileDiff {
+					file_name: Arc::new(stat.file_name.to_owned()),
+					additions: Some(stat.lines_added),
+					deletions: Some(stat.lines_deleted),
+					patch,
+				}
+			})
+			.collect::<Vec<_>>();
+
+		let diff = Diff {
+			additions,
+			deletions,
+			file_diffs,
+		};
+
+		(i, diff)
+	})
+}
+
+fn gh_diff(input: &str) -> IResult<&str, Diff> {
+	// Handle reaching the end of the diff text without causing map0 to error
+	if input.is_empty() {
+		return Err(nom::Err::Error(NomError::new(input, ErrorKind::Many0)));
+	}
+
+	patches_with_context(input).map(|(i, patches)| {
+		log::trace!("patches are {:#?}", patches);
+
+		// GitHub diffs don't provide these.
+		let additions = None;
+		let deletions = None;
+
+		let file_diffs = patches
+			.into_iter()
+			.map(|patch| FileDiff {
+				file_name: Arc::new(patch.file_name),
+				additions: None,
+				deletions: None,
+				patch: patch.content,
+			})
+			.collect();
+		log::trace!("file_diffs are {:#?}", file_diffs);
+
+		let diff = Diff {
+			additions,
+			deletions,
+			file_diffs,
+		};
+		log::trace!("diff is {:#?}", diff);
+
+		(i, diff)
+	})
+}
+
+fn diffs(input: &str) -> IResult<&str, Vec<Diff>> {
+	many0(diff)(input)
+}
+
+fn gh_diffs(input: &str) -> IResult<&str, Vec<Diff>> {
+	log::trace!("input is {}", input);
+	many0(gh_diff)(input)
+}
+
+fn meta(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((single_alpha, line)))(input)
+}
+
+fn metas(input: &str) -> IResult<&str, Vec<&str>> {
+	many1(meta)(input)
+}
+
+fn single_alpha(input: &str) -> IResult<&str, &str> {
+	recognize(one_of(
+		"qwertyuioplokjhgfdsazxcvbnmQWERTYUIOPLOKJHGFDSAZXCVBNM",
+	))(input)
+}
+
+fn patch_header(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((metas, line, line)))(input)
+}
+
+fn plus_or_minus(input: &str) -> IResult<&str, &str> {
+	recognize(one_of("+-"))(input)
+}
+
+fn line_with_ending(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((not_line_ending, line_ending)))(input)
+}
+
+fn chunk_line(input: &str) -> IResult<&str, &str> {
+	preceded(plus_or_minus, line_with_ending)(input)
+}
+
+fn chunk_body(input: &str) -> IResult<&str, String> {
+	fold_many0(chunk_line, String::new, |mut patch, line| {
+		patch.push_str(line);
+		patch
+	})(input)
+}
+
+fn chunk_header(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((peek(character('@')), line)))(input)
+}
+
+fn chunk(input: &str) -> IResult<&str, String> {
+	preceded(chunk_header, chunk_body)(input)
+}
+
+fn chunks(input: &str) -> IResult<&str, String> {
+	fold_many0(chunk, String::new, |mut patch, line| {
+		patch.push_str(&line);
+		patch
+	})(input)
+}
+
+fn no_newline(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((peek(character('\\')), line)))(input)
+}
+
+fn patch_footer(input: &str) -> IResult<&str, Option<&str>> {
+	opt(no_newline)(input)
+}
+
+fn patch(input: &str) -> IResult<&str, String> {
+	tuple((patch_header, chunks, patch_footer))(input).map(|(i, (_, chunks, _))| (i, chunks))
+}
+
+fn gh_meta(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((single_alpha, line)))(input)
+}
+
+fn gh_metas(input: &str) -> IResult<&str, Vec<&str>> {
+	many1(gh_meta)(input)
+}
+
+fn gh_patch_header(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((gh_metas, line, line)))(input)
+}
+
+fn chunk_line_with_context(input: &str) -> IResult<&str, &str> {
+	recognize(tuple((not_line_ending, line_ending)))(input).and_then(|(i, parsed)| {
+		if parsed.starts_with("diff --git") {
+			Err(nom::Err::Error(NomError::new(i, ErrorKind::Many0)))
+		} else {
+			Ok((i, parsed))
+		}
+	})
+}
+
+fn chunk_body_with_context(input: &str) -> IResult<&str, String> {
+	fold_many0(chunk_line_with_context, String::new, |mut patch, line| {
+		if line.starts_with('+') || line.starts_with('-') {
+			// Omit the first character.
+			patch.push_str(&line[1..]);
+		}
+
+		patch
+	})(input)
+}
+
+fn chunk_with_context(input: &str) -> IResult<&str, String> {
+	preceded(chunk_header, chunk_body_with_context)(input)
+}
+
+fn chunks_with_context(input: &str) -> IResult<&str, String> {
+	fold_many0(chunk_with_context, String::new, |mut patch, line| {
+		patch.push_str(&line);
+		patch
+	})(input)
+}
+
+fn patch_with_context(input: &str) -> IResult<&str, GhPatch> {
+	tuple((gh_patch_header, chunks_with_context, patch_footer))(input).map(
+		|(i, (header, content, _))| {
+			let file_name = file_name_from_header(header);
+
+			let gh_patch = GhPatch { file_name, content };
+
+			(i, gh_patch)
+		},
+	)
+}
+
+fn file_name_from_header(header: &str) -> String {
+	let uf = "<unknown file>";
+
+	// Extract the file name from a known-valid diff header.
+	//
+	// Example: diff --git a/README.md b/README.md
+	header
+		.split_whitespace()
+		.nth(3)
+		.unwrap_or(uf)
+		.strip_prefix("b/")
+		.unwrap_or(uf)
+		.trim()
+		.into()
+}
+
+fn patches_with_context(input: &str) -> IResult<&str, Vec<GhPatch>> {
+	many0(patch_with_context)(input)
+}
+
+fn patches(input: &str) -> IResult<&str, Vec<String>> {
+	many0(patch)(input)
+}
+
+#[derive(Debug)]
+struct GhPatch {
+	file_name: String,
+	content: String,
+}
+
+pub struct Stat<'a> {
+	pub lines_added: i64,
+	pub lines_deleted: i64,
+	pub file_name: &'a str,
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn parse_stat() {
+		let line = "7       0       Cargo.toml\n";
+
+		let (remaining, stat) = stat(line).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(7, stat.lines_added);
+		assert_eq!(0, stat.lines_deleted);
+		assert_eq!("Cargo.toml", stat.file_name);
+	}
+
+	#[test]
+	fn parse_stats() {
+		let input = "\
+7       0       Cargo.toml\n\
+18      0       README.md\n\
+3       0       src/main.rs\n";
+
+		let (remaining, stats) = stats(input).unwrap();
+
+		assert_eq!("", remaining);
+
+		assert_eq!(7, stats[0].lines_added);
+		assert_eq!(0, stats[0].lines_deleted);
+		assert_eq!("Cargo.toml", stats[0].file_name);
+
+		assert_eq!(18, stats[1].lines_added);
+		assert_eq!(0, stats[1].lines_deleted);
+		assert_eq!("README.md", stats[1].file_name);
+
+		assert_eq!(3, stats[2].lines_added);
+		assert_eq!(0, stats[2].lines_deleted);
+		assert_eq!("src/main.rs", stats[2].file_name);
+	}
+
+	#[test]
+	fn parse_patch_header() {
+		let input = "\
+diff --git a/src/main.rs b/src/main.rs\n\
+new file mode 100644\n\
+index 0000000..e7a11a9\n\
+--- /dev/null\n\
++++ b/src/main.rs\n";
+
+		let (remaining, header) = patch_header(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(input, header);
+	}
+
+	#[test]
+	fn parse_patches() {
+		let input = "\
+diff --git a/src/main.rs b/src/main.rs\n\
+new file mode 100644\n\
+index 0000000..e7a11a9\n\
+--- /dev/null\n\
++++ b/src/main.rs\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n\
+diff --git a/src/main.rs b/src/main.rs\n\
+new file mode 100644\n\
+index 0000000..e7a11a9\n\
+--- /dev/null\n\
++++ b/src/main.rs\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n";
+
+		let expected_1 = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let expected_2 = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let (remaining, patches) = patches(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected_1, patches[0]);
+		assert_eq!(expected_2, patches[1]);
+	}
+
+	#[test]
+	fn parse_patch() {
+		let input = "\
+diff --git a/src/main.rs b/src/main.rs\n\
+new file mode 100644\n\
+index 0000000..e7a11a9\n\
+--- /dev/null\n\
++++ b/src/main.rs\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n";
+
+		let expected = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let (remaining, patch) = patch(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, patch);
+	}
+
+	#[test]
+	fn parse_chunks() {
+		let input = "\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n";
+
+		let expected = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let (remaining, patch) = chunks(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, patch);
+	}
+
+	#[test]
+	fn parse_chunk() {
+		let input = "\
+@@ -0,0 +1,116 @@\n\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n";
+
+		let expected = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let (remaining, patch) = chunk(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, patch);
+	}
+
+	#[test]
+	fn parse_chunk_header() {
+		let input = "@@ -0,0 +1,116 @@\n";
+		let expected = "@@ -0,0 +1,116 @@\n";
+
+		let (remaining, header) = chunk_header(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, header);
+	}
+
+	#[test]
+	fn parse_chunk_body() {
+		let input = "\
++use clap::{Arg, App, SubCommand};\n\
++use serde::{Serialize, Deserialize};\n";
+
+		let expected = "\
+use clap::{Arg, App, SubCommand};\n\
+use serde::{Serialize, Deserialize};\n";
+
+		let (remaining, body) = chunk_body(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, body);
+	}
+
+	#[test]
+	fn parse_chunk_line() {
+		let input = "+use clap::{Arg, App, SubCommand};\n";
+		let expected = "use clap::{Arg, App, SubCommand};\n";
+
+		let (remaining, line) = chunk_line(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, line);
+	}
+
+	#[test]
+	fn parse_plus_or_minus() {
+		let input_plus = "+";
+		let expected_plus = "+";
+
+		let (remaining, c) = plus_or_minus(input_plus).unwrap();
+		assert_eq!("", remaining);
+		assert_eq!(expected_plus, c);
+
+		let input_minus = "-";
+		let expected_minus = "-";
+		let (remaining, c) = plus_or_minus(input_minus).unwrap();
+		assert_eq!("", remaining);
+		assert_eq!(expected_minus, c);
+	}
+
+	#[test]
+	fn parse_line_with_ending() {
+		let input = "use clap::{Arg, App, SubCommand};\n";
+		let expected = "use clap::{Arg, App, SubCommand};\n";
+
+		let (remaining, line) = line_with_ending(input).unwrap();
+		assert_eq!("", remaining);
+		assert_eq!(expected, line);
+	}
+
+	#[test]
+	fn parse_diff() {
+		let input = r#"10      0       .gitignore
+4       0       Cargo.toml
+127     1       src/main.rs
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..50c8301
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,10 @@
++# Generated by Cargo
++# will have compiled files and executables
++/target/
++
++# Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
++# More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
++Cargo.lock
++
++# These are backup files generated by rustfmt
++**/*.rs.bk
+\ No newline at end of file
+diff --git a/Cargo.toml b/Cargo.toml
+index 191135b..d91dabb 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -7,0 +8,4 @@ edition = "2018"
++clap = "2.33.0"
++petgraph = "0.4.13"
++serde = { version = "1.0.91", features = ["derive"] }
++serde_json = "1.0.39"
+\ No newline at end of file
+diff --git a/src/main.rs b/src/main.rs
+index e7a11a9..4894a2e 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -0,0 +1,116 @@
++use clap::{Arg, App, SubCommand};
++use serde::{Serialize, Deserialize};
++// use petgraph::{Graph, Directed};
++// use std::collections::Vec;
++use std::process::Command;
++use std::str;
++
++// 1. Check that you're in a Git repo.
++//  * If not, error out.
++// 2. Run a command to get the Git log data.
++// 3. Deserialize that data with Serde, into a GitLog data structure.
++// 4. Convert the GitLog data structure into a CommitGraph.
++// 5. Run analyses on the CommitGraph.
++
++/*
++struct CommitGraph {
++    graph: Graph<Commit, String, Directed>,
++}
++
++struct AnalysisReport {
++    records: Vec<AnalysisRecord>,
++}
++
++trait Analysis {
++    fn analyze(commit_graph: &CommitGraph) -> AnalysisReport;
++}
++*/
++
++#[derive(Deserialize, Debug)]
++struct GitContributor {
++    name:   String,
++    email:  String,
++    date:   String,
++}
++
++#[derive(Deserialize, Debug)]
++struct GitCommit {
++    commit:                 String,
++    abbreviated_commit:     String,
++    tree:                   String,
++    abbreviated_tree:       String,
++    parent:                 String,
++    abbreviated_parent:     String,
++    refs:                   String,
++    encoding:               String,
++    subject:                String,
++    sanitized_subject_line: String,
++    body:                   String,
++    commit_notes:           String,
++    verification_flag:      String,
++    signer:                 String,
++    signer_key:             String,
++    author:                 GitContributor,
++    committer:              GitContributor,
++}
++
++#[derive(Deserialize, Debug)]
++struct GitLog {
++    commits: Vec<GitCommit>,
++}
++
++fn strip_characters(original: &str, to_strip: &str) -> String {
++    original.chars().filter(|&c| !to_strip.contains(c)).collect()
++}
++
++fn get_git_log() -> String {
++    // The format string being passed to Git, to get commit data.
++    // Note that this matches the GitLog struct above.
++    let format = "                                                  \
++        --pretty=format:                                            \
++            {                                               %n      \
++                \"commit\":                   \"%H\",       %n      \
++                \"abbreviated_commit\":       \"%h\",       %n      \
++                \"tree\":                     \"%T\",       %n      \
++                \"abbreviated_tree\":         \"%t\",       %n      \
++                \"parent\":                   \"%P\",       %n      \
++                \"abbreviated_parent\":       \"%p\",       %n      \
++                \"refs\":                     \"%D\",       %n      \
++                \"encoding\":                 \"%e\",       %n      \
++                \"subject\":                  \"%s\",       %n      \
++                \"sanitized_subject_line\":   \"%f\",       %n      \
++                \"body\":                     \"%b\",       %n      \
++                \"commit_notes\":             \"%N\",       %n      \
++                \"verification_flag\":        \"%G?\",      %n      \
++                \"signer\":                   \"%GS\",      %n      \
++                \"signer_key\":               \"%GK\",      %n      \
++                \"author\": {                               %n      \
++                    \"name\":                     \"%aN\",  %n      \
++                    \"email\":                    \"%aE\",  %n      \
++                    \"date\":                     \"%aD\"   %n      \
++                },                                          %n      \
++                \"commiter\": {                             %n      \
++                    \"name\":                     \"%cN\",  %n      \
++                    \"email\":                    \"%cE\",  %n      \
++                    \"date\":                     \"%cD\"   %n      \
++                }                                           %n      \
++            },";
++    let format = strip_characters(format, " ");
++
++    // Run the git command and extract the stdout as a string, stripping the trailing comma.
++    let output = Command::new("git")
++                    .args(&["log", &format])
++                    .output()
++                    .expect("failed to execute process");
++    let output = str::from_utf8(&output.stdout).unwrap().to_string();
++    let output = (&output[0..output.len() - 2]).to_string(); // Remove trailing comma.
++
++    // Wrap the result in brackets.
++    let mut result = String::new();
++    result.push('[');
++    result.push_str(&output);
++    result.push(']');
++
++    result
++}
++
+@@ -2 +118,11 @@ fn main() {
+-    println!("Hello, world!");
++    let matches = App::new("hipcheck")
++        .version("0.1")
++        .author("Andrew Lilley Brinker <abrinker@mitre.org>")
++        .about("Check Git history for concerning patterns")
++        .get_matches();
++
++    let log_string = get_git_log();
++
++    let gl: GitLog = serde_json::from_str(&log_string).unwrap();
++
++    println!("{:?}", gl);
+"#;
+
+		let expected = Diff {
+			additions: Some(141),
+			deletions: Some(1),
+			file_diffs: vec![
+				FileDiff {
+					file_name: Arc::new(String::from(".gitignore")),
+					additions: Some(10),
+					deletions: Some(0),
+					patch: String::from(
+						r#"# Generated by Cargo
+# will have compiled files and executables
+/target/
+
+# Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
+# More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
+Cargo.lock
+
+# These are backup files generated by rustfmt
+**/*.rs.bk
+"#,
+					),
+				},
+				FileDiff {
+					file_name: Arc::new(String::from("Cargo.toml")),
+					additions: Some(4),
+					deletions: Some(0),
+					patch: String::from(
+						r#"clap = "2.33.0"
+petgraph = "0.4.13"
+serde = { version = "1.0.91", features = ["derive"] }
+serde_json = "1.0.39"
+"#,
+					),
+				},
+				FileDiff {
+					file_name: Arc::new(String::from("src/main.rs")),
+					additions: Some(127),
+					deletions: Some(1),
+					patch: String::from(
+						r#"use clap::{Arg, App, SubCommand};
+use serde::{Serialize, Deserialize};
+// use petgraph::{Graph, Directed};
+// use std::collections::Vec;
+use std::process::Command;
+use std::str;
+
+// 1. Check that you're in a Git repo.
+//  * If not, error out.
+// 2. Run a command to get the Git log data.
+// 3. Deserialize that data with Serde, into a GitLog data structure.
+// 4. Convert the GitLog data structure into a CommitGraph.
+// 5. Run analyses on the CommitGraph.
+
+/*
+struct CommitGraph {
+    graph: Graph<Commit, String, Directed>,
+}
+
+struct AnalysisReport {
+    records: Vec<AnalysisRecord>,
+}
+
+trait Analysis {
+    fn analyze(commit_graph: &CommitGraph) -> AnalysisReport;
+}
+*/
+
+#[derive(Deserialize, Debug)]
+struct GitContributor {
+    name:   String,
+    email:  String,
+    date:   String,
+}
+
+#[derive(Deserialize, Debug)]
+struct GitCommit {
+    commit:                 String,
+    abbreviated_commit:     String,
+    tree:                   String,
+    abbreviated_tree:       String,
+    parent:                 String,
+    abbreviated_parent:     String,
+    refs:                   String,
+    encoding:               String,
+    subject:                String,
+    sanitized_subject_line: String,
+    body:                   String,
+    commit_notes:           String,
+    verification_flag:      String,
+    signer:                 String,
+    signer_key:             String,
+    author:                 GitContributor,
+    committer:              GitContributor,
+}
+
+#[derive(Deserialize, Debug)]
+struct GitLog {
+    commits: Vec<GitCommit>,
+}
+
+fn strip_characters(original: &str, to_strip: &str) -> String {
+    original.chars().filter(|&c| !to_strip.contains(c)).collect()
+}
+
+fn get_git_log() -> String {
+    // The format string being passed to Git, to get commit data.
+    // Note that this matches the GitLog struct above.
+    let format = "                                                  \
+        --pretty=format:                                            \
+            {                                               %n      \
+                \"commit\":                   \"%H\",       %n      \
+                \"abbreviated_commit\":       \"%h\",       %n      \
+                \"tree\":                     \"%T\",       %n      \
+                \"abbreviated_tree\":         \"%t\",       %n      \
+                \"parent\":                   \"%P\",       %n      \
+                \"abbreviated_parent\":       \"%p\",       %n      \
+                \"refs\":                     \"%D\",       %n      \
+                \"encoding\":                 \"%e\",       %n      \
+                \"subject\":                  \"%s\",       %n      \
+                \"sanitized_subject_line\":   \"%f\",       %n      \
+                \"body\":                     \"%b\",       %n      \
+                \"commit_notes\":             \"%N\",       %n      \
+                \"verification_flag\":        \"%G?\",      %n      \
+                \"signer\":                   \"%GS\",      %n      \
+                \"signer_key\":               \"%GK\",      %n      \
+                \"author\": {                               %n      \
+                    \"name\":                     \"%aN\",  %n      \
+                    \"email\":                    \"%aE\",  %n      \
+                    \"date\":                     \"%aD\"   %n      \
+                },                                          %n      \
+                \"commiter\": {                             %n      \
+                    \"name\":                     \"%cN\",  %n      \
+                    \"email\":                    \"%cE\",  %n      \
+                    \"date\":                     \"%cD\"   %n      \
+                }                                           %n      \
+            },";
+    let format = strip_characters(format, " ");
+
+    // Run the git command and extract the stdout as a string, stripping the trailing comma.
+    let output = Command::new("git")
+                    .args(&["log", &format])
+                    .output()
+                    .expect("failed to execute process");
+    let output = str::from_utf8(&output.stdout).unwrap().to_string();
+    let output = (&output[0..output.len() - 2]).to_string(); // Remove trailing comma.
+
+    // Wrap the result in brackets.
+    let mut result = String::new();
+    result.push('[');
+    result.push_str(&output);
+    result.push(']');
+
+    result
+}
+
+    println!("Hello, world!");
+    let matches = App::new("hipcheck")
+        .version("0.1")
+        .author("Andrew Lilley Brinker <abrinker@mitre.org>")
+        .about("Check Git history for concerning patterns")
+        .get_matches();
+
+    let log_string = get_git_log();
+
+    let gl: GitLog = serde_json::from_str(&log_string).unwrap();
+
+    println!("{:?}", gl);
+"#,
+					),
+				},
+			],
+		};
+
+		let (remaining, diff) = diff(input).unwrap();
+
+		assert_eq!("", remaining);
+		assert_eq!(expected, diff);
+	}
+
+	#[test]
+	fn parse_patch_with_context() {
+		let input = r#"diff --git a/README.md b/README.md
+index 20b42ecfdf..b0f30e8e35 100644
+--- a/README.md
++++ b/README.md
+@@ -432,24 +432,31 @@ Other Style Guides
+		});
+
+		// bad
+-    inbox.filter((msg) => {
+-      const { subject, author } = msg;
+-      if (subject === 'Mockingbird') {
+-        return author === 'Harper Lee';
+-      } else {
+-        return false;
+-      }
+-    });
++    var indexMap = myArray.reduce(function(memo, item, index) {
++      memo[item] = index;
++    }, {});
+
+-    // good
+-    inbox.filter((msg) => {
+-      const { subject, author } = msg;
+-      if (subject === 'Mockingbird') {
+-        return author === 'Harper Lee';
+-      }
+
+-      return false;
++    // good
++    var indexMap = myArray.reduce(function(memo, item, index) {
++      memo[item] = index;
++      return memo;
++    }, {});
++
++
++    // bad
++    const alpha = people.sort((lastOne, nextOne) => {
++      const [aLast, aFirst] = lastOne.split(', ');
++      const [bLast, bFirst] = nextOne.split(', ');
+		});
++
++    // good
++    const alpha = people.sort((lastOne, nextOne) => {
++      const [aLast, aFirst] = lastOne.split(', ');
++      const [bLast, bFirst] = nextOne.split(', ');
++      return aLast > bLast ? 1 : -1;
++    });
++
+		```
+
+	<a name="arrays--bracket-newline"></a>
+"#;
+
+		let expected = r#"    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      } else {
+        return false;
+      }
+    });
+    var indexMap = myArray.reduce(function(memo, item, index) {
+      memo[item] = index;
+    }, {});
+    // good
+    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      }
+      return false;
+    // good
+    var indexMap = myArray.reduce(function(memo, item, index) {
+      memo[item] = index;
+      return memo;
+    }, {});
+
+
+    // bad
+    const alpha = people.sort((lastOne, nextOne) => {
+      const [aLast, aFirst] = lastOne.split(', ');
+      const [bLast, bFirst] = nextOne.split(', ');
+
+    // good
+    const alpha = people.sort((lastOne, nextOne) => {
+      const [aLast, aFirst] = lastOne.split(', ');
+      const [bLast, bFirst] = nextOne.split(', ');
+      return aLast > bLast ? 1 : -1;
+    });
+
+"#;
+
+		let (remaining, patch) = patch_with_context(input).unwrap();
+
+		assert_eq!(
+			"", remaining,
+			"expected nothing remaining, got '{}'",
+			remaining
+		);
+		assert_eq!(expected, patch.content);
+	}
+
+	#[test]
+	fn parse_gh_diff() {
+		let input = r#"diff --git a/README.md b/README.md
+index 20b42ecfdf..b0f30e8e35 100644
+--- a/README.md
++++ b/README.md
+@@ -432,24 +432,31 @@ Other Style Guides
+		});
+
+		// bad
+-    inbox.filter((msg) => {
+-      const { subject, author } = msg;
+-      if (subject === 'Mockingbird') {
+-        return author === 'Harper Lee';
+-      } else {
+-        return false;
+-      }
+-    });
++    var indexMap = myArray.reduce(function(memo, item, index) {
++      memo[item] = index;
++    }, {});
+
+-    // good
+-    inbox.filter((msg) => {
+-      const { subject, author } = msg;
+-      if (subject === 'Mockingbird') {
+-        return author === 'Harper Lee';
+-      }
+
+-      return false;
++    // good
++    var indexMap = myArray.reduce(function(memo, item, index) {
++      memo[item] = index;
++      return memo;
++    }, {});
++
++
++    // bad
++    const alpha = people.sort((lastOne, nextOne) => {
++      const [aLast, aFirst] = lastOne.split(', ');
++      const [bLast, bFirst] = nextOne.split(', ');
+		});
++
++    // good
++    const alpha = people.sort((lastOne, nextOne) => {
++      const [aLast, aFirst] = lastOne.split(', ');
++      const [bLast, bFirst] = nextOne.split(', ');
++      return aLast > bLast ? 1 : -1;
++    });
++
+		```
+
+	<a name="arrays--bracket-newline"></a>
+"#;
+
+		let expected = r#"    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      } else {
+        return false;
+      }
+    });
+    var indexMap = myArray.reduce(function(memo, item, index) {
+      memo[item] = index;
+    }, {});
+    // good
+    inbox.filter((msg) => {
+      const { subject, author } = msg;
+      if (subject === 'Mockingbird') {
+        return author === 'Harper Lee';
+      }
+      return false;
+    // good
+    var indexMap = myArray.reduce(function(memo, item, index) {
+      memo[item] = index;
+      return memo;
+    }, {});
+
+
+    // bad
+    const alpha = people.sort((lastOne, nextOne) => {
+      const [aLast, aFirst] = lastOne.split(', ');
+      const [bLast, bFirst] = nextOne.split(', ');
+
+    // good
+    const alpha = people.sort((lastOne, nextOne) => {
+      const [aLast, aFirst] = lastOne.split(', ');
+      const [bLast, bFirst] = nextOne.split(', ');
+      return aLast > bLast ? 1 : -1;
+    });
+
+"#;
+
+		let (remaining, diff) = gh_diff(input).unwrap();
+
+		assert_eq!(
+			"", remaining,
+			"expected nothing remaining, got '{}'",
+			remaining
+		);
+
+		assert_eq!(None, diff.additions);
+		assert_eq!(None, diff.deletions);
+
+		assert_eq!("README.md", diff.file_diffs[0].file_name.as_ref());
+		assert_eq!(None, diff.file_diffs[0].additions);
+		assert_eq!(None, diff.file_diffs[0].deletions);
+		assert_eq!(expected, diff.file_diffs[0].patch)
+	}
+}

--- a/plugins/git/src/util/command.rs
+++ b/plugins/git/src/util/command.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::{convert::AsRef, env, ffi::OsStr, iter::IntoIterator};
+
+/// Print command line args as well as commands and args for git commands
+pub fn log_git_args<I, S>(repo_path: &str, args: I, git_path: &str)
+where
+	I: IntoIterator<Item = S> + Copy,
+	S: AsRef<OsStr>,
+{
+	log::debug!("logging git CLI args");
+
+	for arg in env::args() {
+		log::debug!("git CLI environment arg [arg='{}']", arg);
+	}
+
+	log::debug!("git CLI executable location [path='{}']", git_path);
+
+	log::debug!("git CLI repository location [path='{}']", repo_path);
+
+	log_each_git_arg(args);
+
+	log::debug!("done logging git CLI args");
+}
+
+pub fn log_each_git_arg<I, S>(args: I)
+where
+	I: IntoIterator<Item = S>,
+	S: AsRef<OsStr>,
+{
+	for (index, val) in args.into_iter().enumerate() {
+		let arg_val = val
+			.as_ref()
+			.to_str()
+			.unwrap_or("argument for command could not be logged.");
+
+		log::debug!("git CLI argument [name='{}', value='{}']", index, arg_val);
+	}
+}

--- a/plugins/git/src/util/git_command.rs
+++ b/plugins/git/src/util/git_command.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::*;
+use crate::parse::*;
+use crate::util::command::log_git_args;
+// use crate::{
+// 	error::{Context as _, Result},
+// 	anyhow,
+// };
+
+use anyhow::{anyhow, Context as _, Result};
+use std::{
+	convert::AsRef, ffi::OsStr, iter::IntoIterator, ops::Not as _, path::Path, process::Command,
+};
+
+#[derive(Debug)]
+pub struct GitCommand {
+	command: Command,
+}
+
+impl GitCommand {
+	pub fn for_repo<I, S>(repo_path: &Path, args: I) -> Result<GitCommand>
+	where
+		I: IntoIterator<Item = S> + Copy,
+		S: AsRef<OsStr>,
+	{
+		GitCommand::internal(Some(repo_path), args)
+	}
+
+	fn internal<I, S>(repo_path: Option<&Path>, args: I) -> Result<GitCommand>
+	where
+		I: IntoIterator<Item = S> + Copy,
+		S: AsRef<OsStr>,
+	{
+		// Init the command.
+		let git_path = which::which("git").context("can't find git command")?;
+		let no_repo_found = Path::new("no_repo_found");
+		let repo = repo_path.unwrap_or(no_repo_found).display().to_string();
+		let path = git_path.display().to_string();
+		log_git_args(&repo, args, &path);
+		let mut command = Command::new(&git_path);
+		command.args(args);
+
+		// Set the path if necessary
+		if let Some(repo_path) = repo_path {
+			command.current_dir(repo_path);
+		}
+
+		if cfg!(windows) {
+			// this method is broken on Windows. See: https://github.com/rust-lang/rust/issues/31259
+			//command.env_clear()
+		} else {
+			command.env_clear();
+		};
+
+		Ok(GitCommand { command })
+	}
+
+	pub fn output(&mut self) -> Result<String> {
+		let output = self.command.output()?;
+
+		if output.status.success() {
+			let output_text = String::from_utf8_lossy(&output.stdout).to_string();
+			return Ok(output_text);
+		}
+
+		match String::from_utf8(output.stderr) {
+			Ok(msg) if msg.is_empty().not() => {
+				Err(anyhow!("(from git) {} [{}]", msg.trim(), output.status))
+			}
+			_ => Err(anyhow!("git failed [{}]", output.status)),
+		}
+	}
+}
+
+pub fn get_commits(repo: &Path) -> Result<Vec<RawCommit>> {
+	let raw_output = GitCommand::for_repo(
+		repo,
+		[
+			"--no-pager",
+			"log",
+			"--no-merges",
+			"--date=iso-strict",
+			"--pretty=tformat:%H%n%aN%n%aE%n%ad%n%cN%n%cE%n%cd%n%GS%n%GK%n",
+		],
+	)?
+	.output()
+	.context("git log command failed")?;
+
+	git_log(&raw_output)
+}
+
+pub fn get_commits_from_date(repo: &Path, date: &str) -> Result<Vec<RawCommit>> {
+	let since_date = format!("--since='{} month ago'", date);
+	let msg = format!("git log from date {} command failed", &date);
+	let raw_output = GitCommand::for_repo(
+		repo,
+		[
+			"--no-pager",
+			"log",
+			"--no-merges",
+			"--date=iso-strict",
+			"--pretty=tformat:%H%n%aN%n%aE%n%ad%n%cN%n%cE%n%cd%n%GS%n%GK%n",
+			"--all",
+			&since_date,
+		],
+	)?
+	.output()
+	.context(msg)?;
+
+	git_log(&raw_output)
+}
+
+pub fn get_diffs(repo: &Path) -> Result<Vec<Diff>> {
+	let output = GitCommand::for_repo(
+		repo,
+		[
+			"--no-pager",
+			"log",
+			"--no-merges",
+			"--numstat",
+			"--pretty=tformat:",
+			"-U0",
+		],
+	)?
+	.output()
+	.context("git diff command failed")?;
+
+	git_diff(&output)
+}

--- a/plugins/git/src/util/mod.rs
+++ b/plugins/git/src/util/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod command;
+pub mod git_command;


### PR DESCRIPTION
Resolves issue #472 

This is mainly a refactor of extant code from `hipcheck/src/data/{mod.rs, git::*}`. The Salsa queries have been changed to query functions compatible with the Hipcheck plugin query system.

We have not refactored data structures and functions related to commit signers, as no Hipcheck analysis currently uses those. These can be added in a future update if desired.

Note that queries involving datetimes accept and return datetime values as plain Strings in the correct formatting for `jiff::Timestamp.` Other plugins should parse and display datetimes accordingly when using the functions in this plugin.