### PR TITLE
feat: add Entropy plugin and Linguist plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "entropy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dashmap",
+ "finl_unicode",
+ "futures",
+ "hipcheck-sdk",
+ "ordered-float",
+ "pathbuf",
+ "rayon",
+ "salsa",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1793,21 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linguist"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hipcheck-sdk",
+ "log",
+ "pathbuf",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ members = [
     "plugins/npm_dependencies",
     "plugins/activity",
     "plugins/affiliation",
-    "plugins/fuzz"
+    "plugins/fuzz",
+    "plugins/entropy",
+    "plugins/linguist",
 ]
 
 # Make sure Hipcheck is run with `cargo run`.

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "entropy"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.89"
+clap = { version = "4.5.20", features = ["derive"] }
+dashmap = { version = "6.1.0", features = ["inline", "rayon"] }
+finl_unicode = { version = "1.2.0", features = ["grapheme_clusters"] }
+futures = "0.3.31"
+hipcheck-sdk = { version = "0.1.0", path = "../../sdk/rust", features = ["macros"] }
+ordered-float = { version = "4.3.0", features = ["serde"] }
+pathbuf = "1.0.0"
+rayon = "1.10.0"
+salsa = "0.16.1"
+schemars = "0.8.21"
+serde = "1.0.210"
+serde_json = "1.0.128"
+tokio = { version = "1.40.0", features = ["rt"] }
+toml = "0.8.19"
+unicode-normalization = "0.1.24"
+
+[dev-dependencies]
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros", "mock_engine"] }

--- a/plugins/entropy/src/error/context.rs
+++ b/plugins/entropy/src/error/context.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! A duplicate of the `anyhow::Context` extension trait intended to
+//! make error propagation less verbose.
+
+use crate::error::{Error, Introspect};
+use std::error::Error as StdError;
+
+/// Functions for adding context to an error result
+///
+/// The `Context` trait is based around the `Error` type defined in
+/// this crate.  Aside from the changed method names (collision
+/// avoidance), it is a duplicate of the `anyhow::Context` trait.
+/// Like its `anyhow` counterpart, this trait is sealed.
+pub trait Context<T>: sealed::Sealed {
+	/// Add context to an error
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static;
+
+	/// Lazily add context to an error
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C;
+}
+
+// `Context` is implemented only for those result types encountered
+// when entering or traversing the query system: `Result<T, Error>`
+// and `Result<T, E>` for dynamic error types `E`.
+
+impl<T> Context<T> for Result<T, Error> {
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+	{
+		self.map_err(|err| err.context(context))
+	}
+
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C,
+	{
+		self.map_err(|err| err.context(context_fn()))
+	}
+}
+
+impl<T, E> Context<T> for Result<T, E>
+where
+	E: StdError + Send + Sync + 'static,
+{
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+	{
+		self.map_err(|err| Error::from(err).context(context))
+	}
+
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C,
+	{
+		self.map_err(|err| Error::from(err).context(context_fn()))
+	}
+}
+
+// Restricts implementations of `Context` only to those contained in
+// this module
+mod sealed {
+	use super::{Error, StdError};
+
+	pub trait Sealed {}
+
+	impl<T> Sealed for Result<T, Error> {}
+
+	impl<T, E> Sealed for Result<T, E> where E: StdError + 'static {}
+}
+
+#[cfg(test)]
+mod tests {
+	//! Tests to ensure `Context` produces output correctly.
+
+	use crate::error::Error;
+	use std::{io, io::ErrorKind};
+
+	// Message source root error with no context
+	#[test]
+	fn debug_behavior_msg_no_context() {
+		let error = Error::msg("error message");
+		let debug = format!("{:?}", error);
+		let expected = "error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Message source root error with a single context message
+	#[test]
+	fn debug_behavior_msg_single_context() {
+		let error = Error::msg("error message").context("context");
+		let debug = format!("{:?}", error);
+		let expected = "context\n\nCaused by: \n    0: error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Message source root error with multiple context messages
+	#[test]
+	fn debug_behavior_msg_multiple_context() {
+		let error = Error::msg("error message")
+			.context("context 1")
+			.context("context 2");
+		let debug = format!("{:?}", error);
+		let expected =
+			"context 2\n\nCaused by: \n    0: context 1\n    1: error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with no context
+	#[test]
+	fn debug_behavior_std_no_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		));
+
+		let debug = format!("{:?}", error);
+		let expected = "connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with a single context message
+	#[test]
+	fn debug_behavior_std_single_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		))
+		.context("context");
+
+		let debug = format!("{:?}", error);
+		let expected = "context\n\nCaused by: \n    0: connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with multiple context messages
+	#[test]
+	fn debug_behavior_std_multiple_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		))
+		.context("context 1")
+		.context("context 2");
+
+		let debug = format!("{:?}", error);
+		let expected =
+			"context 2\n\nCaused by: \n    0: context 1\n    1: connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+}

--- a/plugins/entropy/src/error/mod.rs
+++ b/plugins/entropy/src/error/mod.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused)]
+
+//! An error type suitable for use in Hipcheck's query system.
+//!
+//! Salsa requires memoized query-value types to implement `Clone` and
+//! `Eq`. The `anyhow::Error` type implements neither, making it
+//! difficult to work with directly in this setting.
+//!
+//! Instead, the `Error` type defined in this crate ensures queries
+//! which error out aren't retried, as it always compares as equal to
+//! any other error.
+
+mod context;
+
+pub use crate::error::context::Context;
+use std::{
+	borrow::Cow,
+	error::Error as StdError,
+	fmt,
+	fmt::{Debug, Display},
+	sync::Arc,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A type convertible into a `Cow<'static, str>`.
+///
+/// This impl ensures we can avoid allocations for all of the static string
+/// error messages which exist in the Hipcheck source code.
+pub trait Introspect: Into<Cow<'static, str>> {}
+impl<T: Into<Cow<'static, str>>> Introspect for T {}
+
+/// An error type compatible with Salsa.
+pub struct Error {
+	/// The start of the error linked list.
+	head: Arc<ErrorNode>,
+}
+
+impl Error {
+	/// Create a new `Error` with a message source.
+	pub fn msg(message: impl Introspect) -> Self {
+		let error = Message(message.into());
+		Error::new(error)
+	}
+
+	/// Create a new `Error` from a source error.
+	pub fn new<M>(error: M) -> Self
+	where
+		M: StdError + Send + Sync + 'static,
+	{
+		Error {
+			head: Arc::new(ErrorNode {
+				current: Arc::new(error),
+				next: None,
+			}),
+		}
+	}
+
+	/// Add additional context to an `Error`
+	pub(crate) fn context<M>(self, context: M) -> Self
+	where
+		M: Introspect + 'static,
+	{
+		let message: Cow<'static, str> = context.into();
+
+		Error {
+			head: Arc::new(ErrorNode {
+				current: Arc::new(Message(message)),
+				next: Some(self.head),
+			}),
+		}
+	}
+
+	/// Get an iterator over the errors in a chain.
+	pub fn chain(&self) -> Chain {
+		Chain::new(self)
+	}
+}
+
+/// Allows use of `?` operator on query system entry.
+impl<T> From<T> for Error
+where
+	T: StdError + Send + Sync + 'static,
+{
+	fn from(std_error: T) -> Error {
+		Error::new(std_error)
+	}
+}
+
+impl Clone for Error {
+	fn clone(&self) -> Error {
+		Error {
+			head: Arc::clone(&self.head),
+		}
+	}
+}
+
+// By defining all `Error` instances to be equal, the query system
+// will not update a value with further errors after reaching an
+// initial one.
+impl PartialEq for Error {
+	fn eq(&self, _: &Self) -> bool {
+		true
+	}
+}
+
+impl Eq for Error {}
+
+impl Debug for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Delegate to the debug impl for the head of the list.
+		Debug::fmt(self.head.as_ref(), f)
+	}
+}
+
+impl Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Delegate to the display impl for the head of the list.
+		Display::fmt(self.head.as_ref(), f)
+	}
+}
+
+/// A single node in the linked list of errors.
+pub struct ErrorNode {
+	/// The current error.
+	current: ErrorObj,
+	/// A next error, if present.
+	next: Option<ErrorLink>,
+}
+
+impl Debug for ErrorNode {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.current)?;
+
+		if self.next.is_some() {
+			write!(f, "\n\nCaused by: ")?;
+
+			let mut index = 0;
+			let mut link = self.next.as_ref();
+
+			while let Some(step) = link {
+				write!(f, "\n{:5}: {}", index, step.current)?;
+				link = step.next.as_ref();
+				index += 1;
+			}
+
+			match (index, link) {
+				// Only printed one message.
+				(0, Some(step)) => write!(f, "\n    {}", step.current)?,
+				// Printed more than one.
+				(_, Some(step)) => write!(f, "\n{:5}: {}", index, step.current)?,
+				// Nothing to print.
+				(_, None) => {}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+impl Display for ErrorNode {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.current)
+	}
+}
+
+impl StdError for ErrorNode {
+	fn source(&self) -> Option<&(dyn StdError + 'static)> {
+		self.next
+			.as_deref()
+			.map(|node| node as &(dyn StdError + 'static))
+	}
+}
+
+/// A reference-counted fat pointer to a standard error type.
+type ErrorObj = Arc<dyn StdError + Send + Sync + 'static>;
+
+/// A link in the linked list.
+type ErrorLink = Arc<ErrorNode>;
+
+/// A string-only error message, which can either be a static string
+/// slice, or an owned string.
+#[derive(Debug)]
+struct Message(Cow<'static, str>);
+
+impl Display for Message {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
+
+impl StdError for Message {
+	fn source(&self) -> Option<&(dyn StdError + 'static)> {
+		None
+	}
+}
+
+pub struct Chain<'e> {
+	current: Option<&'e ErrorNode>,
+}
+
+impl<'e> Chain<'e> {
+	fn new(error: &Error) -> Chain<'_> {
+		Chain {
+			current: Some(error.head.as_ref()),
+		}
+	}
+}
+
+impl<'e> Iterator for Chain<'e> {
+	type Item = &'e ErrorNode;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		match self.current {
+			Some(node) => {
+				self.current = node.next.as_deref();
+				Some(node)
+			}
+			None => None,
+		}
+	}
+}
+
+/// A limited analogue of the `anyhow!` macro for `Error`.  Only
+/// intended for input suitable for the `Error::msg` function.
+#[macro_export]
+macro_rules! hc_error {
+    ($msg:literal $(,)?) => {
+        $crate::error::Error::msg($msg)
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::error::Error::msg(format!($fmt, $($arg)*))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+	//! Tests to ensure `Error` produces output correctly.
+
+	// Literal input to `hc_error`
+	#[test]
+	fn macro_literal() {
+		let error = hc_error!("msg source");
+		let debug = format!("{:?}", error);
+		let expected = "msg source".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Format string input to `hc_error`
+	#[test]
+	fn macro_format_string() {
+		let msg = "msg";
+		let source = "source";
+		let error = hc_error!("format {} {}", msg, source);
+		let debug = format!("{:?}", error);
+		let expected = "format msg source".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Verify that the `chain` method on `hc_error` works.
+	#[test]
+	fn hc_error_chain() {
+		let error = hc_error!("first error");
+		let error = error.context("second error");
+		let error = error.context("third error");
+
+		let mut iter = error.chain();
+
+		assert_eq!("third error", iter.next().unwrap().to_string());
+		assert_eq!("second error", iter.next().unwrap().to_string());
+		assert_eq!("first error", iter.next().unwrap().to_string());
+	}
+}

--- a/plugins/entropy/src/linguist/db.rs
+++ b/plugins/entropy/src/linguist/db.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::linguist::SourceFileDetector;
+
+use std::sync::Arc;
+
+#[salsa::query_group(LinguistStorage)]
+pub trait LinguistSource: salsa::Database {
+	/// Returns the code detector for the current session
+	#[salsa::input]
+	fn source_file_detector(&self) -> Arc<SourceFileDetector>;
+
+	/// Returns likely source file assessment for `file_name`
+	fn is_likely_source_file(&self, file_name: String) -> bool;
+}
+
+fn is_likely_source_file(db: &dyn LinguistSource, file_name: String) -> bool {
+	db.source_file_detector().is_likely_source_file(file_name)
+}
+
+#[derive(Default)]
+#[salsa::database(LinguistStorage)]
+pub struct Linguist {
+	storage: salsa::Storage<Self>,
+}
+impl Linguist {
+	pub fn new() -> Self {
+		Linguist {
+			storage: Default::default(),
+		}
+	}
+}
+
+impl salsa::Database for Linguist {}

--- a/plugins/entropy/src/linguist/fs.rs
+++ b/plugins/entropy/src/linguist/fs.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context as _, Result};
+use serde::de::DeserializeOwned;
+use std::{fs, path::Path};
+
+/// Read a file to a string.
+pub fn read_string<P: AsRef<Path>>(path: P) -> Result<String> {
+	fn inner(path: &Path) -> Result<String> {
+		fs::read_to_string(path)
+			.with_context(|| format!("failed to read as UTF-8 string '{}'", path.display()))
+	}
+
+	inner(path.as_ref())
+}
+
+/// Read file to a struct that can be deserialized from TOML format.
+pub fn read_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P) -> Result<T> {
+	let path = path.as_ref();
+	let contents = read_string(path)?;
+	toml::de::from_str(&contents)
+		.with_context(|| format!("failed to read as TOML '{}'", path.display()))
+}

--- a/plugins/entropy/src/linguist/mod.rs
+++ b/plugins/entropy/src/linguist/mod.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod db;
+mod fs;
+
+pub use db::{Linguist, LinguistSource};
+
+use anyhow::{Context as _, Result};
+use fs::read_toml;
+use serde::{de::Visitor, Deserialize, Deserializer};
+use std::{convert::AsRef, fmt, fmt::Formatter, path::Path, result::Result as StdResult};
+
+/// Detects whether a file name is a likely source code file.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SourceFileDetector {
+	extensions: Vec<String>,
+}
+
+impl SourceFileDetector {
+	#[cfg(test)]
+	pub fn new(raw_exts: Vec<&str>) -> Self {
+		let extensions = raw_exts.into_iter().map(str::to_owned).collect();
+		SourceFileDetector { extensions }
+	}
+
+	/// Constructs a new `SourceFileDetector` from the `languages.yml` file.
+	pub fn load<P: AsRef<Path>>(langs_file: P) -> Result<SourceFileDetector> {
+		fn inner(langs_file: &Path) -> Result<SourceFileDetector> {
+			// Load the file and parse it.
+			let language_file: LanguageFile = read_toml(langs_file)
+				.context("failed to read language definitions from langs file")?;
+
+			// Get the list of extensions from it.
+			let extensions = language_file.into_extensions();
+
+			// Return the initialized detector.
+			Ok(SourceFileDetector { extensions })
+		}
+
+		inner(langs_file.as_ref())
+	}
+
+	/// Checks whether a given file is a likely source file based on its file
+	/// extension.
+	pub fn is_likely_source_file<P: AsRef<Path>>(&self, file_name: P) -> bool {
+		fn inner(source_file_detector: &SourceFileDetector, file_name: &Path) -> bool {
+			let extension = match file_name.extension() {
+				// Convert &OsStr to Cow<&str> and prepend a period to match the file
+				Some(e) => format!(".{}", e.to_string_lossy()),
+				// If we can't find an extension, include the file.
+				None => return true,
+			};
+
+			for ext in &source_file_detector.extensions {
+				if *ext == extension {
+					return true;
+				}
+			}
+
+			false
+		}
+
+		inner(self, file_name.as_ref())
+	}
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageFile {
+	languages: Vec<LanguageExtensions>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageExtensions {
+	#[serde(default = "missing_lang_type")]
+	r#type: LanguageType,
+	extensions: Option<Vec<String>>,
+}
+
+impl LanguageFile {
+	fn into_extensions(self) -> Vec<String> {
+		let mut result = Vec::new();
+
+		for language in self.languages {
+			if matches!(language.r#type, LanguageType::Programming) {
+				match language.extensions {
+					None => continue,
+					Some(mut extensions) => result.extend(extensions.drain(0..)),
+				}
+			}
+		}
+
+		result
+	}
+}
+
+#[derive(Debug)]
+enum LanguageType {
+	Data,
+	Programming,
+	Markup,
+	Prose,
+	Missing,
+}
+
+fn missing_lang_type() -> LanguageType {
+	LanguageType::Missing
+}
+
+impl<'de> Deserialize<'de> for LanguageType {
+	fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_str(LanguageTypeVisitor)
+	}
+}
+
+struct LanguageTypeVisitor;
+
+impl<'de> Visitor<'de> for LanguageTypeVisitor {
+	type Value = LanguageType;
+
+	fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "'data', 'programming', 'markup', or 'prose'")
+	}
+
+	fn visit_str<E>(self, value: &str) -> StdResult<Self::Value, E>
+	where
+		E: serde::de::Error,
+	{
+		match value {
+			"data" => Ok(LanguageType::Data),
+			"programming" => Ok(LanguageType::Programming),
+			"markup" => Ok(LanguageType::Markup),
+			"prose" => Ok(LanguageType::Prose),
+			_ => Err(serde::de::Error::custom("unknown language type")),
+		}
+	}
+}

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod error;
+mod linguist;
+mod metric;
+mod types;
+
+use crate::{linguist::*, metric::*, types::*};
+
+use clap::Parser;
+use hipcheck_sdk::{prelude::*, types::Target};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use std::{
+	path::PathBuf,
+	result::Result as StdResult,
+	sync::{Arc, OnceLock},
+};
+
+#[derive(Deserialize)]
+struct Config {
+	langs_file: Option<PathBuf>,
+}
+
+pub static DATABASE: OnceLock<Arc<Mutex<Linguist>>> = OnceLock::new();
+
+#[query]
+async fn commit_entropies(
+	_engine: &mut PluginEngine,
+	commit_diffs: Vec<CommitDiff>,
+) -> Result<Vec<CommitEntropy>> {
+	// Calculate the grapheme frequencies for each commit which contains code.
+	let mut filtered: Vec<CommitDiff> = vec![];
+	let linguist = DATABASE
+		.get()
+		.ok_or(Error::UnspecifiedQueryState)?
+		.lock()
+		.await;
+	for cd in commit_diffs.into_iter() {
+		if is_likely_source_file_cd(&linguist, &cd) {
+			filtered.push(cd);
+		}
+	}
+	let commit_freqs = filtered
+		.iter()
+		.map(|x| grapheme_freqs(&linguist, x))
+		.collect::<Vec<CommitGraphemeFreq>>();
+
+	drop(linguist);
+
+	// Calculate baseline grapheme frequencies across all commits which contain code.
+	let baseline_freqs = baseline_freqs(&commit_freqs);
+
+	// Calculate the entropy of each commit which contains code.
+	let mut commit_entropies = commit_freqs
+		.iter()
+		.map(|commit_freq| commit_entropy(commit_freq, &baseline_freqs))
+		.collect::<Vec<_>>();
+
+	// Sort the commits	by entropy score
+	// PANIC: It is safe to unwrap here, because the entropy scores will always be valid floating point numbers if we get to this point
+	commit_entropies.sort_by(|a, b| b.entropy.partial_cmp(&a.entropy).unwrap());
+
+	// Convert to Z-scores and return results.
+	z_scores(commit_entropies).map_err(|_| Error::UnspecifiedQueryState)
+}
+
+#[query(default)]
+async fn entropy(engine: &mut PluginEngine, value: Target) -> Result<Vec<f64>> {
+	let local = value.local;
+	let val_commits = engine.query("mitre/git/commit_diffs", local).await?;
+	let commits: Vec<CommitDiff> =
+		serde_json::from_value(val_commits).map_err(Error::InvalidJsonInQueryOutput)?;
+	Ok(commit_entropies(engine, commits)
+		.await?
+		.iter()
+		.map(|o| o.entropy)
+		.collect())
+}
+
+#[derive(Clone, Debug)]
+struct EntropyPlugin;
+
+impl Plugin for EntropyPlugin {
+	const PUBLISHER: &'static str = "mitre";
+	const NAME: &'static str = "entropy";
+	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
+		let conf: Config =
+			serde_json::from_value(config).map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?;
+		let sfd = match conf.langs_file {
+			Some(p) => SourceFileDetector::load(p).map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?,
+			None => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "langs_file".to_owned(),
+					field_type: "string".to_owned(),
+					possible_values: vec![],
+				});
+			}
+		};
+		let mut database = Linguist::new();
+		database.set_source_file_detector(Arc::new(sfd));
+		let global_db = Arc::new(Mutex::new(database));
+		DATABASE
+			.set(global_db)
+			.map_err(|_e| ConfigError::Unspecified {
+				message: "config was already set".to_owned(),
+			})
+	}
+
+	fn default_policy_expr(&self) -> Result<String> {
+		Ok("".to_owned())
+	}
+
+	fn explain_default_query(&self) -> Result<Option<String>> {
+		Ok(None)
+	}
+
+	queries! {}
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(EntropyPlugin {})
+		.listen(args.port)
+		.await
+}

--- a/plugins/entropy/src/metric.rs
+++ b/plugins/entropy/src/metric.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	error::*,
+	hc_error,
+	linguist::{Linguist, LinguistSource},
+	types::*,
+};
+use dashmap::DashMap;
+use finl_unicode::grapheme_clusters::Graphemes;
+use rayon::prelude::*;
+use std::{collections::HashMap, iter::Iterator, ops::Not};
+use unicode_normalization::UnicodeNormalization;
+
+/// Check if a commit diff is a likely source file.
+pub fn is_likely_source_file_cd(linguist: &Linguist, commit_diff: &CommitDiff) -> bool {
+	let mut has_source = false;
+	for fd in commit_diff.diff.file_diffs.iter() {
+		has_source |= linguist.is_likely_source_file(fd.file_name.clone());
+	}
+	has_source
+}
+
+/// Calculate the arithmetic mean for a set of floats. Returns an option to account
+/// for the possibility of dividing by zero.
+pub fn mean(data: &[f64]) -> Option<f64> {
+	// Do not use rayon's parallel iter/sum here due to the non-associativity of floating point numbers/math.
+	// See: https://en.wikipedia.org/wiki/Associative_property#Nonassociativity_of_floating_point_calculation.
+	let sum = data.iter().sum::<f64>();
+	let count = data.len();
+
+	match count {
+		positive if positive > 0 => Some(sum / count as f64),
+		_ => None,
+	}
+}
+
+/// Calculate the standard deviation for a set of floats. Returns an option to
+/// account for the possibility of dividing by zero.
+pub fn std_dev(mean: f64, data: &[f64]) -> Option<f64> {
+	match (mean, data.len()) {
+		(mean, count) if count > 0 => {
+			let variance =
+				data.iter()
+					.map(|value| {
+						let diff = mean - *value;
+						diff * diff
+					})
+					.sum::<f64>() / count as f64;
+
+			Some(variance.sqrt())
+		}
+		_ => None,
+	}
+}
+
+/// Calculate grapheme frequencies for each commit.
+pub fn grapheme_freqs(linguist: &Linguist, commit_diff: &CommitDiff) -> CommitGraphemeFreq {
+	// #[cfg(feature = "print-timings")]
+	// let _0 = crate::benchmarking::print_scope_time!("grapheme_freqs");
+
+	// Dashmap (fast concurrent hashmap) to store counts for each grapheme.
+	let grapheme_table: DashMap<String, u64> = DashMap::new();
+
+	// Use this variable to track the total number of graphemes accross all patches in this commit diff.
+	let tgt_diffs: Vec<&FileDiff> = commit_diff
+		.diff
+		.file_diffs
+		.iter()
+		.filter(|file_diff| {
+			// Filter out any that are probably not source files, or are empty patches
+			let is_source = linguist.is_likely_source_file(file_diff.file_name.clone());
+			is_source && file_diff.patch.is_empty().not()
+		})
+		.collect();
+	// Use this variable to track the total number of graphemes accross all patches in this commit diff.
+	let total_graphemes: usize = tgt_diffs
+		// Iterate over each line of each file in parallel
+		.par_iter()
+		.flat_map(|file_diff| file_diff.patch.par_lines())
+		// Normalize each line.
+		// See https://en.wikipedia.org/wiki/Unicode_equivalence.
+		.map(|line: &str| line.chars().nfc().collect::<String>())
+		// Count the graphemes in each normalized line.
+		// Also update the graphemes table here.
+		// We'll sum these counts to get the total number of graphemes.
+		.map(|normalized_line: String| {
+			// Create an iterator over the graphemes in the line.
+			Graphemes::new(&normalized_line)
+				// Update the graphemes table.
+				.map(|grapheme: &str| {
+					// Use this if statement to avoid allocating a new string unless needed.
+					if let Some(mut count) = grapheme_table.get_mut(grapheme) {
+						*count += 1;
+					} else {
+						grapheme_table.insert(grapheme.to_owned(), 1);
+					}
+				})
+				// get the grapheme count for this normalized line.
+				.count()
+		})
+		// Aggregate the grapheme count across all lines of all files
+		.sum();
+
+	// Transform out table (dashmap) of graphemes and their frequencies into a list to return.
+	let grapheme_freqs = grapheme_table
+		// Iterate in parallel for performance.
+		.into_par_iter()
+		.map(|(grapheme, count)| GraphemeFreq {
+			grapheme,
+			freq: count as f64 / total_graphemes as f64,
+		})
+		.collect();
+
+	// Return the collected list of graphemes and their frequencies for this commit diff.
+	CommitGraphemeFreq {
+		commit: commit_diff.commit.clone(),
+		grapheme_freqs,
+	}
+}
+
+/// Calculate baseline frequencies for each grapheme across all commits.
+pub fn baseline_freqs(commit_freqs: &[CommitGraphemeFreq]) -> HashMap<&str, (f64, i64)> {
+	// PERFORMANCE: At the moment this function appears to be faster single-threaded.
+	// I tried switching out the hashmap with a Dashamp and switching the iterator to rayon,
+	// but the overhead is not worth it (against express we go from 3 milliseconds to 6).
+	// This may be worth revisiting if we prioritize projects with huge numbers of commits, but at the moment
+	// I will leave it be.
+
+	let mut baseline: HashMap<&str, (f64, i64)> = HashMap::new();
+
+	commit_freqs
+		.iter()
+		.flat_map(|cf: &CommitGraphemeFreq| cf.grapheme_freqs.iter().map(GraphemeFreq::as_view))
+		.for_each(|view: GraphemeFreqView| {
+			let entry = baseline.entry(view.grapheme).or_insert((0.0, 0));
+			let cum_avg = entry.0;
+			let n = entry.1;
+			entry.0 = (view.freq + (n as f64) * cum_avg) / ((n + 1) as f64);
+			entry.1 = n + 1;
+		});
+
+	baseline
+}
+
+/// Calculate commit entropy for each commit.
+pub fn commit_entropy(
+	commit_freq: &CommitGraphemeFreq,
+	baseline: &HashMap<&str, (f64, i64)>,
+) -> CommitEntropy {
+	let commit = commit_freq.commit.clone();
+	let entropy = commit_freq
+		.grapheme_freqs
+		.iter()
+		.map(|grapheme_freq| {
+			// Get the freq for the current commit & grapheme.
+			let freq = grapheme_freq.freq;
+
+			// Get the baseline freq for that grapheme across all commits.
+			let grapheme = grapheme_freq.grapheme.as_str();
+			let baseline_freq = baseline.get(grapheme).unwrap().0;
+
+			// Calculate the score for that grapheme.
+			freq * (freq / baseline_freq).log2()
+		})
+		// Sum all individual grapheme scores together to get the commit's entropy.
+		.sum();
+
+	CommitEntropy { commit, entropy }
+}
+
+/// Convert entropy scores to Z-scores of the underlying metric.
+pub fn z_scores(mut commit_entropies: Vec<CommitEntropy>) -> Result<Vec<CommitEntropy>> {
+	let entropies: Vec<_> = commit_entropies.iter().map(|c| c.entropy).collect();
+
+	let mean = mean(&entropies).ok_or_else(|| hc_error!("failed to get mean entropy"))?;
+	let std_dev = std_dev(mean, &entropies)
+		.ok_or_else(|| hc_error!("failed to get entropy standard deviation"))?;
+
+	if std_dev == 0.0 {
+		return Err(hc_error!("not enough commits to calculate entropy"));
+	}
+
+	for commit_entropy in &mut commit_entropies {
+		commit_entropy.entropy = (commit_entropy.entropy - mean) / std_dev;
+	}
+
+	Ok(commit_entropies)
+}

--- a/plugins/entropy/src/types.rs
+++ b/plugins/entropy/src/types.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::result::Result;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
+pub struct Commit {
+	pub hash: String,
+	pub written_on: Result<String, String>,
+	pub committed_on: Result<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct FileDiff {
+	pub file_name: String,
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub patch: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct Diff {
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub file_diffs: Vec<FileDiff>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct CommitDiff {
+	pub commit: Commit,
+	pub diff: Diff,
+}
+
+/// The entropy of a single commit.
+#[derive(Debug, Serialize, Clone, JsonSchema, Deserialize)]
+pub struct CommitEntropy {
+	/// The commit
+	pub commit: Commit,
+	/// The entropy score
+	pub entropy: f64,
+}
+
+/// The grapheme frequencies of a single commit.
+#[derive(Debug)]
+pub struct CommitGraphemeFreq {
+	/// The commit.
+	pub commit: Commit,
+	/// The set of grapheme frequencies.
+	pub grapheme_freqs: Vec<GraphemeFreq>,
+}
+
+/// The frequency of a single grapheme.
+#[derive(Debug)]
+pub struct GraphemeFreq {
+	/// The grapheme.
+	pub grapheme: String,
+	/// The frequency.
+	pub freq: f64,
+}
+
+impl GraphemeFreq {
+	pub fn as_view(&self) -> GraphemeFreqView<'_> {
+		GraphemeFreqView {
+			grapheme: &self.grapheme,
+			freq: self.freq,
+		}
+	}
+}
+
+/// A view of a grapheme frequency.
+pub struct GraphemeFreqView<'gra> {
+	/// The view of the grapheme.
+	pub grapheme: &'gra str,
+	/// The freq (fine to copy)
+	pub freq: f64,
+}

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "linguist"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.89"
+clap = { version = "4.5.20", features = ["derive"] }
+hipcheck-sdk = { version = "0.1.0", path = "../../sdk/rust", features = ["macros"] }
+log = "0.4.22"
+pathbuf = "1.0.0"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
+tokio = { version = "1.40.0", features = ["rt"] }
+toml = "0.8.19"
+
+[dev-dependencies]
+hipcheck-sdk = { path = "../../sdk/rust", features = ["macros", "mock_engine"] }

--- a/plugins/linguist/src/fs.rs
+++ b/plugins/linguist/src/fs.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context as _, Result};
+use serde::de::DeserializeOwned;
+use std::{fs, path::Path};
+
+/// Read a file to a string.
+pub fn read_string<P: AsRef<Path>>(path: P) -> Result<String> {
+	fn inner(path: &Path) -> Result<String> {
+		fs::read_to_string(path)
+			.with_context(|| format!("failed to read as UTF-8 string '{}'", path.display()))
+	}
+
+	inner(path.as_ref())
+}
+
+/// Read file to a struct that can be deserialized from TOML format.
+pub fn read_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P) -> Result<T> {
+	let path = path.as_ref();
+	let contents = read_string(path)?;
+	toml::de::from_str(&contents)
+		.with_context(|| format!("failed to read as TOML '{}'", path.display()))
+}

--- a/plugins/linguist/src/linguist.rs
+++ b/plugins/linguist/src/linguist.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::fs::read_toml;
+use anyhow::{Context as _, Result};
+use serde::{de::Visitor, Deserialize, Deserializer};
+use std::{convert::AsRef, fmt, fmt::Formatter, path::Path, result::Result as StdResult};
+
+/// Detects whether a file name is a likely source code file.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SourceFileDetector {
+	extensions: Vec<String>,
+}
+
+impl SourceFileDetector {
+	#[cfg(test)]
+	pub fn new(raw_exts: Vec<&str>) -> Self {
+		let extensions = raw_exts.into_iter().map(str::to_owned).collect();
+		SourceFileDetector { extensions }
+	}
+
+	/// Constructs a new `SourceFileDetector` from the `languages.yml` file.
+	pub fn load<P: AsRef<Path>>(langs_file: P) -> Result<SourceFileDetector> {
+		fn inner(langs_file: &Path) -> Result<SourceFileDetector> {
+			// Load the file and parse it.
+			let language_file: LanguageFile = read_toml(langs_file)
+				.context("failed to read language definitions from langs file")?;
+
+			// Get the list of extensions from it.
+			let extensions = language_file.into_extensions();
+
+			// Return the initialized detector.
+			Ok(SourceFileDetector { extensions })
+		}
+
+		inner(langs_file.as_ref())
+	}
+
+	/// Checks whether a given file is a likely source file based on its file
+	/// extension.
+	pub fn is_likely_source_file<P: AsRef<Path>>(&self, file_name: P) -> bool {
+		fn inner(source_file_detector: &SourceFileDetector, file_name: &Path) -> bool {
+			let extension = match file_name.extension() {
+				// Convert &OsStr to Cow<&str> and prepend a period to match the file
+				Some(e) => format!(".{}", e.to_string_lossy()),
+				// If we can't find an extension, include the file.
+				None => return true,
+			};
+
+			for ext in &source_file_detector.extensions {
+				if *ext == extension {
+					return true;
+				}
+			}
+
+			false
+		}
+
+		inner(self, file_name.as_ref())
+	}
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageFile {
+	languages: Vec<LanguageExtensions>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageExtensions {
+	#[serde(default = "missing_lang_type")]
+	r#type: LanguageType,
+	extensions: Option<Vec<String>>,
+}
+
+impl LanguageFile {
+	fn into_extensions(self) -> Vec<String> {
+		let mut result = Vec::new();
+
+		for language in self.languages {
+			if matches!(language.r#type, LanguageType::Programming) {
+				match language.extensions {
+					None => continue,
+					Some(mut extensions) => result.extend(extensions.drain(0..)),
+				}
+			}
+		}
+
+		log::trace!("linguist known code extensions [exts='{:#?}']", result);
+
+		result
+	}
+}
+
+#[derive(Debug)]
+enum LanguageType {
+	Data,
+	Programming,
+	Markup,
+	Prose,
+	Missing,
+}
+
+fn missing_lang_type() -> LanguageType {
+	LanguageType::Missing
+}
+
+impl<'de> Deserialize<'de> for LanguageType {
+	fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_str(LanguageTypeVisitor)
+	}
+}
+
+struct LanguageTypeVisitor;
+
+impl<'de> Visitor<'de> for LanguageTypeVisitor {
+	type Value = LanguageType;
+
+	fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "'data', 'programming', 'markup', or 'prose'")
+	}
+
+	fn visit_str<E>(self, value: &str) -> StdResult<Self::Value, E>
+	where
+		E: serde::de::Error,
+	{
+		match value {
+			"data" => Ok(LanguageType::Data),
+			"programming" => Ok(LanguageType::Programming),
+			"markup" => Ok(LanguageType::Markup),
+			"prose" => Ok(LanguageType::Prose),
+			_ => Err(serde::de::Error::custom("unknown language type")),
+		}
+	}
+}

--- a/plugins/linguist/src/main.rs
+++ b/plugins/linguist/src/main.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plugin for determining if a particular path is a source file
+
+mod fs;
+mod linguist;
+
+use linguist::SourceFileDetector;
+
+use clap::Parser;
+use hipcheck_sdk::prelude::*;
+use serde::Deserialize;
+
+use std::{path::PathBuf, result::Result as StdResult, sync::OnceLock};
+
+#[derive(Deserialize)]
+struct Config {
+	langs_file: Option<PathBuf>,
+}
+
+static DETECTOR: OnceLock<SourceFileDetector> = OnceLock::new();
+
+#[query(default)]
+async fn is_likely_source_file(_engine: &mut PluginEngine, value: PathBuf) -> Result<bool> {
+	let Some(sfd) = DETECTOR.get() else {
+		return Err(Error::UnspecifiedQueryState);
+	};
+	Ok(sfd.is_likely_source_file(value))
+}
+
+#[derive(Clone, Debug)]
+struct LinguistPlugin;
+
+impl Plugin for LinguistPlugin {
+	const PUBLISHER: &'static str = "mitre";
+
+	const NAME: &'static str = "linguist";
+
+	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
+		let conf: Config =
+			serde_json::from_value(config).map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?;
+		let sfd = match conf.langs_file {
+			Some(p) => SourceFileDetector::load(p).map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?,
+			None => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "langs_file".to_owned(),
+					field_type: "string".to_owned(),
+					possible_values: vec![],
+				});
+			}
+		};
+		DETECTOR.set(sfd).map_err(|_e| ConfigError::Unspecified {
+			message: "config was already set".to_owned(),
+		})
+	}
+
+	fn default_policy_expr(&self) -> Result<String> {
+		Ok("".to_owned())
+	}
+
+	fn explain_default_query(&self) -> Result<Option<String>> {
+		Ok(None)
+	}
+
+	queries! {}
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(LinguistPlugin {})
+		.listen(args.port)
+		.await
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use pathbuf::pathbuf;
+
+	fn source_file_detector() -> SourceFileDetector {
+		SourceFileDetector::new(vec![".c"])
+	}
+
+	#[tokio::test]
+	async fn test_is_likely_source_file() {
+		DETECTOR.set(source_file_detector()).unwrap();
+		let mut engine = PluginEngine::mock(MockResponses::new());
+
+		let source_path = pathbuf!["source.c"];
+		let not_source_path = pathbuf!["source.txt"];
+
+		let res = is_likely_source_file(&mut engine, source_path)
+			.await
+			.unwrap();
+		assert_eq!(true, res);
+
+		let res = is_likely_source_file(&mut engine, not_source_path)
+			.await
+			.unwrap();
+		assert_eq!(false, res);
+	}
+}


### PR DESCRIPTION
Resolves #489 .

`entropy::error` module is directly copied from Hipcheck core `error` module, can be ignored. Similarly, `entropy::linguist::{mod.rs, file.rs}` are copied from Hipcheck core with minimal alteration.

This PR adds the entropy plugin, which relies on a "lingust" analysis to determine whether or not a file is likely a source code file. This PR checks in a linguist plugin, but due to performance concerns, the entropy plugin currently does not use that analysis. Instead, it runs its own internal `salsa` database similar to how linguist results have been memo-ized in Hipcheck core. In the future, when #502 is implemented, we can modify entropy and churn plugins to do things "properly" by having the linguist plugin as a dependency and requesting the source code determination from it.