### PR TITLE
feat: improve error handling if plugin entrypoint does not exist

### DIFF
--- a/hipcheck/src/plugin/manager.rs
+++ b/hipcheck/src/plugin/manager.rs
@@ -82,6 +82,15 @@ impl PluginExecutor {
 			// ports in the desired range are already bound
 			let port = self.get_available_port()?;
 			let port_str = port.to_string();
+
+			if let Ok(false) = std::fs::exists(&plugin.entrypoint) {
+				log::warn!(
+					"entrypoint '{}' for {} does not exist",
+					plugin.entrypoint,
+					plugin.name
+				)
+			}
+
 			// Spawn plugin process
 			log::debug!("Spawning '{}' on port {}", &plugin.entrypoint, port_str);
 			let Ok(mut proc) = Command::new(&plugin.entrypoint)


### PR DESCRIPTION
Closes #583 

With the current codebase and plugins that we have, this check works, but if an entrypoint is not kicking off a binary and runs a docker image or runs `python3 -m ...` or does anything outside of how our plugins work today, this will likely fail. Maybe this should just log a warning that it could not find the provided file and still try to spawn the plugin?