### PR TITLE
fix: Fix plugin downloading and prep bump for fuzz

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,18 +1,20 @@
 plugins {
-    plugin "mitre/activity" version="0.1.0" manifest="./plugins/activity/plugin.kdl"
-    plugin "mitre/binary" version="0.1.0" manifest="./plugins/binary/plugin.kdl"
-    plugin "mitre/fuzz" version="0.1.0" manifest="./plugins/fuzz/plugin.kdl"
-    plugin "mitre/review" version="0.1.0" manifest="./plugins/review/plugin.kdl"
-    plugin "mitre/typo" version="0.1.0" manifest="./plugins/typo/plugin.kdl"
-    plugin "mitre/affiliation" version="0.1.0" manifest="./plugins/affiliation/plugin.kdl"
-    plugin "mitre/entropy" version="0.1.0" manifest="./plugins/entropy/plugin.kdl"
-    plugin "mitre/churn" version="0.1.0" manifest="./plugins/churn/plugin.kdl"
+    plugin "mitre/activity" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/affiliation" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/binary" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/churn" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/fuzz" version="0.1.1" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/review" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
 }
+
 patch {
 	plugin "mitre/github" {
 		api-token-var "HC_GITHUB_TOKEN"
 	}
 }
+
 analyze {
     investigate policy="(gt 0.5 $)"
     investigate-if-fail "mitre/typo" "mitre/binary"

--- a/hipcheck/src/plugin/download_manifest.rs
+++ b/hipcheck/src/plugin/download_manifest.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
+use crate::plugin::arch::KnownArch;
 use crate::{
 	hc_error,
 	plugin::{arch::Arch, PluginVersion},
@@ -7,9 +9,6 @@ use crate::{
 };
 use kdl::{KdlDocument, KdlNode, KdlValue};
 use std::{fmt::Display, str::FromStr};
-
-#[cfg(test)]
-use crate::plugin::arch::KnownArch;
 
 // NOTE: the implementation in this crate was largely derived from RFD #0004
 

--- a/hipcheck/src/plugin/plugin_manifest.rs
+++ b/hipcheck/src/plugin/plugin_manifest.rs
@@ -94,6 +94,7 @@ impl ParseKdlNode for Entrypoints {
 				.value()
 				.as_string()?
 				.to_string();
+
 			if let Err(_e) = entrypoints.insert(arch.clone(), entrypoint) {
 				log::error!("Duplicate entrypoint detected for [{}]", arch);
 				return None;

--- a/plugins/fuzz/plugin.kdl
+++ b/plugins/fuzz/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "fuzz"
-version "0.1.0"
+version "0.1.1"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/plugin/github.kdl"
+  plugin "mitre/github" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }


### PR DESCRIPTION
This fixes plugin downloading by ensuring plugins are downloaded and unarchived to the correct directory, and also fixes an error in the plugin manifests for `fuzz@0.1.0`, bumping to `0.1.1`.