### PR TITLE
chore: Adds e-mail to affiliated concern reporting

### DIFF
--- a/hipcheck/src/source/git.rs
+++ b/hipcheck/src/source/git.rs
@@ -167,7 +167,7 @@ pub fn checkout(repo_path: &Path, refspec: Option<String>) -> HcResult<String> {
 				}
 			},
 		};
-		
+
 		repo.set_head_detached_from_annotated(tgt_ref)?;
 		ret_str = refspec_str;
 	} else {

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -375,7 +375,13 @@ async fn affiliation(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>
 	// then add the contributor's name and its commit count to the contributor frequency hash map
 	for contributor_view in contributor_views {
 		let count = contributor_view.commits.len();
-		contributor_freq_map.insert(contributor_view.contributor.name, count);
+		contributor_freq_map.insert(
+			format!(
+				"{} ({})",
+				contributor_view.contributor.name, contributor_view.contributor.email
+			),
+			count,
+		);
 	}
 
 	let all_contributors_value = engine
@@ -639,6 +645,9 @@ mod test {
 		assert_eq!(output.len(), 2);
 		let num_affiliated = output.iter().filter(|&n| *n).count();
 		assert_eq!(num_affiliated, 1);
-		assert_eq!(concerns[0], "Contributor Jane Doe has count 2")
+		assert_eq!(
+			concerns[0],
+			"Contributor Jane Doe (jdoe@gmail.com) has count 2"
+		)
 	}
 }

--- a/plugins/affiliation/test/example_orgs.kdl
+++ b/plugins/affiliation/test/example_orgs.kdl
@@ -1,7 +1,4 @@
-strategy "independent" {
-    country "United States"
-    org "MITRE"
-}
+strategy "independent"
 orgs {
     org "AT&T" country="United States" {
         host "att.com"


### PR DESCRIPTION
Changes the concern reporting for the affiliation plugin to include contributor name and e-mail. This allows for better understanding of why a contributor is concerning. Concerns go from

`Contributor John Smith has count 2`

to 

`Contributor John Smith (jsmith@mail.com) has count 2`

Also updates `/plugins/affiliation/test/example_orgs.kdl` to use a general "independent" strategy instead of a specific one we use for testing. The specific one is kept in `/plugins/affiliation/test/test_orgs.kdl`