### PR TITLE
chore: removed *_sdk from plugin binary names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 3
 
 [[package]]
-name = "activity_sdk"
+name = "activity"
 version = "0.1.0"
 dependencies = [
  "clap",
@@ -49,7 +49,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "affiliation_sdk"
+name = "affiliation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -1106,22 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
-name = "git_sdk"
+name = "git"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -1136,6 +1121,21 @@ dependencies = [
  "serde",
  "tokio",
  "which",
+]
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -2590,7 +2590,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "review_sdk"
+name = "review"
 version = "0.1.0"
 dependencies = [
  "clap",
@@ -3561,7 +3561,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "typo_sdk"
+name = "typo"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/hipcheck/src/plugin/plugin_manifest.rs
+++ b/hipcheck/src/plugin/plugin_manifest.rs
@@ -576,25 +576,25 @@ dependencies {
 		entrypoints
 			.insert(
 				Arch::Known(KnownArch::Aarch64AppleDarwin),
-				"./target/debug/activity_sdk".to_owned(),
+				"./target/debug/activity".to_owned(),
 			)
 			.unwrap();
 		entrypoints
 			.insert(
 				Arch::Known(KnownArch::X86_64AppleDarwin),
-				"./target/debug/activity_sdk".to_owned(),
+				"./target/debug/activity".to_owned(),
 			)
 			.unwrap();
 		entrypoints
 			.insert(
 				Arch::Known(KnownArch::X86_64UnknownLinuxGnu),
-				"./target/debug/activity_sdk".to_owned(),
+				"./target/debug/activity".to_owned(),
 			)
 			.unwrap();
 		entrypoints
 			.insert(
 				Arch::Known(KnownArch::X86_64PcWindowsMsvc),
-				"./target/debug/activity_sdk".to_owned(),
+				"./target/debug/activity".to_owned(),
 			)
 			.unwrap();
 

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "activity_sdk"
+name = "activity"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/plugins/activity/plugin.kdl
+++ b/plugins/activity/plugin.kdl
@@ -3,10 +3,10 @@ name "activity"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-    on arch="aarch64-apple-darwin" "./target/debug/activity_sdk"
-    on arch="x86_64-apple-darwin" "./target/debug/activity_sdk"
-    on arch="x86_64-unknown-linux-gnu" "./target/debug/activity_sdk"
-    on arch="x86_64-pc-windows-msvc" "./target/debug/activity_sdk"
+    on arch="aarch64-apple-darwin" "./target/debug/activity"
+    on arch="x86_64-apple-darwin" "./target/debug/activity"
+    on arch="x86_64-unknown-linux-gnu" "./target/debug/activity"
+    on arch="x86_64-pc-windows-msvc" "./target/debug/activity"
 }
 dependencies {
     plugin "mitre/git" version="0.1.0" manifest="./plugins/git/plugin.kdl"

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "affiliation_sdk"
+name = "affiliation"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -3,10 +3,10 @@ name "affiliation"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-  on arch="aarch64-apple-darwin" "./target/debug/affiliation_sdk"
-  on arch="x86_64-apple-darwin" "./target/debug/affiliation_sdk"
-  on arch="x86_64-unknown-linux-gnu" "./target/debug/affiliation_sdk"
-  on arch="x86_64-pc-windows-msvc" "./target/debug/affiliation_sdk"
+  on arch="aarch64-apple-darwin" "./target/debug/affiliation"
+  on arch="x86_64-apple-darwin" "./target/debug/affiliation"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/affiliation"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/affiliation"
 }
 
 dependencies {

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git_sdk"
+name = "git"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/plugins/git/plugin.kdl
+++ b/plugins/git/plugin.kdl
@@ -3,8 +3,8 @@ name "git"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-  on arch="aarch64-apple-darwin" "./target/debug/git_sdk"
-  on arch="x86_64-apple-darwin" "./target/debug/git_sdk"
-  on arch="x86_64-unknown-linux-gnu" "./target/debug/git_sdk"
-  on arch="x86_64-pc-windows-msvc" "./target/debug/git_sdk"
+  on arch="aarch64-apple-darwin" "./target/debug/git"
+  on arch="x86_64-apple-darwin" "./target/debug/git"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/git"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/git"
 }

--- a/plugins/review/Cargo.toml
+++ b/plugins/review/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "review_sdk"
+name = "review"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/plugins/review/plugin.kdl
+++ b/plugins/review/plugin.kdl
@@ -3,10 +3,10 @@ name "review"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-  on arch="aarch64-apple-darwin" "./target/debug/review_sdk"
-  on arch="x86_64-apple-darwin" "./target/debug/review_sdk"
-  on arch="x86_64-unknown-linux-gnu" "./target/debug/review_sdk"
-  on arch="x86_64-pc-windows-msvc" "./target/debug/review_sdk"
+  on arch="aarch64-apple-darwin" "./target/debug/review"
+  on arch="x86_64-apple-darwin" "./target/debug/review"
+  on arch="x86_64-unknown-linux-gnu" "./target/debug/review"
+  on arch="x86_64-pc-windows-msvc" "./target/debug/review"
 }
 
 dependencies {

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "typo_sdk"
+name = "typo"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"

--- a/plugins/typo/plugin.kdl
+++ b/plugins/typo/plugin.kdl
@@ -3,10 +3,10 @@ name "typo"
 version "0.1.0"
 license "Apache-2.0"
 entrypoint {
-    on arch="aarch64-apple-darwin" "./target/debug/typo_sdk"
-    on arch="x86_64-apple-darwin" "./target/debug/typo_sdk"
-    on arch="x86_64-unknown-linux-gnu" "./target/debug/typo_sdk"
-    on arch="x86_64-pc-windows-msvc" "./target/debug/typo_sdk"
+    on arch="aarch64-apple-darwin" "./target/debug/typo"
+    on arch="x86_64-apple-darwin" "./target/debug/typo"
+    on arch="x86_64-unknown-linux-gnu" "./target/debug/typo"
+    on arch="x86_64-pc-windows-msvc" "./target/debug/typo"
 }
 dependencies {
     plugin "mitre/npm" version="0.1.0" manifest="./plugins/npm/plugin.kdl"


### PR DESCRIPTION
With migration away from legacy analyses largely complete, plugin binaries no longer need _sdk in their name. All plugins at this point rely on the sdk!