### PR TITLE
chore: Adds full org list to example_orgs.kdl in affiliation plugin

### DIFF
--- a/plugins/affiliation/src/org_spec.rs
+++ b/plugins/affiliation/src/org_spec.rs
@@ -148,7 +148,7 @@ mod test {
 
 		let expected = OrgSpec { strategy, orgs };
 
-		let org_spec_path = pathbuf![&env::current_dir().unwrap(), "test", "example_orgs.kdl"];
+		let org_spec_path = pathbuf![&env::current_dir().unwrap(), "test", "test_orgs.kdl"];
 
 		let result = OrgSpec::load_from(&org_spec_path).unwrap();
 

--- a/plugins/affiliation/test/example_orgs.kdl
+++ b/plugins/affiliation/test/example_orgs.kdl
@@ -3,12 +3,155 @@ strategy "independent" {
     org "MITRE"
 }
 orgs {
+    org "AT&T" country="United States" {
+        host "att.com"
+    }
+    org "Alibaba" country="China" {
+        host "alibaba.com"
+    }
+    org "Amazon" country="United States" {
+        host "amazon.com"
+    }
+    org "Blue Box Cloud" country="United States" {
+        host "blueboxcloud.com"
+    }
+    org "CERN" country="Switzerland" {
+        host "home.cern"
+    }
+    org "Cisco" country="United States" {
+        host "cisco.com"
+    }
+    org "Cloud Foundry" country="United States" {
+        host "cloudfoundry.org"
+    }
+    org "Code Think" country="United Kingdom" {
+        host "codethink.co.uk"
+    }
+    org "Comcast" country="United States" {
+        host "comcast.com"
+    }
+    org "CoreOS" country="United States" {
+        host "coreos.com"
+    }
+    org "Dell EMC" country="United States" {
+        host "dellemc.com"
+        host "emc.com"
+    }
+    org "DT Dream" country="China" {
+        host "dtdream.com"
+    }
+    org "Facebook" country="United States" {
+        host "facebook.com"
+    }
+    org "Fujitsu" country="Japan" {
+        host "fujitsu.com"
+    }
+    org "Google" country="United States" {
+        host "google.com"
+    }
     org "HP" country="United States" {
         host "hp.com"
         host "hpe.com"
     }
+    org "Heroku" country="United States" {
+        host "heroku.com"
+    }
+    org "Huawei" country="China" {
+        host "huawei.com"
+    }
+    org "IBM" country="United States" {
+        host "ibm.com"
+    }
+    org "Influx Data" country="United States" {
+        host "influxdata.com"
+    }
+    org "Intel" country="United States" {
+        host "intel.com"
+    }
+    org "MIT" country="United States" {
+        host "mit.edu"
+    }
     org "MITRE" country="United States" {
         host "mitre.org"
+    }
+    org "Microsoft" country="United States" {
+        host "microsoft.com"
+    }
+    org "NTT" country="Japan" {
+        host "ntt.com"
+    }
+    org "Oracle" country="United States" {
+        host "oracle.com"
+    }
+    org "Orange" country="France" {
+        host "orange.com"
+    }
+    org "Percona" country="United States" {
+        host "persona.com"
+    }
+    org "Pivotal" country="United States" {
+        host "pivotal.io"
+        host "pivotallabs.com"
+    }
+    org "Rackspace" country="United States" {
+        host "rackspace.com"
+    }
+    org "Rakuten" country="Japan" {
+        host "rakuten.com"
+    }
+    org "Red Hat" country="United States" {
+        host "redhat.com"
+    }
+    org "RightScale" country="United States" {
+        host "rightscale.com"
+    }
+    org "SAP" country="Germany" {
+        host "sap.com"
+    }
+    org "SINA" country="China" {
+        host "sina.com"
+    }
+    org "SUSE" country="Germany" {
+        host "suse.com"
+    }
+    org "SalesForce" country="United States" {
+        host "salesforce.com"
+    }
+    org "Stark & Wayne" country="United States" {
+        host "starkandwayne.com"
+    }
+    org "Stripe" country="United States" {
+        host "stripe.com"
+    }
+    org "Swisscom" country="Switzerland" {
+        host "swisscom.com"
+    }
+    org "Apache" country="United States" {
+        host "apache.org"
+    }
+    org "ThoughtWorks" country="United States" {
+        host "thoughtworks.com"
+    }
+    org "Undead Labs" country="United States" {
+        host "undeadlabs.com"
+    }
+    org "VMWare" country="United States" {
+        host "vmware.com"
+    }
+    org "Walmart" country="United States" {
+        host "walmart.com"
+    }
+    org "ZTE" country="China" {
+        host "zte.com.cn"
+    }
+    org "ZJI" country="China" {
+        host "zji.edu.cn"
+    }
+    org "NPM" country="United States" {
+        host "npmjs.com"
+    }
+    org "UK Digital Cabinet Office" country="United Kingdom" {
+        host "digital.cabinet-office.gov.uk"
     }
     org "RBC Royal Bank" country="Canada" {
         host "rbcon.com"

--- a/plugins/affiliation/test/test_orgs.kdl
+++ b/plugins/affiliation/test/test_orgs.kdl
@@ -1,0 +1,16 @@
+strategy "independent" {
+    country "United States"
+    org "MITRE"
+}
+orgs {
+    org "HP" country="United States" {
+        host "hp.com"
+        host "hpe.com"
+    }
+    org "MITRE" country="United States" {
+        host "mitre.org"
+    }
+    org "RBC Royal Bank" country="Canada" {
+        host "rbcon.com"
+    }
+}


### PR DESCRIPTION
Resolves #522 

The `example_orgs.kdl` file in the `affiliation` plugin now contains the full list of orgs found in the `config/Orgs.toml` file used by the older affiliation metric. The previous `example_orgs.kdl`, with a shorter list of orgs, has been renamed to `test_orgs.kdl` for use in testing.