### PR TITLE
fix: backoff_interval adjusted for MacOS

### DIFF
--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -219,7 +219,7 @@ pub fn start_plugins(
 		/* max_spawn_attempts */ 3,
 		/* max_conn_attempts */ 5,
 		/* port_range */ 40000..u16::MAX,
-		/* backoff_interval_micros */ 1000,
+		/* backoff_interval_micros */ 100000,
 		/* jitter_percent */ 10,
 	)?;
 

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -562,7 +562,7 @@ fn cmd_plugin(args: PluginArgs) {
 		/* max_spawn_attempts */ 3,
 		/* max_conn_attempts */ 5,
 		/* port_range */ 40000..u16::MAX,
-		/* backoff_interval_micros */ 1000,
+		/* backoff_interval_micros */ 100000,
 		/* jitter_percent */ 10,
 	)
 	.unwrap();


### PR DESCRIPTION
The `backoff_interval` was causing failures to run on MacOS with a `Reached max spawn attempts for plugin...` error. This fix increases the `backoff_interval_micros` value to allow enough time for a connection to made for the plugin. 