### PR TITLE
fix: add hash check when copying local plugins on windows

### DIFF
--- a/hipcheck/src/util/fs.rs
+++ b/hipcheck/src/util/fs.rs
@@ -71,3 +71,9 @@ pub fn exists<P: AsRef<Path>>(path: P) -> Result<()> {
 
 	inner(path.as_ref())
 }
+
+/// return the sha256 of a file
+pub fn file_sha256<P: AsRef<Path>>(path: P) -> Result<String> {
+	let bytes = read_bytes(path)?;
+	Ok(sha256::digest(&bytes))
+}


### PR DESCRIPTION
I tested simultaneous execution of Hipcheck on Windows, and found that Windows won't let us overwrite plugins in the cache as we have been if another HC instance is using that plugin. 

I pulled in some changes @patrickjcasey wrote to do sha256-hash checking, and set the logic so that it would only do this on Windows so other OSes don't take the performance hit.