### PR TITLE
Improve `hc scoring` and update use of `print-timings` feature

### DIFF
--- a/hipcheck/src/analysis/score.rs
+++ b/hipcheck/src/analysis/score.rs
@@ -197,7 +197,7 @@ pub fn score_results(_phase: &SpinnerPhase, db: &dyn ScoringProvider) -> Result<
 	// Values set with -1.0 are reseved for parent nodes whose score comes always
 	// from children nodes with a score set by hc_analysis algorithms
 
-	let analysis_tree = db.normalized_analysis_tree()?;
+	let analysis_tree = db.analysis_tree()?;
 	let mut plugin_results = PluginAnalysisResults::default();
 
 	// RFD4 analysis style - get all "leaf" analyses and call through plugin architecture

--- a/hipcheck/src/benchmarking.rs
+++ b/hipcheck/src/benchmarking.rs
@@ -11,7 +11,6 @@
 //! A macro is provided to automatically tag timings with the file and line number that they were created on.
 
 use crate::shell::Shell;
-pub use print_scope_time;
 use std::time::Instant;
 
 /// Structure used to track timing that will print its location and elapsed time when dropped.
@@ -47,7 +46,7 @@ macro_rules! print_scope_time {
 		))
 	};
 
-	($msg:literal) => {
+	($msg:expr) => {
 		$crate::benchmarking::PrintTime::new(format!(
 			"{}:{}:{} ({})",
 			module_path!(),
@@ -57,3 +56,6 @@ macro_rules! print_scope_time {
 		))
 	};
 }
+
+// Make `print_scope_time` available through `benchmarking` module
+pub(super) use print_scope_time;

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -293,10 +293,9 @@ impl CliConfig {
 		CliConfig {
 			path_args: PathArgs {
 				cache: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "cache"]),
-				// TODO: currently if this is set, then when running `hc check`, it errors out
-				// because policy files are not yet supported
-				// policy: env::current_dir().ok().map(|dir| pathbuf![&dir, "Hipcheck.kdl"]),
-				policy: None,
+				policy: std::env::current_dir()
+					.ok()
+					.map(|dir| pathbuf![&dir, "Hipcheck.kdl"]),
 			},
 			deprecated_args: DeprecatedArgs {
 				config: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "config"]),

--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -77,9 +77,13 @@ fn query(
 	query: String,
 	key: Value,
 ) -> Result<QueryResult> {
+	let hash_key = get_plugin_key(publisher.as_str(), plugin.as_str());
+
+	#[cfg(feature = "print-timings")]
+	let _0 = crate::benchmarking::print_scope_time!(format!("{}/{}", &hash_key, &query));
+
 	let runtime = RUNTIME.handle();
 	let core = db.core();
-	let hash_key = get_plugin_key(publisher.as_str(), plugin.as_str());
 
 	// Find the plugin
 	let Some(p_handle) = core.plugins.get(&hash_key) else {
@@ -127,8 +131,12 @@ pub fn async_query(
 	key: Value,
 ) -> BoxFuture<'static, Result<QueryResult>> {
 	async move {
-		// Find the plugin
 		let hash_key = get_plugin_key(publisher.as_str(), plugin.as_str());
+
+		#[cfg(feature = "print-timings")]
+		let _0 = crate::benchmarking::print_scope_time!(format!("{}/{}", &hash_key, &query));
+
+		// Find the plugin
 		let Some(p_handle) = core.plugins.get(&hash_key) else {
 			return Err(hc_error!("No such plugin {}", hash_key));
 		};

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -31,6 +31,9 @@ pub fn retrieve_plugins(
 	policy_plugins: &[PolicyPlugin],
 	plugin_cache: &HcPluginCache,
 ) -> Result<HashSet<PluginId>, Error> {
+	#[cfg(feature = "print-timings")]
+	let _0 = crate::benchmarking::print_scope_time!("retrieve plugins");
+
 	let mut required_plugins = HashSet::new();
 
 	for policy_plugin in policy_plugins.iter() {

--- a/hipcheck/src/policy/mod.rs
+++ b/hipcheck/src/policy/mod.rs
@@ -2,9 +2,11 @@
 
 //! Data types and functions for parsing policy KDL files
 
-pub mod config_to_policy;
+mod config_to_policy;
 pub mod policy_file;
 mod tests;
+
+pub use config_to_policy::config_to_policy;
 
 use crate::{
 	error::Result,

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -17,6 +17,9 @@ use std::{collections::HashSet, default::Default};
 
 /// Print the final report of a Hipcheck run.
 pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Report> {
+	#[cfg(feature = "print-timings")]
+	let _0 = crate::benchmarking::print_scope_time!("build_report");
+
 	log::debug!("building final report");
 
 	// This function needs to:

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 	metric::{
 		binary_detector::BinaryFileStorage, linguist::LinguistStorage, MetricProviderStorage,
 	},
-	policy::{config_to_policy::config_to_policy, PolicyFile},
+	policy::{config_to_policy, PolicyFile},
 	report::{ReportParams, ReportParamsStorage},
 	session::{
 		cyclone_dx::extract_cyclonedx_download_url,
@@ -253,7 +253,7 @@ fn load_software_versions() -> Result<(String, String)> {
 	Ok((git_version, npm_version))
 }
 
-fn load_config_and_data(config_path: Option<&Path>) -> Result<(PolicyFile, PathBuf, String)> {
+pub fn load_config_and_data(config_path: Option<&Path>) -> Result<(PolicyFile, PathBuf, String)> {
 	// Start the phase.
 	let phase = SpinnerPhase::start("Loading configuration and data files from config file. Note: The use of a config TOML file is deprecated. Please consider using a policy KDL file in the future.");
 	// Increment the phase into the "running" stage.
@@ -280,7 +280,7 @@ fn load_config_and_data(config_path: Option<&Path>) -> Result<(PolicyFile, PathB
 	Ok((policy, valid_config_path.to_path_buf(), hc_github_token))
 }
 
-fn load_policy_and_data(policy_path: Option<&Path>) -> Result<(PolicyFile, PathBuf, String)> {
+pub fn load_policy_and_data(policy_path: Option<&Path>) -> Result<(PolicyFile, PathBuf, String)> {
 	// Start the phase.
 	let phase = SpinnerPhase::start("loading policy and data files");
 	// Increment the phase into the "running" stage.

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -110,6 +110,7 @@ impl Shell {
 	///
 	/// This is equivalent to using [Shell::set_verbosity] to silence the global shell,
 	/// and then reseting it back to the previous value whenever the returned [SilenceGuard] is [drop]ped.
+	#[allow(unused)]
 	pub fn silence() -> SilenceGuard {
 		let previous_verbosity = Shell::get_verbosity();
 		Shell::set_verbosity(Verbosity::Silent);


### PR DESCRIPTION
Resolves #647 .

First commit: 
- Reviewed use of `print-timings` crate, fixed one compilation error, included timing prints in plugin infrastructure for future optimization efforts.

Second commit:
- Noticed that `hc scoring` which simply prints the normalized weight tree for a policy file required using fake data to spin up a sham `Session` object. Added a few functions to `config.rs` to be able to get a weight tree without a `Session` object. Now, we can get an "unresolved" but normalized weight tree, and then the existing `analysis_tree()` salsa function just applies the plugin's default policy expr to each analysis node without a policy.