### PR TITLE
feat: add churn plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "churn"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "hipcheck-sdk",
+ "log",
+ "pathbuf",
+ "salsa",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,10 @@ members = [
     "plugins/entropy",
     "plugins/linguist",
     "plugins/review",
-    "plugins/binary"
-, "plugins/identity"]
+    "plugins/binary",
+    "plugins/identity",
+    "plugins/churn"
+]
 
 # Make sure Hipcheck is run with `cargo run`.
 #

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -106,7 +106,7 @@ impl ActivePlugin {
 			concerns: vec![],
 		};
 
-		eprintln!("Resuming query with answer {query:?}");
+		eprintln!("Resuming query");
 
 		Ok(self.channel.query(query).await?.into())
 	}

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -28,12 +28,11 @@ use xz2::read::XzDecoder;
 use super::get_current_arch;
 
 /// The plugins currently are not delegated via the `plugin` system and are still part of `hipcheck` core
-pub const MITRE_LEGACY_PLUGINS: [&str; 6] = [
+pub const MITRE_LEGACY_PLUGINS: [&str; 5] = [
 	"activity",
 	"entropy",
 	"affiliation",
 	"binary",
-	"churn",
 	"typo",
 ];
 

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "churn"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { version = "4.5.20", features = ["derive"] }
+hipcheck-sdk = { version = "0.1.0", path = "../../sdk/rust", features = ["macros"] }
+log = "0.4.22"
+salsa = "0.16.1"
+schemars = "0.8.21"
+serde = "1.0.213"
+serde_json = "1.0.132"
+tokio = { version = "1.41.0", features = ["rt"] }
+toml = "0.8.19"
+
+[dev-dependencies]
+hipcheck-sdk = { path = "../../sdk/rust", features = ["mock_engine"] }
+pathbuf = "1.0.0"

--- a/plugins/churn/plugin.kdl
+++ b/plugins/churn/plugin.kdl
@@ -1,0 +1,14 @@
+publisher "mitre"
+name "churn"
+version "0.1.0"
+license "Apache-2.0"
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/debug/churn"
+  on arch="x86_64-apple-darwin" "./target/debug/churn"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/churn"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/churn"
+}
+
+dependencies {
+  plugin "mitre/git" version="0.1.0" manifest="./plugins/git/plugin.kdl"
+}

--- a/plugins/churn/src/error/context.rs
+++ b/plugins/churn/src/error/context.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! A duplicate of the `anyhow::Context` extension trait intended to
+//! make error propagation less verbose.
+
+use crate::error::{Error, Introspect};
+use std::error::Error as StdError;
+
+/// Functions for adding context to an error result
+///
+/// The `Context` trait is based around the `Error` type defined in
+/// this crate.  Aside from the changed method names (collision
+/// avoidance), it is a duplicate of the `anyhow::Context` trait.
+/// Like its `anyhow` counterpart, this trait is sealed.
+pub trait Context<T>: sealed::Sealed {
+	/// Add context to an error
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static;
+
+	/// Lazily add context to an error
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C;
+}
+
+// `Context` is implemented only for those result types encountered
+// when entering or traversing the query system: `Result<T, Error>`
+// and `Result<T, E>` for dynamic error types `E`.
+
+impl<T> Context<T> for Result<T, Error> {
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+	{
+		self.map_err(|err| err.context(context))
+	}
+
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C,
+	{
+		self.map_err(|err| err.context(context_fn()))
+	}
+}
+
+impl<T, E> Context<T> for Result<T, E>
+where
+	E: StdError + Send + Sync + 'static,
+{
+	fn context<C>(self, context: C) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+	{
+		self.map_err(|err| Error::from(err).context(context))
+	}
+
+	fn with_context<C, F>(self, context_fn: F) -> Result<T, Error>
+	where
+		C: Introspect + 'static,
+		F: FnOnce() -> C,
+	{
+		self.map_err(|err| Error::from(err).context(context_fn()))
+	}
+}
+
+// Restricts implementations of `Context` only to those contained in
+// this module
+mod sealed {
+	use super::{Error, StdError};
+
+	pub trait Sealed {}
+
+	impl<T> Sealed for Result<T, Error> {}
+
+	impl<T, E> Sealed for Result<T, E> where E: StdError + 'static {}
+}
+
+#[cfg(test)]
+mod tests {
+	//! Tests to ensure `Context` produces output correctly.
+
+	use crate::error::Error;
+	use std::{io, io::ErrorKind};
+
+	// Message source root error with no context
+	#[test]
+	fn debug_behavior_msg_no_context() {
+		let error = Error::msg("error message");
+		let debug = format!("{:?}", error);
+		let expected = "error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Message source root error with a single context message
+	#[test]
+	fn debug_behavior_msg_single_context() {
+		let error = Error::msg("error message").context("context");
+		let debug = format!("{:?}", error);
+		let expected = "context\n\nCaused by: \n    0: error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Message source root error with multiple context messages
+	#[test]
+	fn debug_behavior_msg_multiple_context() {
+		let error = Error::msg("error message")
+			.context("context 1")
+			.context("context 2");
+		let debug = format!("{:?}", error);
+		let expected =
+			"context 2\n\nCaused by: \n    0: context 1\n    1: error message".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with no context
+	#[test]
+	fn debug_behavior_std_no_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		));
+
+		let debug = format!("{:?}", error);
+		let expected = "connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with a single context message
+	#[test]
+	fn debug_behavior_std_single_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		))
+		.context("context");
+
+		let debug = format!("{:?}", error);
+		let expected = "context\n\nCaused by: \n    0: connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Dynamic error source with multiple context messages
+	#[test]
+	fn debug_behavior_std_multiple_context() {
+		let error = Error::from(io::Error::new(
+			ErrorKind::ConnectionRefused,
+			"connection refused",
+		))
+		.context("context 1")
+		.context("context 2");
+
+		let debug = format!("{:?}", error);
+		let expected =
+			"context 2\n\nCaused by: \n    0: context 1\n    1: connection refused".to_string();
+		assert_eq!(expected, debug);
+	}
+}

--- a/plugins/churn/src/error/mod.rs
+++ b/plugins/churn/src/error/mod.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused)]
+
+//! An error type suitable for use in Hipcheck's query system.
+//!
+//! Salsa requires memoized query-value types to implement `Clone` and
+//! `Eq`. The `anyhow::Error` type implements neither, making it
+//! difficult to work with directly in this setting.
+//!
+//! Instead, the `Error` type defined in this crate ensures queries
+//! which error out aren't retried, as it always compares as equal to
+//! any other error.
+
+mod context;
+
+pub use crate::error::context::Context;
+use std::{
+	borrow::Cow,
+	error::Error as StdError,
+	fmt,
+	fmt::{Debug, Display},
+	sync::Arc,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A type convertible into a `Cow<'static, str>`.
+///
+/// This impl ensures we can avoid allocations for all of the static string
+/// error messages which exist in the Hipcheck source code.
+pub trait Introspect: Into<Cow<'static, str>> {}
+impl<T: Into<Cow<'static, str>>> Introspect for T {}
+
+/// An error type compatible with Salsa.
+pub struct Error {
+	/// The start of the error linked list.
+	head: Arc<ErrorNode>,
+}
+
+impl Error {
+	/// Create a new `Error` with a message source.
+	pub fn msg(message: impl Introspect) -> Self {
+		let error = Message(message.into());
+		Error::new(error)
+	}
+
+	/// Create a new `Error` from a source error.
+	pub fn new<M>(error: M) -> Self
+	where
+		M: StdError + Send + Sync + 'static,
+	{
+		Error {
+			head: Arc::new(ErrorNode {
+				current: Arc::new(error),
+				next: None,
+			}),
+		}
+	}
+
+	/// Add additional context to an `Error`
+	pub(crate) fn context<M>(self, context: M) -> Self
+	where
+		M: Introspect + 'static,
+	{
+		let message: Cow<'static, str> = context.into();
+
+		Error {
+			head: Arc::new(ErrorNode {
+				current: Arc::new(Message(message)),
+				next: Some(self.head),
+			}),
+		}
+	}
+
+	/// Get an iterator over the errors in a chain.
+	pub fn chain(&self) -> Chain {
+		Chain::new(self)
+	}
+}
+
+/// Allows use of `?` operator on query system entry.
+impl<T> From<T> for Error
+where
+	T: StdError + Send + Sync + 'static,
+{
+	fn from(std_error: T) -> Error {
+		Error::new(std_error)
+	}
+}
+
+impl Clone for Error {
+	fn clone(&self) -> Error {
+		Error {
+			head: Arc::clone(&self.head),
+		}
+	}
+}
+
+// By defining all `Error` instances to be equal, the query system
+// will not update a value with further errors after reaching an
+// initial one.
+impl PartialEq for Error {
+	fn eq(&self, _: &Self) -> bool {
+		true
+	}
+}
+
+impl Eq for Error {}
+
+impl Debug for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Delegate to the debug impl for the head of the list.
+		Debug::fmt(self.head.as_ref(), f)
+	}
+}
+
+impl Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Delegate to the display impl for the head of the list.
+		Display::fmt(self.head.as_ref(), f)
+	}
+}
+
+/// A single node in the linked list of errors.
+pub struct ErrorNode {
+	/// The current error.
+	current: ErrorObj,
+	/// A next error, if present.
+	next: Option<ErrorLink>,
+}
+
+impl Debug for ErrorNode {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.current)?;
+
+		if self.next.is_some() {
+			write!(f, "\n\nCaused by: ")?;
+
+			let mut index = 0;
+			let mut link = self.next.as_ref();
+
+			while let Some(step) = link {
+				write!(f, "\n{:5}: {}", index, step.current)?;
+				link = step.next.as_ref();
+				index += 1;
+			}
+
+			match (index, link) {
+				// Only printed one message.
+				(0, Some(step)) => write!(f, "\n    {}", step.current)?,
+				// Printed more than one.
+				(_, Some(step)) => write!(f, "\n{:5}: {}", index, step.current)?,
+				// Nothing to print.
+				(_, None) => {}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+impl Display for ErrorNode {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.current)
+	}
+}
+
+impl StdError for ErrorNode {
+	fn source(&self) -> Option<&(dyn StdError + 'static)> {
+		self.next
+			.as_deref()
+			.map(|node| node as &(dyn StdError + 'static))
+	}
+}
+
+/// A reference-counted fat pointer to a standard error type.
+type ErrorObj = Arc<dyn StdError + Send + Sync + 'static>;
+
+/// A link in the linked list.
+type ErrorLink = Arc<ErrorNode>;
+
+/// A string-only error message, which can either be a static string
+/// slice, or an owned string.
+#[derive(Debug)]
+struct Message(Cow<'static, str>);
+
+impl Display for Message {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
+
+impl StdError for Message {
+	fn source(&self) -> Option<&(dyn StdError + 'static)> {
+		None
+	}
+}
+
+pub struct Chain<'e> {
+	current: Option<&'e ErrorNode>,
+}
+
+impl<'e> Chain<'e> {
+	fn new(error: &Error) -> Chain<'_> {
+		Chain {
+			current: Some(error.head.as_ref()),
+		}
+	}
+}
+
+impl<'e> Iterator for Chain<'e> {
+	type Item = &'e ErrorNode;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		match self.current {
+			Some(node) => {
+				self.current = node.next.as_deref();
+				Some(node)
+			}
+			None => None,
+		}
+	}
+}
+
+/// A limited analogue of the `anyhow!` macro for `Error`.  Only
+/// intended for input suitable for the `Error::msg` function.
+#[macro_export]
+macro_rules! hc_error {
+    ($msg:literal $(,)?) => {
+        $crate::error::Error::msg($msg)
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::error::Error::msg(format!($fmt, $($arg)*))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+	//! Tests to ensure `Error` produces output correctly.
+
+	// Literal input to `hc_error`
+	#[test]
+	fn macro_literal() {
+		let error = hc_error!("msg source");
+		let debug = format!("{:?}", error);
+		let expected = "msg source".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Format string input to `hc_error`
+	#[test]
+	fn macro_format_string() {
+		let msg = "msg";
+		let source = "source";
+		let error = hc_error!("format {} {}", msg, source);
+		let debug = format!("{:?}", error);
+		let expected = "format msg source".to_string();
+		assert_eq!(expected, debug);
+	}
+
+	// Verify that the `chain` method on `hc_error` works.
+	#[test]
+	fn hc_error_chain() {
+		let error = hc_error!("first error");
+		let error = error.context("second error");
+		let error = error.context("third error");
+
+		let mut iter = error.chain();
+
+		assert_eq!("third error", iter.next().unwrap().to_string());
+		assert_eq!("second error", iter.next().unwrap().to_string());
+		assert_eq!("first error", iter.next().unwrap().to_string());
+	}
+}

--- a/plugins/churn/src/linguist/db.rs
+++ b/plugins/churn/src/linguist/db.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::linguist::SourceFileDetector;
+
+use std::sync::Arc;
+
+#[salsa::query_group(LinguistStorage)]
+pub trait LinguistSource: salsa::Database {
+	/// Returns the code detector for the current session
+	#[salsa::input]
+	fn source_file_detector(&self) -> Arc<SourceFileDetector>;
+
+	/// Returns likely source file assessment for `file_name`
+	fn is_likely_source_file(&self, file_name: String) -> bool;
+}
+
+fn is_likely_source_file(db: &dyn LinguistSource, file_name: String) -> bool {
+	db.source_file_detector().is_likely_source_file(file_name)
+}
+
+#[derive(Default)]
+#[salsa::database(LinguistStorage)]
+pub struct Linguist {
+	storage: salsa::Storage<Self>,
+}
+impl Linguist {
+	pub fn new() -> Self {
+		Linguist {
+			storage: Default::default(),
+		}
+	}
+}
+
+impl salsa::Database for Linguist {}

--- a/plugins/churn/src/linguist/fs.rs
+++ b/plugins/churn/src/linguist/fs.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+
+use serde::de::DeserializeOwned;
+use std::{fs, path::Path};
+
+/// Read a file to a string.
+pub fn read_string<P: AsRef<Path>>(path: P) -> Result<String> {
+	fn inner(path: &Path) -> Result<String> {
+		fs::read_to_string(path)
+			.with_context(|| format!("failed to read as UTF-8 string '{}'", path.display()))
+	}
+
+	inner(path.as_ref())
+}
+
+/// Read file to a struct that can be deserialized from TOML format.
+pub fn read_toml<P: AsRef<Path>, T: DeserializeOwned>(path: P) -> Result<T> {
+	let path = path.as_ref();
+	let contents = read_string(path)?;
+	toml::de::from_str(&contents)
+		.with_context(|| format!("failed to read as TOML '{}'", path.display()))
+}

--- a/plugins/churn/src/linguist/mod.rs
+++ b/plugins/churn/src/linguist/mod.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod db;
+mod fs;
+
+pub use db::{Linguist, LinguistSource};
+
+use crate::error::*;
+
+use fs::read_toml;
+use serde::{de::Visitor, Deserialize, Deserializer};
+use std::{convert::AsRef, fmt, fmt::Formatter, path::Path, result::Result as StdResult};
+
+/// Detects whether a file name is a likely source code file.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SourceFileDetector {
+	extensions: Vec<String>,
+}
+
+impl SourceFileDetector {
+	#[cfg(test)]
+	pub fn new(raw_exts: Vec<&str>) -> Self {
+		let extensions = raw_exts.into_iter().map(str::to_owned).collect();
+		SourceFileDetector { extensions }
+	}
+
+	/// Constructs a new `SourceFileDetector` from the `languages.yml` file.
+	pub fn load<P: AsRef<Path>>(langs_file: P) -> Result<SourceFileDetector> {
+		fn inner(langs_file: &Path) -> Result<SourceFileDetector> {
+			// Load the file and parse it.
+			let language_file: LanguageFile = read_toml(langs_file)
+				.context("failed to read language definitions from langs file")?;
+
+			// Get the list of extensions from it.
+			let extensions = language_file.into_extensions();
+
+			// Return the initialized detector.
+			Ok(SourceFileDetector { extensions })
+		}
+
+		inner(langs_file.as_ref())
+	}
+
+	/// Checks whether a given file is a likely source file based on its file
+	/// extension.
+	pub fn is_likely_source_file<P: AsRef<Path>>(&self, file_name: P) -> bool {
+		fn inner(source_file_detector: &SourceFileDetector, file_name: &Path) -> bool {
+			let extension = match file_name.extension() {
+				// Convert &OsStr to Cow<&str> and prepend a period to match the file
+				Some(e) => format!(".{}", e.to_string_lossy()),
+				// If we can't find an extension, include the file.
+				None => return true,
+			};
+
+			for ext in &source_file_detector.extensions {
+				if *ext == extension {
+					return true;
+				}
+			}
+
+			false
+		}
+
+		inner(self, file_name.as_ref())
+	}
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageFile {
+	languages: Vec<LanguageExtensions>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LanguageExtensions {
+	#[serde(default = "missing_lang_type")]
+	r#type: LanguageType,
+	extensions: Option<Vec<String>>,
+}
+
+impl LanguageFile {
+	fn into_extensions(self) -> Vec<String> {
+		let mut result = Vec::new();
+
+		for language in self.languages {
+			if matches!(language.r#type, LanguageType::Programming) {
+				match language.extensions {
+					None => continue,
+					Some(mut extensions) => result.extend(extensions.drain(0..)),
+				}
+			}
+		}
+
+		result
+	}
+}
+
+#[derive(Debug)]
+enum LanguageType {
+	Data,
+	Programming,
+	Markup,
+	Prose,
+	Missing,
+}
+
+fn missing_lang_type() -> LanguageType {
+	LanguageType::Missing
+}
+
+impl<'de> Deserialize<'de> for LanguageType {
+	fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_str(LanguageTypeVisitor)
+	}
+}
+
+struct LanguageTypeVisitor;
+
+impl<'de> Visitor<'de> for LanguageTypeVisitor {
+	type Value = LanguageType;
+
+	fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "'data', 'programming', 'markup', or 'prose'")
+	}
+
+	fn visit_str<E>(self, value: &str) -> StdResult<Self::Value, E>
+	where
+		E: serde::de::Error,
+	{
+		match value {
+			"data" => Ok(LanguageType::Data),
+			"programming" => Ok(LanguageType::Programming),
+			"markup" => Ok(LanguageType::Markup),
+			"prose" => Ok(LanguageType::Prose),
+			_ => Err(serde::de::Error::custom("unknown language type")),
+		}
+	}
+}

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod error;
+mod linguist;
+mod metric;
+mod types;
+
+use crate::{
+	linguist::*,
+	metric::*,
+	types::{CommitChurn, CommitChurnFreq, CommitDiff},
+};
+
+use clap::Parser;
+use hipcheck_sdk::{prelude::*, types::Target};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use std::{
+	collections::HashMap,
+	path::PathBuf,
+	result::Result as StdResult,
+	sync::{Arc, OnceLock},
+};
+
+#[derive(Deserialize)]
+struct RawConfig {
+	#[serde(rename = "langs-file")]
+	langs_file: Option<PathBuf>,
+	#[serde(rename = "churn-freq")]
+	churn_freq: Option<f64>,
+	#[serde(rename = "commit-percentage")]
+	commit_percentage: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+struct PolicyExprConf {
+	pub churn_freq: f64,
+	pub commit_percentage: f64,
+}
+
+struct Config {
+	langs_file: PathBuf,
+	opt_policy: Option<PolicyExprConf>,
+}
+
+impl TryFrom<RawConfig> for Config {
+	type Error = hipcheck_sdk::error::ConfigError;
+	fn try_from(value: RawConfig) -> StdResult<Config, Self::Error> {
+		// Langs file field must always be present
+		let Some(langs_file) = value.langs_file else {
+			return Err(ConfigError::MissingRequiredConfig {
+				field_name: "langs_file".to_owned(),
+				field_type: "string".to_owned(),
+				possible_values: vec![],
+			});
+		};
+		// Default policy expr depends on two fields. If neither present, no default
+		// policy. else make sure both are present
+		let opt_policy = match (value.churn_freq, value.commit_percentage) {
+			(None, None) => None,
+			(Some(_), None) => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "commit_percentage".to_owned(),
+					field_type: "float".to_owned(),
+					possible_values: vec![],
+				});
+			}
+			(None, Some(_)) => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "churn_freq".to_owned(),
+					field_type: "float".to_owned(),
+					possible_values: vec![],
+				});
+			}
+			(Some(churn_freq), Some(commit_percentage)) => Some(PolicyExprConf {
+				churn_freq,
+				commit_percentage,
+			}),
+		};
+		// Sanity check on policy expr config
+		if let Some(policy_ref) = &opt_policy {
+			if policy_ref.commit_percentage < 0.0 || policy_ref.commit_percentage > 1.0 {
+				return Err(ConfigError::InvalidConfigValue {
+					field_name: "commit_percentage".to_owned(),
+					value: policy_ref.commit_percentage.to_string(),
+					reason: "percentage must be between 0.0 and 1.0, inclusive".to_owned(),
+				});
+			}
+		}
+		Ok(Config {
+			langs_file,
+			opt_policy,
+		})
+	}
+}
+
+pub static DATABASE: OnceLock<Arc<Mutex<Linguist>>> = OnceLock::new();
+
+#[query]
+async fn commit_churns(
+	_engine: &mut PluginEngine,
+	mut commit_diffs: Vec<CommitDiff>,
+) -> Result<Vec<CommitChurnFreq>> {
+	let linguist = DATABASE
+		.get()
+		.ok_or(Error::UnspecifiedQueryState)?
+		.lock()
+		.await;
+	commit_diffs.retain(|x| is_likely_source_file_cd(&linguist, x));
+
+	let mut commit_churns = Vec::new();
+	let mut total_files_changed: i64 = 0;
+	let mut total_lines_changed: i64 = 0;
+
+	for commit_diff in commit_diffs {
+		let source_files = commit_diff
+			.diff
+			.file_diffs
+			.iter()
+			.filter(|file_diff| linguist.is_likely_source_file(file_diff.file_name.clone()))
+			.collect::<Vec<_>>();
+
+		// Update files changed.
+		let files_changed = source_files.len() as i64;
+		total_files_changed += files_changed;
+
+		// Update lines changed.
+		let mut lines_changed: i64 = 0;
+		for file_diff in &source_files {
+			lines_changed += file_diff.additions.ok_or_else(|| {
+				log::error!("GitHub commits can't be used for churn");
+				Error::UnspecifiedQueryState
+			})?;
+			lines_changed += file_diff.deletions.ok_or_else(|| {
+				log::error!("GitHub commits can't be used for churn");
+				Error::UnspecifiedQueryState
+			})?;
+		}
+		total_lines_changed += lines_changed;
+
+		commit_churns.push(CommitChurn {
+			commit: commit_diff.commit.clone(),
+			files_changed,
+			lines_changed,
+		});
+	}
+
+	let mut commit_churn_freqs: Vec<_> = {
+		let file_frequencies: HashMap<&str, f64> = commit_churns
+			.iter()
+			.map(|commit_churn| {
+				// avoid dividing by zero.
+				if total_files_changed == 0 {
+					(commit_churn.commit.hash.as_ref(), 0.0)
+				} else {
+					(
+						commit_churn.commit.hash.as_ref(),
+						commit_churn.files_changed as f64 / total_files_changed as f64,
+					)
+				}
+			})
+			.collect();
+
+		let line_frequencies: HashMap<&str, f64> = commit_churns
+			.iter()
+			.map(|commit_churn| {
+				// avoid dividing by zero.
+				if total_lines_changed == 0 {
+					(commit_churn.commit.hash.as_ref(), 0.0)
+				} else {
+					(
+						commit_churn.commit.hash.as_ref(),
+						commit_churn.lines_changed as f64 / total_lines_changed as f64,
+					)
+				}
+			})
+			.collect();
+
+		commit_churns
+			.iter()
+			.map(|commit_churn| {
+				let hash: &str = commit_churn.commit.hash.as_ref();
+				let file_frequency = file_frequencies[hash];
+				let line_frequency = line_frequencies[hash];
+				// PANIC: Safe to unwrap, beacuse we are creating a valid floating point number
+				let churn = file_frequency * line_frequency * line_frequency * 1_000_000.0;
+				CommitChurnFreq {
+					commit: commit_churn.commit.clone(),
+					churn,
+				}
+			})
+			.collect()
+	};
+
+	let churns: Vec<_> = commit_churn_freqs.iter().map(|c| c.churn).collect();
+
+	let mean = mean(&churns).ok_or_else(|| {
+		log::error!("failed to get mean churn value");
+		Error::UnspecifiedQueryState
+	})?;
+	let std_dev = std_dev(mean, &churns).ok_or_else(|| {
+		log::error!("failed to get churn standard deviation");
+		Error::UnspecifiedQueryState
+	})?;
+
+	log::trace!("mean of churn scores [mean='{}']", mean);
+	log::trace!("standard deviation of churn scores [stddev='{}']", std_dev);
+
+	if std_dev == 0.0 {
+		log::error!("not enough commits to calculate churn");
+		return Err(Error::UnspecifiedQueryState);
+	}
+
+	for commit_churn_freq in &mut commit_churn_freqs {
+		commit_churn_freq.churn = (commit_churn_freq.churn - mean) / std_dev;
+	}
+
+	log::info!("completed churn metric");
+
+	Ok(commit_churn_freqs)
+}
+
+#[query(default)]
+async fn churn(engine: &mut PluginEngine, value: Target) -> Result<Vec<f64>> {
+	let local = value.local;
+	let val_commits = engine.query("mitre/git/commit_diffs", local).await?;
+	let commits: Vec<CommitDiff> =
+		serde_json::from_value(val_commits).map_err(Error::InvalidJsonInQueryOutput)?;
+	Ok(commit_churns(engine, commits)
+		.await?
+		.iter()
+		.map(|o| o.churn)
+		.collect())
+}
+
+#[derive(Clone, Debug, Default)]
+struct ChurnPlugin {
+	policy_conf: OnceLock<Option<PolicyExprConf>>,
+}
+
+impl Plugin for ChurnPlugin {
+	const PUBLISHER: &'static str = "mitre";
+	const NAME: &'static str = "churn";
+	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
+		// Deserialize and validate the config struct
+		let conf: Config = serde_json::from_value::<RawConfig>(config)
+			.map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?
+			.try_into()?;
+		// Store the PolicyExprConf to be accessed only in the `default_policy_expr()` impl
+		self.policy_conf
+			.set(conf.opt_policy)
+			.map_err(|_| ConfigError::Unspecified {
+				message: "plugin was already configured".to_string(),
+			})?;
+		// Use the langs file to create a SourceFileDetector and init the salsa db
+		let sfd =
+			SourceFileDetector::load(conf.langs_file).map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?;
+		let mut database = Linguist::new();
+		database.set_source_file_detector(Arc::new(sfd));
+		let global_db = Arc::new(Mutex::new(database));
+		// Make the salsa db globally accessible
+		DATABASE
+			.set(global_db)
+			.map_err(|_e| ConfigError::Unspecified {
+				message: "config was already set".to_owned(),
+			})
+	}
+
+	fn default_policy_expr(&self) -> Result<String> {
+		match self.policy_conf.get() {
+			None => Err(Error::UnspecifiedQueryState),
+			// If no policy vars, we have no default expr
+			Some(None) => Ok("".to_owned()),
+			// Use policy config vars to construct a default expr
+			Some(Some(policy_conf)) => Ok(format!(
+				"(lte (divz (count (filter (gt {}) $)) (count $)) {})",
+				policy_conf.churn_freq, policy_conf.commit_percentage
+			)),
+		}
+	}
+
+	fn explain_default_query(&self) -> Result<Option<String>> {
+		Ok(Some(
+			"The churn frequency calculation of each commit in a repo".to_owned(),
+		))
+	}
+
+	queries! {}
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+	#[arg(long)]
+	port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+	let args = Args::try_parse().unwrap();
+	PluginServer::register(ChurnPlugin::default())
+		.listen(args.port)
+		.await
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::types::{Commit, Diff, FileDiff};
+	use pathbuf::pathbuf;
+
+	fn init_db_if_uninited() {
+		fn create_db() -> Arc<Mutex<Linguist>> {
+			let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+			let langs_path = pathbuf![&manifest_dir, "../../config/Langs.toml"];
+			let sfd = SourceFileDetector::load(langs_path)
+				.map_err(|e| ConfigError::Unspecified {
+					message: e.to_string(),
+				})
+				.unwrap();
+			let mut database = Linguist::new();
+			database.set_source_file_detector(Arc::new(sfd));
+			Arc::new(Mutex::new(database))
+		}
+		DATABASE.get_or_init(create_db);
+	}
+
+	fn test_data() -> Vec<CommitDiff> {
+		let c1 = Commit {
+			hash: "abc123".to_owned(),
+			written_on: Ok("10/23/2024".to_owned()),
+			committed_on: Ok("10/23/2024".to_owned()),
+		};
+		let c2 = Commit {
+			hash: "def456".to_owned(),
+			written_on: Ok("10/23/2024".to_owned()),
+			committed_on: Ok("10/23/2024".to_owned()),
+		};
+		let d1 = Diff {
+			additions: Some(100),
+			deletions: Some(20),
+			file_diffs: vec![
+				FileDiff {
+					file_name: "foo.java".to_owned(),
+					additions: Some(80),
+					deletions: Some(0),
+					patch: "".to_owned(),
+				},
+				FileDiff {
+					file_name: "bar.java".to_owned(),
+					additions: Some(10),
+					deletions: Some(15),
+					patch: "".to_owned(),
+				},
+				FileDiff {
+					file_name: "baz.java".to_owned(),
+					additions: Some(10),
+					deletions: Some(5),
+					patch: "".to_owned(),
+				},
+			],
+		};
+		let d2 = Diff {
+			additions: Some(2000),
+			deletions: Some(1500),
+			file_diffs: vec![
+				FileDiff {
+					file_name: "foo.java".to_owned(),
+					additions: Some(100),
+					deletions: Some(1200),
+					patch: "".to_owned(),
+				},
+				FileDiff {
+					file_name: "bar.java".to_owned(),
+					additions: Some(1800),
+					deletions: Some(300),
+					patch: "".to_owned(),
+				},
+				FileDiff {
+					file_name: "baz.java".to_owned(),
+					additions: Some(100),
+					deletions: Some(0),
+					patch: "".to_owned(),
+				},
+			],
+		};
+
+		vec![
+			CommitDiff {
+				commit: c1,
+				diff: d1,
+			},
+			CommitDiff {
+				commit: c2,
+				diff: d2,
+			},
+		]
+	}
+
+	#[tokio::test]
+	async fn test_foo() {
+		init_db_if_uninited();
+
+		let mut engine = PluginEngine::mock(MockResponses::new());
+		let key = test_data();
+
+		let freqs = commit_churns(&mut engine, key).await.unwrap();
+
+		// Churn metric normalizes across the mean and returns churns as
+		// standard deviations from the mean. Since we have only two values,
+		// the mean will always be halfway between the two and one will be
+		// one std dev less, the other one std dev more
+		assert_eq!(freqs.len(), 2);
+		assert_eq!(freqs[0].churn, -1.0);
+		assert_eq!(freqs[1].churn, 1.0);
+	}
+}

--- a/plugins/churn/src/metric.rs
+++ b/plugins/churn/src/metric.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	linguist::{Linguist, LinguistSource},
+	types::*,
+};
+use std::iter::Iterator;
+
+/// Check if a commit diff is a likely source file.
+pub fn is_likely_source_file_cd(linguist: &Linguist, commit_diff: &CommitDiff) -> bool {
+	let mut has_source = false;
+	for fd in commit_diff.diff.file_diffs.iter() {
+		has_source |= linguist.is_likely_source_file(fd.file_name.clone());
+	}
+	has_source
+}
+
+/// Calculate the arithmetic mean for a set of floats. Returns an option to account
+/// for the possibility of dividing by zero.
+pub fn mean(data: &[f64]) -> Option<f64> {
+	// Do not use rayon's parallel iter/sum here due to the non-associativity of floating point numbers/math.
+	// See: https://en.wikipedia.org/wiki/Associative_property#Nonassociativity_of_floating_point_calculation.
+	let sum = data.iter().sum::<f64>();
+	let count = data.len();
+
+	match count {
+		positive if positive > 0 => Some(sum / count as f64),
+		_ => None,
+	}
+}
+
+/// Calculate the standard deviation for a set of floats. Returns an option to
+/// account for the possibility of dividing by zero.
+pub fn std_dev(mean: f64, data: &[f64]) -> Option<f64> {
+	match (mean, data.len()) {
+		(mean, count) if count > 0 => {
+			let variance =
+				data.iter()
+					.map(|value| {
+						let diff = mean - *value;
+						diff * diff
+					})
+					.sum::<f64>() / count as f64;
+
+			Some(variance.sqrt())
+		}
+		_ => None,
+	}
+}

--- a/plugins/churn/src/types.rs
+++ b/plugins/churn/src/types.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::result::Result;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
+pub struct Commit {
+	pub hash: String,
+	pub written_on: Result<String, String>,
+	pub committed_on: Result<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct FileDiff {
+	pub file_name: String,
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub patch: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct Diff {
+	pub additions: Option<i64>,
+	pub deletions: Option<i64>,
+	pub file_diffs: Vec<FileDiff>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, JsonSchema, Deserialize)]
+pub struct CommitDiff {
+	pub commit: Commit,
+	pub diff: Diff,
+}
+
+#[derive(Debug, Clone, JsonSchema, Serialize)]
+pub struct CommitChurnFreq {
+	/// The commit
+	pub commit: Commit,
+	/// The churn score
+	pub churn: f64,
+}
+
+#[derive(Debug)]
+pub struct CommitChurn {
+	pub commit: Commit,
+	pub files_changed: i64,
+	pub lines_changed: i64,
+}


### PR DESCRIPTION
Resolves #520 .

As with the entropy plugin, this lifts its `error::*`, `types.rs` and `linguist::{fs.rs, mod.rs}` almost directly from Hipcheck core. 

The `metric.rs` file is lifted almost directly from `plugins/entropy/src/metric.rs`.

The configuration requires `langs-file` to be present, but also optionally allows two additional args for a custom default query. if either of the args are present, the other is expected and the parsing code reflects that.