### PR TITLE
fix: new clippy warnings for lifetime elision and doc comments

### DIFF
--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -410,7 +410,7 @@ mod de {
 	{
 		struct PercentVisitor;
 
-		impl<'de> Visitor<'de> for PercentVisitor {
+		impl Visitor<'_> for PercentVisitor {
 			type Value = f64;
 
 			fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -859,12 +859,12 @@ pub fn normalized_unresolved_analysis_tree(db: &dyn ConfigSource) -> Result<Rc<A
 	Ok(Rc::new(norm_tree))
 }
 
-/// Derived query implementations
+// Derived query implementations
 
-/// In general, these simply return the value of a particular field in
-/// one of the `Config` child structs.  When the type of the desired
-/// field is `String`, it is returned wrapped in an `Rc`.  This is
-/// done to keep Salsa's cloning cheap.
+// In general, these simply return the value of a particular field in
+// one of the `Config` child structs.  When the type of the desired
+// field is `String`, it is returned wrapped in an `Rc`.  This is
+// done to keep Salsa's cloning cheap.
 
 fn risk_policy(db: &dyn RiskConfigQuery) -> Rc<String> {
 	let policy = db.policy();

--- a/hipcheck/src/error/mod.rs
+++ b/hipcheck/src/error/mod.rs
@@ -205,7 +205,7 @@ pub struct Chain<'e> {
 	current: Option<&'e ErrorNode>,
 }
 
-impl<'e> Chain<'e> {
+impl Chain<'_> {
 	fn new(error: &Error) -> Chain<'_> {
 		Chain {
 			current: Some(error.head.as_ref()),

--- a/hipcheck/src/policy_exprs/env.rs
+++ b/hipcheck/src/policy_exprs/env.rs
@@ -358,7 +358,7 @@ fn ty_bool_binary(args: &[Type]) -> Result<ReturnableType> {
 	Ok(PrimitiveType::Bool.into())
 }
 
-impl<'parent> Env<'parent> {
+impl Env<'_> {
 	/// Create an empty environment.
 	fn empty() -> Self {
 		Env {

--- a/hipcheck/src/policy_exprs/json_pointer.rs
+++ b/hipcheck/src/policy_exprs/json_pointer.rs
@@ -21,7 +21,7 @@ impl<'ctx> LookupJsonPointers<'ctx> {
 	}
 }
 
-impl<'ctx> ExprMutator for LookupJsonPointers<'ctx> {
+impl ExprMutator for LookupJsonPointers<'_> {
 	fn visit_json_pointer(&self, mut jp: JsonPointer) -> Result<Expr> {
 		let pointer = &jp.pointer;
 		let context = self.context;

--- a/hipcheck/src/session/pm.rs
+++ b/hipcheck/src/session/pm.rs
@@ -256,7 +256,7 @@ impl<'s> PartialEq for ScoredCandidateUrl<'s> {
 	}
 }
 
-impl<'s> Eq for ScoredCandidateUrl<'s> {}
+impl Eq for ScoredCandidateUrl<'_> {}
 
 impl<'s> PartialOrd for ScoredCandidateUrl<'s> {
 	fn partial_cmp(&self, other: &ScoredCandidateUrl<'s>) -> Option<Ordering> {

--- a/hipcheck/src/source/mod.rs
+++ b/hipcheck/src/source/mod.rs
@@ -15,23 +15,23 @@ use pathbuf::pathbuf;
 use std::path::{Path, PathBuf};
 use url::{Host, Url};
 
-/// Resolving is how we ensure we have a valid, ready-to-go source of Git data
-/// for the rest of Hipcheck's analysis. The below functions handle the resolution
-/// of local or remote repos.
-///
-/// If the repo is local, the resolve function will work with the local repository
-/// without cloning (all operationsare write-only, so this won't harm the repo at
-/// all).
-///
-/// If it's a remote source, Hipcheck will clone the source so it can work with a
-/// local copy, putting the clone in '<root>/clones'. It also notes whether a
-/// remote repo is from a known or unknown host, because some forms of analysis
-/// rely on accessing the API's of certain known hosts (currently just GitHub).
-///
-/// In either case, it also gets the commit head of the HEAD commit, so we can
-/// make sure future operations are all done relative to the HEAD, and that any
-/// cached data records what the HEAD was at the time of caching, to enable
-/// cache invalidation.
+// Resolving is how we ensure we have a valid, ready-to-go source of Git data
+// for the rest of Hipcheck's analysis. The below functions handle the resolution
+// of local or remote repos.
+//
+// If the repo is local, the resolve function will work with the local repository
+// without cloning (all operationsare write-only, so this won't harm the repo at
+// all).
+//
+// If it's a remote source, Hipcheck will clone the source so it can work with a
+// local copy, putting the clone in '<root>/clones'. It also notes whether a
+// remote repo is from a known or unknown host, because some forms of analysis
+// rely on accessing the API's of certain known hosts (currently just GitHub).
+//
+// In either case, it also gets the commit head of the HEAD commit, so we can
+// make sure future operations are all done relative to the HEAD, and that any
+// cached data records what the HEAD was at the time of caching, to enable
+// cache invalidation.
 
 /// Resolves a specified local git repo into a Target for analysis by Hipcheck
 pub fn resolve_local_repo(

--- a/hipcheck/src/source/query.rs
+++ b/hipcheck/src/source/query.rs
@@ -24,11 +24,11 @@ pub trait SourceQuery: salsa::Database {
 	fn url(&self) -> Option<Arc<String>>;
 }
 
-/// Derived query implementations
+// Derived query implementations
 
-/// These return the value of a particular field in the input `Target`
-/// struct.  Since all are owned types, the values are wrapped in an
-/// `Rc` to keep cloning cheap.
+// These return the value of a particular field in the input `Target`
+// struct.  Since all are owned types, the values are wrapped in an
+// `Rc` to keep cloning cheap.
 
 fn local(db: &dyn SourceQuery) -> Arc<PathBuf> {
 	let target = db.target();

--- a/plugins/binary/src/binary_detector.rs
+++ b/plugins/binary/src/binary_detector.rs
@@ -110,7 +110,7 @@ impl<'de> Deserialize<'de> for BinaryType {
 
 struct BinaryTypeVisitor;
 
-impl<'de> Visitor<'de> for BinaryTypeVisitor {
+impl Visitor<'_> for BinaryTypeVisitor {
 	type Value = BinaryType;
 	fn expecting(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "'executable', 'object', or 'combination'")

--- a/plugins/binary/src/error/mod.rs
+++ b/plugins/binary/src/error/mod.rs
@@ -201,7 +201,7 @@ pub struct Chain<'e> {
 	current: Option<&'e ErrorNode>,
 }
 
-impl<'e> Chain<'e> {
+impl Chain<'_> {
 	fn new(error: &Error) -> Chain<'_> {
 		Chain {
 			current: Some(error.head.as_ref()),

--- a/plugins/churn/src/error/mod.rs
+++ b/plugins/churn/src/error/mod.rs
@@ -201,7 +201,7 @@ pub struct Chain<'e> {
 	current: Option<&'e ErrorNode>,
 }
 
-impl<'e> Chain<'e> {
+impl Chain<'_> {
 	fn new(error: &Error) -> Chain<'_> {
 		Chain {
 			current: Some(error.head.as_ref()),

--- a/plugins/churn/src/linguist/mod.rs
+++ b/plugins/churn/src/linguist/mod.rs
@@ -118,7 +118,7 @@ impl<'de> Deserialize<'de> for LanguageType {
 
 struct LanguageTypeVisitor;
 
-impl<'de> Visitor<'de> for LanguageTypeVisitor {
+impl Visitor<'_> for LanguageTypeVisitor {
 	type Value = LanguageType;
 
 	fn expecting(&self, f: &mut Formatter) -> fmt::Result {

--- a/plugins/entropy/src/error/mod.rs
+++ b/plugins/entropy/src/error/mod.rs
@@ -201,7 +201,7 @@ pub struct Chain<'e> {
 	current: Option<&'e ErrorNode>,
 }
 
-impl<'e> Chain<'e> {
+impl Chain<'_> {
 	fn new(error: &Error) -> Chain<'_> {
 		Chain {
 			current: Some(error.head.as_ref()),

--- a/plugins/entropy/src/linguist/mod.rs
+++ b/plugins/entropy/src/linguist/mod.rs
@@ -117,7 +117,7 @@ impl<'de> Deserialize<'de> for LanguageType {
 
 struct LanguageTypeVisitor;
 
-impl<'de> Visitor<'de> for LanguageTypeVisitor {
+impl Visitor<'_> for LanguageTypeVisitor {
 	type Value = LanguageType;
 
 	fn expecting(&self, f: &mut Formatter) -> fmt::Result {

--- a/plugins/linguist/src/linguist.rs
+++ b/plugins/linguist/src/linguist.rs
@@ -114,7 +114,7 @@ impl<'de> Deserialize<'de> for LanguageType {
 
 struct LanguageTypeVisitor;
 
-impl<'de> Visitor<'de> for LanguageTypeVisitor {
+impl Visitor<'_> for LanguageTypeVisitor {
 	type Value = LanguageType;
 
 	fn expecting(&self, f: &mut Formatter) -> fmt::Result {


### PR DESCRIPTION
Seems with Rust 1.83 we were exposed to clippy warnings we previously had not, causing all our PR branches and `main` to fail CI. Fixes the offending code sections.