### PR TITLE
fix: entropy plugin exec and remove legacy plugin handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "convert_case",
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -5,7 +5,7 @@ plugins {
     plugin "mitre/review" version="0.1.0" manifest="./plugins/review/plugin.kdl"
     plugin "mitre/typo" version="0.1.0" manifest="./plugins/typo/plugin.kdl"
     plugin "mitre/affiliation" version="0.1.0" manifest="./plugins/affiliation/plugin.kdl"
-    plugin "mitre/entropy" version="0.1.0"
+    plugin "mitre/entropy" version="0.1.0" manifest="./plugins/entropy/plugin.kdl"
     plugin "mitre/churn" version="0.1.0" manifest="./plugins/churn/plugin.kdl"
 }
 patch {
@@ -41,6 +41,8 @@ analyze {
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
 				langs-file "./config/Langs.toml"
+				entropy-threshold 10.0
+				commit-percentage 0.0
 	 		}
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
 				langs-file "./config/Langs.toml"

--- a/config/Hipcheck.toml
+++ b/config/Hipcheck.toml
@@ -12,7 +12,7 @@
 
 #==============================================================================
 # Risk
-# 
+#
 # Configuration related to the overall risk tolerance across all analyses.
 #==============================================================================
 
@@ -101,7 +101,7 @@ weight = 1
 
 # The threshold for the number of binary files present in the repository,
 # over which a repository will be marked as failing this analysis.
-# 
+#
 # Default: 0
 binary_file_threshold = 0
 
@@ -364,9 +364,9 @@ weight = 1
 value_threshold = 3
 
 # This is the month range in which the committer needs to have the above value_threshold
-# committer must have commits counts more or equal to X (value_threshold) commits 
+# committer must have commits counts more or equal to X (value_threshold) commits
 # since Y (trust_month_count_threshold) months ago
-# 
+#
 # Default: 3
 trust_month_count_threshold = 3
 

--- a/hipcheck-sdk-macros/Cargo.toml
+++ b/hipcheck-sdk-macros/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 [dependencies]
 anyhow = "1.0.91"
 convert_case = "0.6.0"
+log = "0.4.22"
 proc-macro2 = "1.0.89"
 quote = "1.0.37"
 syn = { version = "2.0.87", features = ["full", "printing"] }

--- a/hipcheck-sdk-macros/src/lib.rs
+++ b/hipcheck-sdk-macros/src/lib.rs
@@ -268,7 +268,7 @@ pub fn queries(_item: TokenStream) -> TokenStream {
 		};
 		agg.extend(out);
 	}
-	eprintln!(
+	log::info!(
 		"Auto-generating Plugin::queries() with {} detected queries",
 		q_lock.len()
 	);

--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -508,7 +508,6 @@ pub trait CommitConfigQuery: ConfigSource {
 	fn contributor_trust_month_count_threshold(&self) -> Result<u64>;
 }
 
-pub static MITRE_PUBLISHER: &str = "mitre";
 pub static DEFAULT_QUERY: &str = "";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -516,19 +515,6 @@ pub struct Analysis {
 	pub publisher: String,
 	pub plugin: String,
 	pub query: String,
-}
-impl Analysis {
-	pub fn new(publisher: &str, plugin: &str, query: &str) -> Analysis {
-		Analysis {
-			publisher: publisher.to_owned(),
-			plugin: plugin.to_owned(),
-			query: query.to_owned(),
-		}
-	}
-
-	pub fn legacy(analysis: &str) -> Analysis {
-		Analysis::new(MITRE_PUBLISHER, analysis, DEFAULT_QUERY)
-	}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -98,7 +98,7 @@ fn query(
 	// (with salsa memo-ization) to get the needed data, and resume our
 	// current query by providing the plugin the answer.
 	loop {
-		eprintln!("Query needs more info, recursing...");
+		log::trace!("Query needs more info, recursing...");
 		let answer = db
 			.query(
 				ar.publisher.clone(),
@@ -107,7 +107,7 @@ fn query(
 				ar.key.clone(),
 			)?
 			.value;
-		eprintln!("Got answer, resuming");
+		log::trace!("Got answer, resuming");
 		ar = match runtime.block_on(p_handle.resume_query(ar, answer))? {
 			PluginResponse::RemoteClosed => {
 				return Err(hc_error!("Plugin channel closed unexpected"));
@@ -134,7 +134,7 @@ pub fn async_query(
 		};
 		// Initiate the query. If remote closed or we got our response immediately,
 		// return
-		eprintln!("Querying: {query}, key: {key:?}");
+		log::trace!("Querying: {query}, key: {key:?}");
 		let mut ar = match p_handle.query(query, key).await? {
 			PluginResponse::RemoteClosed => {
 				return Err(hc_error!("Plugin channel closed unexpected"));
@@ -148,7 +148,7 @@ pub fn async_query(
 		// (with salsa memo-ization) to get the needed data, and resume our
 		// current query by providing the plugin the answer.
 		loop {
-			eprintln!("Awaiting result, now recursing");
+			log::trace!("Awaiting result, now recursing");
 			let answer = async_query(
 				Arc::clone(&core),
 				ar.publisher.clone(),
@@ -158,7 +158,7 @@ pub fn async_query(
 			)
 			.await?
 			.value;
-			eprintln!("Resuming query with answer {answer:?}");
+			log::trace!("Resuming query with answer {answer:?}");
 			ar = match p_handle.resume_query(ar, answer).await? {
 				PluginResponse::RemoteClosed => {
 					return Err(hc_error!("Plugin channel closed unexpected"));
@@ -196,7 +196,7 @@ impl HcEngineImpl {
 	// independent of Salsa.
 	pub fn new(executor: PluginExecutor, plugins: Vec<PluginWithConfig>) -> Result<Self> {
 		let runtime = RUNTIME.handle();
-		eprintln!("Starting HcPluginCore");
+		log::info!("Starting HcPluginCore");
 		let core = runtime.block_on(HcPluginCore::new(executor, plugins))?;
 		let mut engine = HcEngineImpl {
 			storage: Default::default(),

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -13,7 +13,7 @@ pub use crate::plugin::{get_plugin_key, manager::*, plugin_id::PluginId, types::
 pub use arch::{get_current_arch, try_set_arch, Arch};
 pub use download_manifest::{ArchiveFormat, DownloadManifest, HashAlgorithm, HashWithDigest};
 pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
-pub use retrieval::{retrieve_plugins, MITRE_LEGACY_PLUGINS};
+pub use retrieval::retrieve_plugins;
 use serde_json::Value;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
@@ -106,7 +106,7 @@ impl ActivePlugin {
 			concerns: vec![],
 		};
 
-		eprintln!("Resuming query");
+		log::trace!("Resuming query");
 
 		Ok(self.channel.query(query).await?.into())
 	}

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -2,7 +2,6 @@
 
 use crate::{
 	cache::plugin::HcPluginCache,
-	config::MITRE_PUBLISHER,
 	error::Error,
 	hc_error,
 	plugin::{
@@ -27,9 +26,6 @@ use xz2::read::XzDecoder;
 
 use super::get_current_arch;
 
-/// The plugins currently are not delegated via the `plugin` system and are still part of `hipcheck` core
-pub const MITRE_LEGACY_PLUGINS: [&str; 1] = ["entropy"];
-
 /// determine all of the plugins that need to be run and locate download them, if they do not exist
 pub fn retrieve_plugins(
 	policy_plugins: &[PolicyPlugin],
@@ -38,14 +34,6 @@ pub fn retrieve_plugins(
 	let mut required_plugins = HashSet::new();
 
 	for policy_plugin in policy_plugins.iter() {
-		// TODO: while the legacy passes are still integrated in the main codebase, we skip downloading them!
-		if policy_plugin.name.publisher.0.as_str() == MITRE_PUBLISHER
-			&& MITRE_LEGACY_PLUGINS
-				.iter()
-				.any(|x| *x == policy_plugin.name.name.0.as_str())
-		{
-			continue;
-		}
 		retrieve_plugin(
 			policy_plugin.get_plugin_id(),
 			&policy_plugin.manifest,

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -19,9 +19,75 @@ use std::{
 };
 
 #[derive(Deserialize)]
-struct Config {
+struct RawConfig {
 	#[serde(rename = "langs-file")]
 	langs_file: Option<PathBuf>,
+	#[serde(rename = "entropy-threshold")]
+	entropy_threshold: Option<f64>,
+	#[serde(rename = "commit-percentage")]
+	commit_percentage: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+struct PolicyExprConf {
+	pub entropy_threshold: f64,
+	pub commit_percentage: f64,
+}
+
+struct Config {
+	langs_file: PathBuf,
+	opt_policy: Option<PolicyExprConf>,
+}
+
+impl TryFrom<RawConfig> for Config {
+	type Error = hipcheck_sdk::error::ConfigError;
+	fn try_from(value: RawConfig) -> StdResult<Config, Self::Error> {
+		// Langs file field must always be present
+		let Some(langs_file) = value.langs_file else {
+			return Err(ConfigError::MissingRequiredConfig {
+				field_name: "langs-file".to_owned(),
+				field_type: "string".to_owned(),
+				possible_values: vec![],
+			});
+		};
+		// Default policy expr depends on two fields. If neither present, no default
+		// policy. else make sure both are present
+		let opt_policy = match (value.entropy_threshold, value.commit_percentage) {
+			(None, None) => None,
+			(Some(_), None) => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "commit-percentage".to_owned(),
+					field_type: "float".to_owned(),
+					possible_values: vec![],
+				});
+			}
+			(None, Some(_)) => {
+				return Err(ConfigError::MissingRequiredConfig {
+					field_name: "entropy-threshold".to_owned(),
+					field_type: "float".to_owned(),
+					possible_values: vec![],
+				});
+			}
+			(Some(entropy_threshold), Some(commit_percentage)) => Some(PolicyExprConf {
+				entropy_threshold,
+				commit_percentage,
+			}),
+		};
+		// Sanity check on policy expr config
+		if let Some(policy_ref) = &opt_policy {
+			if policy_ref.commit_percentage < 0.0 || policy_ref.commit_percentage > 1.0 {
+				return Err(ConfigError::InvalidConfigValue {
+					field_name: "commit-percentage".to_owned(),
+					value: policy_ref.commit_percentage.to_string(),
+					reason: "percentage must be between 0.0 and 1.0, inclusive".to_owned(),
+				});
+			}
+		}
+		Ok(Config {
+			langs_file,
+			opt_policy,
+		})
+	}
 }
 
 pub static DATABASE: OnceLock<Arc<Mutex<Linguist>>> = OnceLock::new();
@@ -80,29 +146,31 @@ async fn entropy(engine: &mut PluginEngine, value: Target) -> Result<Vec<f64>> {
 		.collect())
 }
 
-#[derive(Clone, Debug)]
-struct EntropyPlugin;
+#[derive(Clone, Debug, Default)]
+struct EntropyPlugin {
+	policy_conf: OnceLock<Option<PolicyExprConf>>,
+}
 
 impl Plugin for EntropyPlugin {
 	const PUBLISHER: &'static str = "mitre";
 	const NAME: &'static str = "entropy";
 	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
-		let conf: Config =
-			serde_json::from_value(config).map_err(|e| ConfigError::Unspecified {
+		// Deserialize and validate the config struct
+		let conf: Config = serde_json::from_value::<RawConfig>(config)
+			.map_err(|e| ConfigError::Unspecified {
+				message: e.to_string(),
+			})?
+			.try_into()?;
+		// Store the PolicyExprConf to be accessed only in the `default_policy_expr()` impl
+		self.policy_conf
+			.set(conf.opt_policy)
+			.map_err(|_| ConfigError::Unspecified {
+				message: "plugin was already configured".to_string(),
+			})?;
+		let sfd =
+			SourceFileDetector::load(conf.langs_file).map_err(|e| ConfigError::Unspecified {
 				message: e.to_string(),
 			})?;
-		let sfd = match conf.langs_file {
-			Some(p) => SourceFileDetector::load(p).map_err(|e| ConfigError::Unspecified {
-				message: e.to_string(),
-			})?,
-			None => {
-				return Err(ConfigError::MissingRequiredConfig {
-					field_name: "langs-file".to_owned(),
-					field_type: "string".to_owned(),
-					possible_values: vec![],
-				});
-			}
-		};
 		let mut database = Linguist::new();
 		database.set_source_file_detector(Arc::new(sfd));
 		let global_db = Arc::new(Mutex::new(database));
@@ -114,11 +182,22 @@ impl Plugin for EntropyPlugin {
 	}
 
 	fn default_policy_expr(&self) -> Result<String> {
-		Ok("".to_owned())
+		match self.policy_conf.get() {
+			None => Err(Error::UnspecifiedQueryState),
+			// If no policy vars, we have no default expr
+			Some(None) => Ok("".to_owned()),
+			// Use policy config vars to construct a default expr
+			Some(Some(policy_conf)) => Ok(format!(
+				"(lte (divz (count (filter (gt {}) $)) (count $)) {})",
+				policy_conf.entropy_threshold, policy_conf.commit_percentage
+			)),
+		}
 	}
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
-		Ok(None)
+		Ok(Some(
+			"The entropy calculation of each commit in a repo".to_owned(),
+		))
 	}
 
 	queries! {}
@@ -133,7 +212,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(EntropyPlugin {})
+	PluginServer::register(EntropyPlugin::default())
 		.listen(args.port)
 		.await
 }

--- a/plugins/review/src/main.rs
+++ b/plugins/review/src/main.rs
@@ -79,7 +79,6 @@ impl Plugin for ReviewPlugin {
 	const NAME: &'static str = "review";
 
 	fn set_config(&self, config: Value) -> StdResult<(), ConfigError> {
-		println!("config: {config:?}");
 		let conf =
 			serde_json::from_value::<Config>(config).map_err(|e| ConfigError::Unspecified {
 				message: e.to_string(),


### PR DESCRIPTION
Resolves #559 . Resolves #579 .

Updates `entropy` plugin to run smoothly, and also rips out the `MITRE_LEGACY_PLUGINS` infrastructure from Hipcheck core, as after this there are no more legacy plugin implementations.

Separate commit adds outbound chunking to hipcheck core and SDK, which was not previously implemented causing too-large gRPC messages to crash the analysis.

Also replaces a lot of `println/eprintln` calls with `log::{warn, error, trace, debug}`