### PR TITLE
chore: Updates file path tags in example policy file

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -29,13 +29,13 @@ analyze {
 
     category "attacks" {
         analysis "mitre/typo" {
-            typo-file-path "./config/Typos.toml"
+            typo-file "./config/Typos.toml"
             count-threshold 0
         }
 
         category "commit" {
             analysis "mitre/affiliation" {
-                orgs-file-path "./plugins/affiliation/test/example_orgs.kdl"
+                orgs-file "./plugins/affiliation/test/example_orgs.kdl"
                 count-threshold 0
             }
 


### PR DESCRIPTION
The example policy file `config/Hipheck.kdl` was still using the older `foo-file-path` label for some of the additional file locations, instead of `foo-file`. This fixes that so the example policy file works correctly.