### PR TITLE
fix review plugin and SDK error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "futures",
  "hipcheck-sdk-macros",
  "indexmap 2.6.0",
+ "log",
  "prost",
  "rand",
  "schemars",

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -28,13 +28,12 @@ use xz2::read::XzDecoder;
 use super::get_current_arch;
 
 /// The plugins currently are not delegated via the `plugin` system and are still part of `hipcheck` core
-pub const MITRE_LEGACY_PLUGINS: [&str; 7] = [
+pub const MITRE_LEGACY_PLUGINS: [&str; 6] = [
 	"activity",
 	"entropy",
 	"affiliation",
 	"binary",
 	"churn",
-	"review",
 	"typo",
 ];
 

--- a/plugins/review/plugin.kdl
+++ b/plugins/review/plugin.kdl
@@ -3,10 +3,10 @@ name "review"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-  on arch="aarch64-apple-darwin" "./hc-mitre-review"
-  on arch="x86_64-apple-darwin" "./hc-mitre-review"
-  on arch="x86_64-unknown-linux-gnu" "./hc-mitre-review"
-  on arch="x86_64-pc-windows-msvc" "./hc-mitre-review"
+  on arch="aarch64-apple-darwin" "./target/debug/review_sdk"
+  on arch="x86_64-apple-darwin" "./target/debug/review_sdk"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/review_sdk"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/review_sdk"
 }
 
 dependencies {

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -19,6 +19,7 @@ schemars = { version = "0.8.21", features = ["url"] }
 hipcheck-sdk-macros = { path = "../../hipcheck-sdk-macros", version = "0.1.0", optional = true }
 typify-macro = "0.2.0"
 url = { version = "2.5.2", features = ["serde"] }
+log = "0.4.22"
 
 
 [build-dependencies]


### PR DESCRIPTION
Resolves #547 . Resolves #503 . 

Separated into two commits - one fixes the rust SDK's handling of errors, the other updates the review plugin to run properly.