### PR TITLE
feat: improve experience when using local plugins

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,12 +1,12 @@
 plugins {
     plugin "mitre/activity" version="0.1.0"
-    plugin "mitre/binary" version="0.1.0"
+    plugin "mitre/binary" version="0.1.0" manifest="./plugins/binary/plugin.kdl"
     plugin "mitre/fuzz" version="0.1.0" manifest="./plugins/fuzz/plugin.kdl"
     plugin "mitre/review" version="0.1.0" manifest="./plugins/review/plugin.kdl"
     plugin "mitre/typo" version="0.1.0" manifest="./plugins/typo/plugin.kdl"
     plugin "mitre/affiliation" version="0.1.0"
     plugin "mitre/entropy" version="0.1.0"
-    plugin "mitre/churn" version="0.1.0"
+    plugin "mitre/churn" version="0.1.0" manifest="./plugins/churn/plugin.kdl"
 }
 patch {
 	plugin "mitre/github_api" {
@@ -24,7 +24,7 @@ analyze {
 			binary-file-threshold 0
 		}
         analysis "mitre/fuzz" policy="(eq #t $)"
-        analysis "mitre/review" policy="(lte $ 0.05)"
+        analysis "mitre/review" policy="(lte (divz (count (filter (eq #f) $)) (count $)) 0.05)"
     }
 
     category "attacks" {

--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -7,7 +7,7 @@ use crate::{
 	hc_error,
 	plugin::{PluginId, PluginName, PluginPublisher, PluginVersion},
 	string_newtype_parse_kdl_node,
-	util::kdl::{extract_data, ParseKdlNode},
+	util::kdl::{extract_data, ParseKdlNode, ToKdlNode},
 };
 
 use kdl::KdlNode;
@@ -21,6 +21,15 @@ pub enum ManifestLocation {
 	Url(Url),
 	/// local filepath to a PluginManifest
 	Local(PathBuf),
+}
+
+impl Display for ManifestLocation {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			ManifestLocation::Url(url) => write!(f, "{}", url.as_str()),
+			ManifestLocation::Local(path_buf) => write!(f, "{}", path_buf.to_string_lossy()),
+		}
+	}
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -297,7 +297,7 @@ fn load_policy_and_data(policy_path: Option<&Path>) -> Result<(PolicyFile, PathB
 
 	// Load the policy file.
 	let policy = PolicyFile::load_from(valid_policy_path)
-		.context("Failed to load policy. Plase make sure the policy file is in the proidved location and is formatted correctly.")?;
+		.context("Failed to load policy. Plase make sure the policy file is in the provided location and is formatted correctly.")?;
 
 	// Resolve the github token file.
 	let hc_github_token = resolve_token()?;

--- a/hipcheck/src/util/kdl.rs
+++ b/hipcheck/src/util/kdl.rs
@@ -16,6 +16,11 @@ where
 	fn parse_node(node: &KdlNode) -> Option<Self>;
 }
 
+pub trait ToKdlNode {
+	/// convert self to a KdlNode
+	fn to_kdl_node(&self) -> KdlNode;
+}
+
 /// Returns the first successful node that can be parsed into T, if there is one
 pub fn extract_data<T>(nodes: &[KdlNode]) -> Option<T>
 where
@@ -33,8 +38,9 @@ where
 /// code is quite repetitive for this simple task.
 ///
 /// As a bonus, the following code is also generated:
-/// - AsRef<String>
-/// - new(value: String) -> Self
+/// - `AsRef<String>`
+/// - `new(value: String) -> Self`
+/// - `ToKdlNode`
 ///
 /// NOTE: This only works with newtype wrappers around String!
 ///
@@ -73,6 +79,15 @@ macro_rules! string_newtype_parse_kdl_node {
 		impl AsRef<String> for $type {
 			fn as_ref(&self) -> &String {
 				&self.0
+			}
+		}
+
+		impl ToKdlNode for $type {
+			#[allow(unused)]
+			fn to_kdl_node(&self) -> KdlNode {
+				let mut node = KdlNode::new(Self::kdl_key());
+				node.insert(0, self.0.clone());
+				node
 			}
 		}
 	};


### PR DESCRIPTION
This change set improves the ergonomics of run 'local' plugins. Rather than running them at the path reachable in a provided Policy file, hipcheck now copies the entrypoints and plugin manifest files to the same cache locations that downloaded plugins would use.

Here is what `tree ~/Library/Caches/hipcheck/plugins` looks like on macOS after running hipcheck:

![image](https://github.com/user-attachments/assets/aafab0e4-92d1-4c84-89c5-6755bcffd6fc)


I deleted everything in `~/Library/Caches/hipcheck/plugins` before this run

I used the config on this branch in `config/Hipcheck.kdl` for testing this branch

This branch also added manifest paths to `binary` and `churn` to `config/Hipcheck.kdl` and updated the policy expression for `review`, in order to allow `hipcheck` to successfully complete its analysis with the config in the repo
