### PR TITLE
fix: reduce unnecessary filesytem copies when spawning plugins

### DIFF
--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -100,7 +100,12 @@ rustls = { version = "0.23.10", default-features = false, features = [
 ] }
 rustls-native-certs = "0.8.0"
 salsa = "0.16.1"
-schemars = { version = "0.8.21", default-features = false, features = ["derive", "preserve_order", "chrono", "url"] }
+schemars = { version = "0.8.21", default-features = false, features = [
+    "derive",
+    "preserve_order",
+    "chrono",
+    "url",
+] }
 semver = "1.0.9"
 serde = { version = "1.0.214", features = ["derive", "rc"] }
 serde_derive = "1.0.137"
@@ -110,6 +115,7 @@ smart-default = "0.7.1"
 spdx-rs = "0.5.0"
 tabled = "0.16.0"
 tar = "0.4.43"
+tempfile = "3.13.0"
 term_size = "0.3.2"
 tokio = { version = "1.41.1", features = [
     "rt",
@@ -149,7 +155,6 @@ which = { version = "7.0.0", default-features = false }
 [dev-dependencies]
 
 dirs = "5.0.1"
-tempfile = "3.13.0"
 test-log = "0.2.16"
 
 [package.metadata.dist]


### PR DESCRIPTION
Here is a video of this branch having two macOS `hc check` commands work at the same time!

https://github.com/user-attachments/assets/9c4a6355-8817-421e-85e4-00f903140946

To trigger this bug on macOS, the following steps were the easiest way I could find to reliably trigger this
1. Have a plugin running
2. While it is still running, copy over the running binary location on disk
3. Attempt to run this new binary (it will fail)

To avoid this issue, `hc` now checks the `sha256` of the source and destination before copying the files and skips the copy if the hashes are identical