### PR TITLE
feat: Add download manifests for all new plugins.

### DIFF
--- a/site/static/dl/plugin/mitre/activity.kdl
+++ b/site/static/dl/plugin/mitre/activity.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/activity-v0.1.0/activity-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="5089ef5d6e7307adc1793cbfc8dde8f53d407d8a9c6e77dcad0703c4d2431f2f"
+  compress format="tar.xz"
+  size bytes=1_096_284
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/activity-v0.1.0/activity-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="0138af7120977be6a0f44309345a9a79a0d4d1ba3cd77dd02635450ac0ab1a11"
+  compress format="tar.xz"
+  size bytes=1_185_456
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/activity-v0.1.0/activity-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="791c1051179966f59f9c1e14ccd21fedfa58458a83bda7d570acfcca7a647761"
+  compress format="zip"
+  size bytes=3_989_179
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/activity-v0.1.0/activity-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="83db1e17115fc5b8c71a06ca79ffa10cf972288001bc11ec5252ac301897f091"
+  compress format="tar.xz"
+  size bytes=1_275_520
+}

--- a/site/static/dl/plugin/mitre/affiliation.kdl
+++ b/site/static/dl/plugin/mitre/affiliation.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.1.0/affiliation-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="31672ec1e7cbde637c9c1a7a890d40fefb44d2e47205fb21d8ab812092bf3208"
+  compress format="tar.xz"
+  size bytes=1_143_068
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.1.0/affiliation-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="1303425c8cde0236f7f80da3bb227f01d222e38f0c0da1329563243401d045e7"
+  compress format="tar.xz"
+  size bytes=1_242_800
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.1.0/affiliation-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="d6745e07807c7bb195f822be4a3416a2ed2b2080cb9f9379c7fc7743a652ed19"
+  compress format="zip"
+  size bytes=4_139_728
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.1.0/affiliation-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="f2ec3958e00e7f877b4efde246f8596e502b1f2240914e22b28e58840f3fdf3b"
+  compress format="tar.xz"
+  size bytes=1_332_908
+}

--- a/site/static/dl/plugin/mitre/binary.kdl
+++ b/site/static/dl/plugin/mitre/binary.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/binary-v0.1.0/binary-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="66ece652f44ff47ad8f5ab45d4de1cde9f35fdc15c7c43b89aebb7203d277e8e"
+  compress format="tar.xz"
+  size bytes=1_183_768
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/binary-v0.1.0/binary-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="b3c7e463c701988bdb568bf520f71ef7e6fa21b5c5bc68449a53a42e59b575ab"
+  compress format="tar.xz"
+  size bytes=1_289_520
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/binary-v0.1.0/binary-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="aea41cd5b91c79432baf0b00b5f85fef33ecaefcc2dfe24028b5d7dbf6e0365c"
+  compress format="zip"
+  size bytes=4_322_356
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/binary-v0.1.0/binary-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="dfe3f12d5c4b8c9397f69aad40db27978f5777dd16440380e8f35c6ddf65f485"
+  compress format="tar.xz"
+  size bytes=1_382_112
+}

--- a/site/static/dl/plugin/mitre/churn.kdl
+++ b/site/static/dl/plugin/mitre/churn.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/churn-v0.1.0/churn-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="37ade41aadb25db06d49ddd3e87839cf81f454334239b08195c8a03041a62714"
+  compress format="tar.xz"
+  size bytes=1_240_268
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/churn-v0.1.0/churn-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="8cc59a50f877e7d28c60a4c4914acc4a09a7b0fee49509fb2abf4842bb2f4060"
+  compress format="tar.xz"
+  size bytes=1_347_532
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/churn-v0.1.0/churn-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="dfae4f6ab9a5632274c65ab89e63d44bd35a459f22f875e5844aefd58df45351"
+  compress format="zip"
+  size bytes=4_578_470
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/churn-v0.1.0/churn-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="2b45370f46212f8b6186618291b02e14b91b0df30051b5b21eb3ae09acd0fee3"
+  compress format="tar.xz"
+  size bytes=1_443_640
+}

--- a/site/static/dl/plugin/mitre/entropy.kdl
+++ b/site/static/dl/plugin/mitre/entropy.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.1.0/entropy-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="a68265eabb994f65aa01ead6747421000f47051960dd10a195f01a1741c84687"
+  compress format="tar.xz"
+  size bytes=1_332_104
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.1.0/entropy-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="81a5962e3819b82d2999f1a5a575894aab451cc69485b65cba581c28f5b305ff"
+  compress format="tar.xz"
+  size bytes=1_446_056
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.1.0/entropy-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="794c72b0793de206d2d99c59d3bfbf079ab13d39a59b012ae50535d57e119586"
+  compress format="zip"
+  size bytes=4_889_780
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.1.0/entropy-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="fb23a8df4904e188e130ecba17ca1d8f9795ee3d788ccee103b11d45d8590dac"
+  compress format="tar.xz"
+  size bytes=1_543_064
+}

--- a/site/static/dl/plugin/mitre/fuzz.kdl
+++ b/site/static/dl/plugin/mitre/fuzz.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.1.0/fuzz-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="774811c01d0c351c2c1b8e60b6b1f89773d4ab73cbb4b83c229357bf6778fa17"
+  compress format="tar.xz"
+  size bytes=1_066_152
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.1.0/fuzz-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="429314ada27f2f0230f9eb7f0109481dea211218bda1eaa1e9282413836923cb"
+  compress format="tar.xz"
+  size bytes=1_157_248
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.1.0/fuzz-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="e9b6b8e7066fc860610b2408cd3180e114108d7c8d8ee3e87e5b1a320dbe7822"
+  compress format="zip"
+  size bytes=3_883_154
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.1.0/fuzz-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="769a55b18246d273eae538ba19f9cbeaba3c787358c5017aa5b65ce376d596c9"
+  compress format="tar.xz"
+  size bytes=1_243_404
+}

--- a/site/static/dl/plugin/mitre/git.kdl
+++ b/site/static/dl/plugin/mitre/git.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/git-v0.1.0/git-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="e419092d9caef566ef1903c417f66ecb155917cc50e278e8b2c5de127baf51c7"
+  compress format="tar.xz"
+  size bytes=1_081_808
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/git-v0.1.0/git-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="e0bc850db7fdd14b3386656d9076b55cc6ba1f9cdab91b764378449f95e9cf6b"
+  compress format="tar.xz"
+  size bytes=1_177_464
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/git-v0.1.0/git-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="b9ab124af4b22df0b68e57f1e036ac5127d391e1745527bfec86c79f2a9e49b3"
+  compress format="zip"
+  size bytes=4_085_279
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/git-v0.1.0/git-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="df3660353b36b4fe95544fe2411c6a90283002628409997fe7e9313aa01170d3"
+  compress format="tar.xz"
+  size bytes=1_270_216
+}

--- a/site/static/dl/plugin/mitre/github.kdl
+++ b/site/static/dl/plugin/mitre/github.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/github-v0.1.0/github-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="c26f375f4c899b316281759193b21c382f97d49d59ca8bffe6225f5f06d723b4"
+  compress format="tar.xz"
+  size bytes=1_734_932
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/github-v0.1.0/github-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="d3538a11379f6ac00c71b78a31ac87aa15e0613f352603922eb0e6f58ff9f056"
+  compress format="tar.xz"
+  size bytes=1_893_876
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/github-v0.1.0/github-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="e44d51e608dec66ebbca59a5d53dd13894ed41247771d2d472360b5b8b0e880d"
+  compress format="zip"
+  size bytes=5_822_004
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/github-v0.1.0/github-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="69380bb7c1548a07e29bb9959b8f774eebfd3b70f3c3b30ee2808904416ddece"
+  compress format="tar.xz"
+  size bytes=2_029_200
+}

--- a/site/static/dl/plugin/mitre/identity.kdl
+++ b/site/static/dl/plugin/mitre/identity.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/identity-v0.1.0/identity-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="29743e3af0c58d89aae7609463b268548b13d1f0ebc3380be3bb47406206b877"
+  compress format="tar.xz"
+  size bytes=1_083_808
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/identity-v0.1.0/identity-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="6b6ba8985c8a5c1a322d211c451040d9d2166cb4943284c8321fecfcd8f70190"
+  compress format="tar.xz"
+  size bytes=1_174_092
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/identity-v0.1.0/identity-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="ceea8f1003efaf712c42987a04a61ce5d0c7c7331b9098fa70f2d16a85effbcb"
+  compress format="zip"
+  size bytes=3_961_541
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/identity-v0.1.0/identity-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="81087950da4be880f1cf7900f2f105f6a26a7d625365f3e027b475b076dfd820"
+  compress format="tar.xz"
+  size bytes=1_261_408
+}

--- a/site/static/dl/plugin/mitre/linguist.kdl
+++ b/site/static/dl/plugin/mitre/linguist.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.1.0/linguist-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="0f07051f7b1e68b532eb674b90b7e8df5d27ce889c81e05404e63b611ddffa7e"
+  compress format="tar.xz"
+  size bytes=1_061_228
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.1.0/linguist-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="f6dd7c23f63d571bedbde7c827658aab563e24939e3cc100196689809545ec9d"
+  compress format="tar.xz"
+  size bytes=1_154_760
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.1.0/linguist-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="4e8d4e03578b3957fc7937ffe5a6986e50f81b631ef685552396d05ca3d16ba5"
+  compress format="zip"
+  size bytes=3_813_954
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.1.0/linguist-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="b747a227e976f15b36ceffd2bee932d28631b0d90014868693d8ba5aded15a33"
+  compress format="tar.xz"
+  size bytes=1_242_572
+}

--- a/site/static/dl/plugin/mitre/npm.kdl
+++ b/site/static/dl/plugin/mitre/npm.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/npm-v0.1.0/npm-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="844d46b0dcf40d8d936a225bc2b3e05770328d0f999f3d140e770006cde26b6b"
+  compress format="tar.xz"
+  size bytes=1_372_136
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/npm-v0.1.0/npm-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="8df805599f507ab2cb4a1f5290b3c7fe32ce2725998640b94e91140d0550f9dc"
+  compress format="tar.xz"
+  size bytes=1_516_548
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/npm-v0.1.0/npm-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="3bad07bf00da8420704431c8a5038b997243404427d2a405c8adc2a8d4162647"
+  compress format="zip"
+  size bytes=5_334_047
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/npm-v0.1.0/npm-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="1a18e92ab219dfb846d6c781fe97d6c37c6892b22db51c36de05912b21fee231"
+  compress format="tar.xz"
+  size bytes=1_654_852
+}

--- a/site/static/dl/plugin/mitre/review.kdl
+++ b/site/static/dl/plugin/mitre/review.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/review-v0.1.0/review-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="8a8326468ea9a0f7e29696426a82c5366512b45659d7a3cc8761bf8ad6b0c861"
+  compress format="tar.xz"
+  size bytes=1_077_628
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/review-v0.1.0/review-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="a8103dd97d1b8438e3c30d0f164dea57834e42d51bb41f92a10fd68f0fadb08c"
+  compress format="tar.xz"
+  size bytes=1_168_736
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/review-v0.1.0/review-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="ae0cbc0dadace695a99aff433a48be6d4d55f1312460c81897ea5fbf821d452c"
+  compress format="zip"
+  size bytes=3_920_051
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/review-v0.1.0/review-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="254615fdd57ab3f949bbcbe5bbe0c1c457430de991515daeafc15cb5a3e612d8"
+  compress format="tar.xz"
+  size bytes=1_257_140
+}

--- a/site/static/dl/plugin/mitre/typo.kdl
+++ b/site/static/dl/plugin/mitre/typo.kdl
@@ -1,0 +1,28 @@
+
+plugin version="0.1.0" arch="aarch64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/typo-v0.1.0/typo-aarch64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="9107c6c16db5ffc5dc539c491ea68b2a65ed146488b2eb7abb4bdb055d04ecc5"
+  compress format="tar.xz"
+  size bytes=1_193_744
+}
+
+plugin version="0.1.0" arch="x86_64-apple-darwin" {
+  url "https://github.com/mitre/hipcheck/releases/download/typo-v0.1.0/typo-x86_64-apple-darwin.tar.xz"
+  hash alg="SHA256" digest="b3cd10abe658448484503b215aa06e65a28c29c3d533279d0bece53ab6143762"
+  compress format="tar.xz"
+  size bytes=1_298_664
+}
+
+plugin version="0.1.0" arch="x86_64-pc-windows-msvc" {
+  url "https://github.com/mitre/hipcheck/releases/download/typo-v0.1.0/typo-x86_64-pc-windows-msvc.zip"
+  hash alg="SHA256" digest="68af2b1c0109dc336fbd2e7ef12a7862af74e47f926dc031df93e79d4cb3a331"
+  compress format="zip"
+  size bytes=4_370_591
+}
+
+plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
+  url "https://github.com/mitre/hipcheck/releases/download/typo-v0.1.0/typo-x86_64-uknown-linux-gnu.tar.xz"
+  hash alg="SHA256" digest="8d11ef7f23c438dfcc4c9a84a774e9a86aa5467430fca896d4954da1b3d56be9"
+  compress format="tar.xz"
+  size bytes=1_392_500
+}


### PR DESCRIPTION
In the future we'll automate this. These are the download manifests for the new plugins, which are the mechanism that users of Hipcheck will use to incorporate these plugins themselves. It tells Hipcheck where to find the proper bundle for a specific plugin architecture + version combo.