### PR TITLE
chore: revert "fix: remove double-printing of policy exprs"

### DIFF
--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -282,14 +282,18 @@ pub struct Analysis {
 	/// We use this when printing the result to help explain to the user
 	/// *why* an analysis failed.
 	policy_expr: String,
+
+	/// The default query explanation pulled from RPC with the plugin.
+	message: String,
 }
 
 impl Analysis {
-	pub fn plugin(name: String, passed: bool, policy_expr: String) -> Self {
+	pub fn plugin(name: String, passed: bool, policy_expr: String, message: String) -> Self {
 		Analysis {
 			name,
 			passed,
 			policy_expr,
+			message,
 		}
 	}
 
@@ -305,11 +309,8 @@ impl Analysis {
 		}
 	}
 
-	#[allow(unused)]
 	pub fn explanation(&self) -> String {
-		// @Todo - create subsystem that takes an Expr and explains in
-		// English why the policy did or did not fail
-		"".to_owned()
+		self.message.clone()
 	}
 }
 

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -4,6 +4,7 @@ pub use crate::report::*;
 use crate::{
 	analysis::score::*,
 	config::{ConfigSource, RiskConfigQuery},
+	engine::HcEngine,
 	error::{Error, Result},
 	hc_error,
 	plugin::{PluginName, PluginPublisher},
@@ -34,8 +35,13 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 
 		match &stored.response {
 			Ok(res) => {
+				// This is the "explanation" pulled from the new gRPC call.
+				let message = session
+					.default_query_explanation(analysis.publisher.clone(), analysis.plugin.clone())?
+					.unwrap_or("no query explanation provided".to_owned());
+
 				builder.add_analysis(
-					Analysis::plugin(name, stored.passed, stored.policy.clone()),
+					Analysis::plugin(name, stored.passed, stored.policy.clone(), message),
 					res.concerns.clone(),
 				)?;
 			}

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -357,6 +357,7 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Passed,
 				analysis.statement()
 			);
+			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
 			// Empty line at end to space out analyses.
 			macros::println!();
 		}
@@ -380,6 +381,7 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Failed,
 				analysis.statement()
 			);
+			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
 
 			for concern in failing_analysis.concerns() {
 				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", concern);


### PR DESCRIPTION
This reverts commit c82797e4e6be9b9a9b4ecbc78f63818040fcc162.