### PR TITLE
feat: enable SDK plugins to report concerns

### DIFF
--- a/hipcheck-sdk-macros/src/lib.rs
+++ b/hipcheck-sdk-macros/src/lib.rs
@@ -255,7 +255,10 @@ pub fn queries(_item: TokenStream) -> TokenStream {
 	let q_lock = QUERIES.lock().unwrap();
 	// Create a NamedQuery for each #query func we've seen
 	for q in q_lock.iter() {
-		let name = q.function.as_str();
+		let name = match q.default {
+			true => "",
+			false => q.function.as_str(),
+		};
 		let inner = Ident::new(q.struct_name.as_str(), Span::call_site());
 		let out = quote::quote! {
 			NamedQuery {

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -7,10 +7,13 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.18", features = ["derive"] }
-hipcheck-sdk = { path = "../../sdk/rust", features = ["macros", "mock_engine"]}
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros"] }
 jiff = { version = "0.1.13", features = ["serde"] }
 log = "0.4.22"
 schemars = { version = "0.8.21", features = ["url"] }
 serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["rt"] }
+
+[dev-dependencies]
+hipcheck-sdk = { path = "../../sdk/rust", features = ["mock_engine"] }

--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -71,14 +71,11 @@ impl Plugin for ActivityPlugin {
 	}
 
 	fn default_policy_expr(&self) -> Result<String> {
-		match CONFIG
-			.get()
-			.ok_or_else(|| {
-				log::error!("tried to access config before set by Hipcheck core!");
-				Error::UnspecifiedQueryState
-			})?
-			.weeks
-		{
+		let Some(conf) = CONFIG.get() else {
+			log::error!("tried to access config before set by Hipcheck core!");
+			return Err(Error::UnspecifiedQueryState);
+		};
+		match conf.weeks {
 			Some(weeks) => Ok(format!("lte $ P{}w", weeks)),
 			None => Ok("".to_owned()),
 		}

--- a/plugins/dummy_rand_data_sdk/src/main.rs
+++ b/plugins/dummy_rand_data_sdk/src/main.rs
@@ -25,9 +25,9 @@ struct RandDataPlugin;
 async fn rand_data(engine: &mut PluginEngine, size: u64) -> Result<u64> {
 	let reduced_num = reduce(size);
 
-	let value = engine
-		.query("dummy/sha256/sha256", vec![reduced_num])
-		.await?;
+	engine.record_concern("this is a test");
+
+	let value = engine.query("dummy/sha256", vec![reduced_num]).await?;
 
 	let Value::Array(mut sha256) = value else {
 		return Err(Error::UnexpectedPluginQueryInputFormat);
@@ -36,6 +36,8 @@ async fn rand_data(engine: &mut PluginEngine, size: u64) -> Result<u64> {
 	let Value::Number(num) = sha256.pop().unwrap() else {
 		return Err(Error::UnexpectedPluginQueryInputFormat);
 	};
+
+	engine.record_concern("this is a test2");
 
 	num.as_u64().ok_or(Error::UnexpectedPluginQueryOutputFormat)
 }
@@ -82,7 +84,7 @@ mod test {
 
 	fn mock_responses() -> StdResult<MockResponses, Error> {
 		// when calling into query 1, Value::Array(vec![1]) gets passed to `sha256`, lets assume it returns 1
-		Ok(MockResponses::new().insert("dummy/sha256/sha256", vec![1], Ok(vec![1]))?)
+		Ok(MockResponses::new().insert("dummy/sha256", vec![1], Ok(vec![1]))?)
 	}
 
 	#[tokio::test]

--- a/plugins/dummy_sha256_sdk/src/main.rs
+++ b/plugins/dummy_sha256_sdk/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use hipcheck_sdk::prelude::*;
 use sha2::{Digest, Sha256};
 
-#[query(default = false)]
+#[query(default)]
 async fn query_sha256(_engine: &mut PluginEngine, content: Vec<u8>) -> Result<Vec<u8>> {
 	let mut hasher = Sha256::new();
 	hasher.update(content.as_slice());


### PR DESCRIPTION
Resolves #501 .

Adds the `fn record_concern` to `PluginEngine`, so that query endpoints can add concerns to be passed along with the return value of the query.

Fixes a few bugs, such as "default" queries not getting an empty-string name in the SDK macros crate.