### PR TITLE
chore: Makes changes needed for affiliation plugin to run

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -4,7 +4,7 @@ plugins {
     plugin "mitre/fuzz" version="0.1.0" manifest="./plugins/fuzz/plugin.kdl"
     plugin "mitre/review" version="0.1.0" manifest="./plugins/review/plugin.kdl"
     plugin "mitre/typo" version="0.1.0" manifest="./plugins/typo/plugin.kdl"
-    plugin "mitre/affiliation" version="0.1.0"
+    plugin "mitre/affiliation" version="0.1.0" manifest="./plugins/affiliation/plugin.kdl"
     plugin "mitre/entropy" version="0.1.0"
     plugin "mitre/churn" version="0.1.0" manifest="./plugins/churn/plugin.kdl"
 }
@@ -34,8 +34,9 @@ analyze {
         }
 
         category "commit" {
-            analysis "mitre/affiliation" policy="(eq 0 (count $))" {
-                orgs-file "./config/Orgs.toml"
+            analysis "mitre/affiliation" {
+                orgs-file-path "./plugins/affiliation/test/example_orgs.kdl"
+                count-threshold 0
             }
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -28,7 +28,7 @@ use xz2::read::XzDecoder;
 use super::get_current_arch;
 
 /// The plugins currently are not delegated via the `plugin` system and are still part of `hipcheck` core
-pub const MITRE_LEGACY_PLUGINS: [&str; 3] = ["activity", "entropy", "affiliation"];
+pub const MITRE_LEGACY_PLUGINS: [&str; 2] = ["activity", "entropy"];
 
 /// determine all of the plugins that need to be run and locate download them, if they do not exist
 pub fn retrieve_plugins(

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -3,10 +3,10 @@ name "affiliation"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-  on arch="aarch64-apple-darwin" "./hc-mitre-affiliation"
-  on arch="x86_64-apple-darwin" "./hc-mitre-affiliation"
-  on arch="x86_64-unknown-linux-gnu" "./hc-mitre-affiliation"
-  on arch="x86_64-pc-windows-msvc" "./hc-mitre-affiliation"
+  on arch="aarch64-apple-darwin" "./target/debug/affiliation_sdk"
+  on arch="x86_64-apple-darwin" "./target/debug/affiliation_sdk"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/affiliation_sdk"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/affiliation_sdk"
 }
 
 dependencies {

--- a/plugins/git/src/data.rs
+++ b/plugins/git/src/data.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use hipcheck_sdk::types::LocalGitRepo;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -7,6 +8,17 @@ use std::{
 	hash::Hash,
 	sync::Arc,
 };
+
+/// A locally stored git repo, with optional additional details
+/// The details will vary based on the query (e.g. a date, a committer e-mail address, a commit hash)
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DetailedGitRepo {
+	/// The local repo
+	pub local: LocalGitRepo,
+
+	/// Optional additional information for the query
+	pub details: Option<String>,
+}
 
 /// Commits as they come directly out of `git log`.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/plugins/git/src/local.rs
+++ b/plugins/git/src/local.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Copies of functions from main.rs that do not run as queries
+//! This is a temporary solution until batching is implemented
+
+use crate::{
+	data::{Commit, CommitContributor, CommitContributorView, Contributor, ContributorView},
+	util::git_command::get_commits,
+};
+use hipcheck_sdk::{prelude::*, types::LocalGitRepo};
+
+/// Returns all commits extracted from the repository
+pub fn local_commits(repo: LocalGitRepo) -> Result<Vec<Commit>> {
+	let path = &repo.path;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+	let commits = raw_commits
+		.iter()
+		.map(|raw| Commit {
+			hash: raw.hash.to_owned(),
+			written_on: raw.written_on.to_owned(),
+			committed_on: raw.committed_on.to_owned(),
+		})
+		.collect();
+
+	Ok(commits)
+}
+
+/// Returns all contributors to the repository
+pub fn local_contributors(repo: LocalGitRepo) -> Result<Vec<Contributor>> {
+	let path = &repo.path;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let mut contributors: Vec<_> = raw_commits
+		.iter()
+		.flat_map(|raw| [raw.author.to_owned(), raw.committer.to_owned()])
+		.collect();
+
+	contributors.sort();
+	contributors.dedup();
+
+	Ok(contributors)
+}
+
+/// Returns the commits associated with a given contributor (identified by e-mail address in the `details` value)
+pub fn local_commits_for_contributor(
+	all_commits: &[Commit],
+	contributors: &[Contributor],
+	commit_contributors: &[CommitContributor],
+	email: &str,
+) -> Result<ContributorView> {
+	// Get the index of the contributor
+	let contributor_id = contributors
+		.iter()
+		.position(|c| c.email == email)
+		.ok_or_else(|| {
+			log::error!("failed to find contributor");
+			Error::UnspecifiedQueryState
+		})?;
+
+	// Get the contributor
+	let contributor = contributors[contributor_id].clone();
+
+	// Find commits that have that contributor
+	let commits = commit_contributors
+		.iter()
+		.filter_map(|com_con| {
+			if com_con.author_id == contributor_id || com_con.committer_id == contributor_id {
+				// SAFETY: This index is guaranteed to be valid in
+				// `all_commits` because of how it and `commit_contributors`
+				// are constructed from `db.raw_commits()`
+				Some(all_commits[com_con.commit_id].clone())
+			} else {
+				None
+			}
+		})
+		.collect();
+
+	Ok(ContributorView {
+		contributor,
+		commits,
+	})
+}
+
+/// Returns the contributor view for a given commit (idenftied by hash in the `details` field)
+pub fn local_contributors_for_commit(
+	commits: &[Commit],
+	contributors: &[Contributor],
+	commit_contributors: &[CommitContributor],
+	hash: &str,
+) -> Result<CommitContributorView> {
+	// Get the index of the commit
+	let commit_id = commits.iter().position(|c| c.hash == hash).ok_or_else(|| {
+		log::error!("failed to find contributor");
+		Error::UnspecifiedQueryState
+	})?;
+
+	// Get the commit
+	let commit = commits[commit_id].clone();
+
+	// Find the author and committer for that commit
+	commit_contributors
+		.iter()
+		.find(|com_con| com_con.commit_id == commit_id)
+		.map(|com_con| {
+			// SAFETY: These indices are guaranteed to be valid in
+			// `contributors` because of how `commit_contributors` is
+			// constructed from it.
+			let author = contributors[com_con.author_id].clone();
+			let committer = contributors[com_con.committer_id].clone();
+
+			CommitContributorView {
+				commit,
+				author,
+				committer,
+			}
+		})
+		.ok_or_else(|| {
+			log::error!("failed to find contributor info");
+			Error::UnspecifiedQueryState
+		})
+}
+
+pub fn local_commit_contributors(
+	repo: LocalGitRepo,
+	contributors: &[Contributor],
+) -> Result<Vec<CommitContributor>> {
+	let path = &repo.path;
+	let raw_commits = get_commits(path).map_err(|e| {
+		log::error!("failed to get raw commits: {}", e);
+		Error::UnspecifiedQueryState
+	})?;
+
+	let commit_contributors = raw_commits
+		.iter()
+		.enumerate()
+		.map(|(commit_id, raw)| {
+			// SAFETY: These `position` calls are guaranteed to return `Some`
+			// given how `contributors` is constructed from `db.raw_commits()`
+			let author_id = contributors.iter().position(|c| c == &raw.author).unwrap();
+			let committer_id = contributors
+				.iter()
+				.position(|c| c == &raw.committer)
+				.unwrap();
+
+			CommitContributor {
+				commit_id,
+				author_id,
+				committer_id,
+			}
+		})
+		.collect();
+
+	Ok(commit_contributors)
+}


### PR DESCRIPTION
Resolves #549 

Updates affiliation plugin to run properly.

Because we have not yet implemented batching for queries, this PR adds temporary "local" functions to the git plugin, which do the same thing as existing async query functions but are not queries. It also adds new "batch" queries that call these local functions instead of relying on nested queries and can process more than one commit or contributor at once.

The code in the affiliation plugin has been updated to use these temporary queries instead of making looped calls to the regular queries. Once batching has been implemented, we can remove the temporary functions and change the execution code for affiliation back.