### PR TITLE
fix: Ensure plugins have protoc installed for dist.

### DIFF
--- a/plugins/activity/dist.toml
+++ b/plugins/activity/dist.toml
@@ -15,3 +15,15 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/affiliation/dist.toml
+++ b/plugins/affiliation/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/binary/dist.toml
+++ b/plugins/binary/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/churn/dist.toml
+++ b/plugins/churn/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/entropy/dist.toml
+++ b/plugins/entropy/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/fuzz/dist.toml
+++ b/plugins/fuzz/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/git/dist.toml
+++ b/plugins/git/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/github/dist.toml
+++ b/plugins/github/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/identity/dist.toml
+++ b/plugins/identity/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/linguist/dist.toml
+++ b/plugins/linguist/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/npm/dist.toml
+++ b/plugins/npm/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/review/dist.toml
+++ b/plugins/review/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"

--- a/plugins/typo/dist.toml
+++ b/plugins/typo/dist.toml
@@ -15,3 +15,14 @@ install-updater = false
 
 # Make sure to include the plugin manifest.
 include = ["plugin.kdl"]
+# Make sure that both Hipcheck and all the plugins are built with the protobuf
+# compiler present on their platform.
+
+[dist.dependencies.apt]
+protobuf-compiler = "*"
+
+[dist.dependencies.homebrew]
+protobuf = "*"
+
+[dist.dependencies.chocolatey]
+protoc = "*"


### PR DESCRIPTION
This fixes a build failure during plugin release caused by a missing protobuf compiler.