### PR TITLE
fix: Git log commit parser now returns more than one commit.

### DIFF
--- a/plugins/git/src/parse.rs
+++ b/plugins/git/src/parse.rs
@@ -74,6 +74,9 @@ fn commit(input: &str) -> IResult<&str, RawCommit> {
 	let (input, committer_name) = line(input)?;
 	let (input, committer_email) = line(input)?;
 	let (input, committed_on_str) = line(input)?;
+	// For now, we do not use a commit's signer information
+	let (input, _signer_name) = line(input)?;
+	let (input, _signer_key) = line(input)?;
 	// There is always an empty line here; ignore it
 	let (input, _empty_line) = line(input)?;
 


### PR DESCRIPTION
Resolves #538 

The `commits()` query for the `git` plugin now correctly returns all commits to a repo, not just the first commit.

The error originated when we removed commit signer information during the refactor of code from `hipcheck/src/data/git/parse.rs` to `plugins/git/src/parse.rs`. The lines that parse the singer name and key were removed from the git log commit parser function `commit()`, which caused the parser to look for the incorrect number of lines to the next commit. The `commits()` function that was supposed to repeat the `commit()` function for each commit in the git log consequently exited early after only adding the first commit to the returned `Vec` of commits.

These lines have been restored, which fixed the bug.