### PR TITLE
fix: remove double-printing of policy exprs

### DIFF
--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -282,18 +282,14 @@ pub struct Analysis {
 	/// We use this when printing the result to help explain to the user
 	/// *why* an analysis failed.
 	policy_expr: String,
-
-	/// The default query explanation pulled from RPC with the plugin.
-	message: String,
 }
 
 impl Analysis {
-	pub fn plugin(name: String, passed: bool, policy_expr: String, message: String) -> Self {
+	pub fn plugin(name: String, passed: bool, policy_expr: String) -> Self {
 		Analysis {
 			name,
 			passed,
 			policy_expr,
-			message,
 		}
 	}
 
@@ -309,8 +305,11 @@ impl Analysis {
 		}
 	}
 
+	#[allow(unused)]
 	pub fn explanation(&self) -> String {
-		self.message.clone()
+		// @Todo - create subsystem that takes an Expr and explains in
+		// English why the policy did or did not fail
+		"".to_owned()
 	}
 }
 

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -4,7 +4,6 @@ pub use crate::report::*;
 use crate::{
 	analysis::score::*,
 	config::{ConfigSource, RiskConfigQuery},
-	engine::HcEngine,
 	error::{Error, Result},
 	hc_error,
 	plugin::{PluginName, PluginPublisher},
@@ -35,13 +34,8 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 
 		match &stored.response {
 			Ok(res) => {
-				// This is the "explanation" pulled from the new gRPC call.
-				let message = session
-					.default_query_explanation(analysis.publisher.clone(), analysis.plugin.clone())?
-					.unwrap_or("no query explanation provided".to_owned());
-
 				builder.add_analysis(
-					Analysis::plugin(name, stored.passed, stored.policy.clone(), message),
+					Analysis::plugin(name, stored.passed, stored.policy.clone()),
 					res.concerns.clone(),
 				)?;
 			}

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -357,7 +357,6 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Passed,
 				analysis.statement()
 			);
-			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
 			// Empty line at end to space out analyses.
 			macros::println!();
 		}
@@ -381,7 +380,6 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Failed,
 				analysis.statement()
 			);
-			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
 
 			for concern in failing_analysis.concerns() {
 				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", concern);


### PR DESCRIPTION
Resolves #598 .

Removed unused `message` field from Analysis struct for reports, it was just printing the default policy expr, which may not even be the policy used in the analysis. For now removed the explanation print from the report emitting code, we will re-add an explanation once we have a system for auto-generating policy expr explanations.