### PR TITLE
fix(sdk): plugins that provide default query explanations are now pro…

### DIFF
--- a/sdk/rust/src/plugin_server.rs
+++ b/sdk/rust/src/plugin_server.rs
@@ -101,8 +101,11 @@ impl<P: Plugin> PluginService for PluginServer<P> {
 		&self,
 		_req: Req<ExplainDefaultQueryReq>,
 	) -> QueryResult<Resp<ExplainDefaultQueryResp>> {
-		match self.plugin.default_policy_expr() {
-			Ok(explanation) => Ok(Resp::new(ExplainDefaultQueryResp { explanation })),
+		match self.plugin.explain_default_query() {
+			Ok(explanation) => Ok(Resp::new(ExplainDefaultQueryResp {
+				explanation: explanation
+					.unwrap_or_else(|| "No default query explanation provided".to_owned()),
+			})),
 			Err(e) => Err(Status::new(
 				tonic::Code::NotFound,
 				format!(


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f45f9d5d-4bf8-4347-a579-59127d8dc3d4)


Fixed a bug in the sdk that was forwarding the wrong message from a plugin when the `default_query_explanation` was asked for