### PR TITLE
fix: bugs in detecting empty git diffs and end of patch meta block

### DIFF
--- a/plugins/git/src/main.rs
+++ b/plugins/git/src/main.rs
@@ -469,4 +469,12 @@ mod test {
 		let (leftover, _) = crate::parse::patch(input).unwrap();
 		assert!(leftover.is_empty());
 	}
+
+	#[test]
+	fn test_patch_without_triple_plus_minus() {
+		let input = "~~~\n\n0\t0\tmy_test_.py\n\ndiff --git a/my_test_.py b/my_test_.py\ndeleted file mode 100644\nindex e69de29bb2..0000000000\n~~~\n\n33\t3\tnumpy/_core/src/umath/string_fastsearch.h\n\ndiff --git a/numpy/_core/src/umath/string_fastsearch.h b/numpy/_core/src/umath/string_fastsearch.h\nindex 2a778bb86f..1f2d47e8f1 100644\n--- a/numpy/_core/src/umath/string_fastsearch.h\n+++ b/numpy/_core/src/umath/string_fastsearch.h\n@@ -35,0 +36 @@\n+ * @internal\n";
+		let (leftover, diffs) = crate::parse::diffs(input).unwrap();
+		assert!(leftover.is_empty());
+		assert!(diffs.len() == 2);
+	}
 }

--- a/plugins/git/src/util/git_command.rs
+++ b/plugins/git/src/util/git_command.rs
@@ -78,7 +78,7 @@ pub fn get_commits(repo: &str) -> Result<Vec<RawCommit>> {
 			"log",
 			"--no-merges",
 			"--date=iso-strict",
-			"--pretty=tformat:%H%n%aN%n%aE%n%ad%n%cN%n%cE%n%cd%n%GS%n%GK%n",
+			"--pretty=tformat:%H%n%aN%n%aE%n%ad%n%cN%n%cE%n%cd%n",
 		],
 	)?
 	.output()
@@ -118,7 +118,7 @@ pub fn get_diffs(repo: &str) -> Result<Vec<Diff>> {
 			"log",
 			"--no-merges",
 			"--numstat",
-			"--pretty=tformat:",
+			"--pretty=tformat:~~~",
 			"-U0",
 		],
 	)?


### PR DESCRIPTION
Resolves a few bugs in the `plugins/git` diff parser that I encountered while trying to run `plugins/entropy` on `numpy@no version`.

1. Our format specifier for `get_commits()` caused GPG key info to be printed and parsed, but locally I was getting an error in the GPG processing C code in `git`. Other team member got a different error, with git seemingly trying to do validation against GPG signatures in the git history when GPG was not set up on his machine.

2. Some diffs that just delete a file do not have the 1-2 lines prefixed with `+++` or `---` between the patch metadata and patch chunks. We were naively using `opt(line)` to capture these, which would eat up the start of another `diff` in some cases. Now we check for those lines explicitly. 

3. Some other commits (such as those just used to force the CI to re-run) have zero output in our customized `git log` invocation used for parsing diffs. Without any changes, we have no way to detect these commits, and our # parsed diffs != # num parsed commits. My solution was to add `~~~` to this argument `"--pretty=tformat:`, causing each diff to have a header of `~~~` printed whether or not there is anything else to print for that diff. This way, we can at least count empty diffs. Now we successfully parse all commit diffs for a large repo like `numpy` which has 28,000+ commits