### PR TITLE
integrate type checking, and add graceful handling of plugin startup errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1353,6 +1389,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "sha256",
  "smart-default",
  "spdx-rs",
@@ -1705,6 +1742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "identity"
 version = "0.1.0"
 dependencies = [
@@ -1758,6 +1801,7 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
+ "serde",
 ]
 
 [[package]]
@@ -3034,6 +3078,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -141,6 +141,7 @@ zip = "2.2.1"
 zip-extensions = "0.8.1"
 zstd = "0.13.2"
 hipcheck-common = { version = "0.1.0", path = "../hipcheck-common" }
+serde_with = "3.11.0"
 
 [build-dependencies]
 

--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -9,6 +9,7 @@ use crate::{
 		QueryResult,
 	},
 	policy::PolicyFile,
+	policy_exprs::Expr,
 	Result,
 };
 use futures::future::{BoxFuture, FutureExt};
@@ -27,7 +28,7 @@ pub trait HcEngine: salsa::Database {
 	#[salsa::input]
 	fn core(&self) -> Arc<HcPluginCore>;
 
-	fn default_policy_expr(&self, publisher: String, plugin: String) -> Result<Option<String>>;
+	fn default_policy_expr(&self, publisher: String, plugin: String) -> Result<Option<Expr>>;
 
 	fn default_query_explanation(
 		&self,
@@ -48,7 +49,7 @@ fn default_policy_expr(
 	db: &dyn HcEngine,
 	publisher: String,
 	plugin: String,
-) -> Result<Option<String>> {
+) -> Result<Option<Expr>> {
 	let core = db.core();
 	let key = get_plugin_key(publisher.as_str(), plugin.as_str());
 	let Some(p_handle) = core.plugins.get(&key) else {

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -10,6 +10,7 @@ mod types;
 
 use crate::error::Result;
 pub use crate::plugin::{get_plugin_key, manager::*, plugin_id::PluginId, types::*};
+use crate::policy_exprs::Expr;
 pub use arch::{get_current_arch, try_set_arch, Arch};
 pub use download_manifest::{ArchiveFormat, DownloadManifest, HashAlgorithm, HashWithDigest};
 use hipcheck_common::types::{Query, QueryDirection};
@@ -55,7 +56,7 @@ impl ActivePlugin {
 		}
 	}
 
-	pub fn get_default_policy_expr(&self) -> Option<&String> {
+	pub fn get_default_policy_expr(&self) -> Option<&Expr> {
 		self.channel.opt_default_policy_expr.as_ref()
 	}
 

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -58,7 +58,7 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 
 	builder
 		.set_risk_score(scoring.score.total)
-		.set_risk_policy(session.risk_policy().as_ref().clone());
+		.set_risk_policy(session.risk_policy()?.as_ref().clone());
 
 	let report = builder.build()?;
 
@@ -85,7 +85,7 @@ pub struct ReportBuilder<'sess> {
 	errored: Vec<ErroredAnalysis>,
 
 	/// What risk threshold was configured for the run.
-	risk_policy: Option<String>,
+	risk_policy: Option<Expr>,
 
 	/// What risk score Hipcheck assigned.
 	risk_score: Option<f64>,
@@ -151,7 +151,7 @@ impl<'sess> ReportBuilder<'sess> {
 	}
 
 	/// Set what's being recommended to the user.
-	pub fn set_risk_policy(&mut self, risk_policy: String) -> &mut Self {
+	pub fn set_risk_policy(&mut self, risk_policy: Expr) -> &mut Self {
 		self.risk_policy = Some(risk_policy);
 		self
 	}
@@ -177,7 +177,7 @@ impl<'sess> ReportBuilder<'sess> {
 			let policy = self
 				.risk_policy
 				.ok_or_else(|| hc_error!("no risk threshold set for report"))
-				.map(RiskPolicy)?;
+				.map(RiskPolicy::new)?;
 
 			// Determine recommendation based on score and investigate policy expr
 			let mut rec = Recommendation::is(score, policy)?;

--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -76,7 +76,7 @@ impl Plugin for ActivityPlugin {
 			return Err(Error::UnspecifiedQueryState);
 		};
 
-		Ok(format!("lte $ P{}w", conf.weeks.unwrap_or(71)))
+		Ok(format!("(lte $ P{}w)", conf.weeks.unwrap_or(71)))
 	}
 
 	fn explain_default_query(&self) -> Result<Option<String>> {


### PR DESCRIPTION
Resolves #677 .

This PR submits 2 commits, the long form of each commit message explains their purpose.

Broadly, this swaps `String` with `Expr` where applicable in the codebase. 

One major design decision was to not have `PolicyFile` itself try to parse the policy expressions and do the parsing when we transfer "policy expression" Strings from that file into the broader Hipcheck environment. 