### PR TITLE
fix: handling of plugin entrypoint string

### DIFF
--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -12,7 +12,9 @@ use crate::error::Result;
 pub use crate::plugin::{get_plugin_key, manager::*, plugin_id::PluginId, types::*};
 pub use arch::{get_current_arch, try_set_arch, Arch};
 pub use download_manifest::{ArchiveFormat, DownloadManifest, HashAlgorithm, HashWithDigest};
-pub use plugin_manifest::{PluginManifest, PluginName, PluginPublisher, PluginVersion};
+pub use plugin_manifest::{
+	try_get_bin_for_entrypoint, PluginManifest, PluginName, PluginPublisher, PluginVersion,
+};
 pub use retrieval::retrieve_plugins;
 use serde_json::Value;
 use std::collections::HashMap;


### PR DESCRIPTION
The existing code treated the `entrypoint` string as a `PathBuf`, when in reality it could be a cmdline string with spaces and arguments. 

This PR updates the handling to reflect this, and also modifies the `retrieve_local_plugin()` behavior to only copy the plugin entrypoint binary if it is a path. For instance, if the entrypoint started as `docker ...`, we wouldn't copy the `docker` binary because does not exist as a path. 

Also updated the warning in `start_plugin()` to warn if the binary component of `entrypoint` cannot be found with `which`.