### PR TITLE
chore: 3.8.0 announcement post

### DIFF
--- a/site/content/blog/2024-11-04-hipcheck-3.8.0-release.md
+++ b/site/content/blog/2024-11-04-hipcheck-3.8.0-release.md
@@ -1,0 +1,186 @@
+---
+title: Hipcheck 3.8.0 Release
+authors:
+  - Andrew Lilley Brinker
+extra:
+  author_img: "images/authors/andrew.jpg"
+---
+
+Introducing Hipcheck 3.8.0, with stable support for third-party plugins, a
+suite of initial plugins, and a lot of polish for the plugin user experience.
+
+<!-- more -->
+
+---
+
+## 📦&nbsp;&nbsp;Stable Support for Plugins
+
+In [Hipcheck 3.6.2][hc_3_6_2], we introduced experimental support for plugins,
+which add support for new data sources and analyses to Hipcheck. The goals
+of the plugin system are to enable _anyone_ to expand Hipcheck's analysis
+capabilities themselves and to ensure it's the best tool for users to express
+and enforce their own policies for third-party&nbsp;dependencies.
+
+Plugins in Hipcheck work by submitting queries to each other; when a plugin is
+specified in a user's [policy file], Hipcheck runs that plugin's "default query,"
+sending information about the target source repository and any package the user
+is analyzing. Those plugins can then make queries back to Hipcheck,
+which Hipcheck dispatches out to the appropriate plugin. For every query,
+Hipcheck also caches the result and can reuse it for any other plugins that
+need it. Even better, plugins expose JSON schemas for all queries which
+Hipcheck validates, and which dependent plugins can use to ensure compatibility.
+
+Since 3.6.2, we've been working on testing and improving the plugin system,
+and on transitioning Hipcheck's existing data sources and analyses out from
+the `hc` program itself and into plugins.
+
+This transition, to make all data sources and analyses run as plugins, ensures
+we gain firsthand experience with the plugin system and with our Rust plugin
+SDK. During this transition we identified bugs and deficiencies in the plugin
+system which have been fixed or have spurred the creation of RFDs proposing
+enhancements, including:
+
+- Chunked requests for plugin queries ([RFD&nbsp;#10][rfd_10]), to enable
+  sending queries with large keys, which can arise when analyzing large Git
+  repositories like the Linux kernel repository.
+- Support for batch querying ([RFD&nbsp;#9][rfd_9]), to enable sending many
+  small queries which are cached independently but combined in a single query
+  to reduce gRPC&nbsp;overhead.
+
+We expect to implement these RFDs in future versions of Hipcheck.
+
+### Introducing the New Plugins
+
+The following table lists all of the plugins added, and links to the
+documentation for each plugin:
+
+| Plugin Name           | Top-Level? | Download Manifest Location                                   |
+|:----------------------|:-----------|:-------------------------------------------------------------|
+| [`mitre/activity`]    | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl>    |
+| [`mitre/affiliation`] | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl> |
+| [`mitre/binary`]      | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl>      |
+| [`mitre/churn`]       | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl>       |
+| [`mitre/entropy`]     | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl>     |
+| [`mitre/fuzz`]        | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl>        |
+| [`mitre/git`]         | -          | <https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl>         |
+| [`mitre/github`]      | -          | <https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl>      |
+| [`mitre/identity`]    | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl>    |
+| [`mitre/linguist`]    | -          | <https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl>    |
+| [`mitre/npm`]         | -          | <https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl>         |
+| [`mitre/review`]      | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl>      |
+| [`mitre/typo`]        | Yes        | <https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl>        |
+
+The plugins listed as being "top-level" can be used directly in a policy file,
+because they support a default query accepting a Hipcheck "target" to analyze.
+
+The "download manifest locations" specify the files Hipcheck uses to determine
+what artifacts to download for a plugin based on your desired version and
+current architecture. You specify a `plugin` in a `plugins` block in your
+policy file, like so:
+
+```kdl
+plugins {
+    plugin "mitre/activity" version="0.1.0" \
+        manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+}
+```
+
+## 🦀&nbsp;&nbsp;Rust SDK version 0.2.0
+
+This release also includes improvements for the Hipcheck Rust SDK, including:
+
+- __New Features__
+  - Plugins can now report "concerns," additional information to inform a
+    Hipcheck user what to inspect if they want to further investigate
+    a target&nbsp;([#511](https://github.com/mitre/hipcheck/pull/511))
+  - Reduced the size of compiled code from the SDK using non-generic inner
+    functions&nbsp;([#488](https://github.com/mitre/hipcheck/pull/488))
+  - Added ability for plugin test code to mock query
+    responses&nbsp;([#476](https://github.com/mitre/hipcheck/pull/476))
+
+- __Bugfixes__
+  - Fixed bugs with query chunking which could result in errors when analyzing
+    large
+    repositories&nbsp;([#630](https://github.com/mitre/hipcheck/pull/630))
+  - Fixed bug that resulted in duplicate reporting of query explanations for
+    the default query of a
+    plugin&nbsp;([#605](https://github.com/mitre/hipcheck/pull/605))
+  - Fixed bug that caused failing queries to not send errors over gRPC back to
+    Hipcheck core&nbsp;([#548](https://github.com/mitre/hipcheck/pull/548))
+
+## 🗺️&nbsp;&nbsp;How to Get Involved
+
+Hipcheck is an open source project, and we'd love to get more contributors
+involved in building it. This doesn't just mean contributing to `hc` itself
+or building plugins, but also contributing to the website, improving the
+documentation, asking questions and sharing ideas in the issue tracker
+and discussions forum, and writing about your own experiences and lessons
+with Hipcheck for others to read.
+
+We have big plans for version 3.9.0 and beyond, including:
+
+- __Version 3.9.0__
+  - Query Batching and Submit Chunking
+  - Integrating plugins with the `hc ready` command
+- __Version 3.10.0__
+  - Substantial plugin documentation improvements, especially for creating your
+    own plugins
+  - Refactoring target resolution to make it easier to add support for more
+    types of targets, like more SBOM formats or package hosts
+- __Version 3.11.0__
+  - Explainable policy expressions, improving reporting of failed analyses by
+    explaining policy expressions in plain language
+  - Overhaul result reporting to make it easier to improve in the future, and
+    improve parity between the human-readable and JSON formats
+  - Upgrade `salsa`, the Rust package we use internally for query caching, to
+    the latest major version
+  - Introduce new documentation on how to become a Hipcheck developer yourself
+
+You can [the full roadmap][roadmap] on GitHub.
+
+## ⭐️&nbsp;&nbsp;Thank You to Our Contributors and Supporters
+
+I want to say a big "Thank you!" to everyone who supports the project here at
+MITRE, to CISA for [sponsoring our current work on it][cisa_hipcheck], to our
+prior government sponsors who have helped advance Hipcheck, and to everyone who
+has contributed, given feedback, or encouraged us in building it.
+
+Thank you especially to the contributors for this release:
+
+- [Julian Lanson], Hipcheck Development Team Lead at MITRE
+- [Patrick Casey], Hipcheck Developer at MITRE
+- [Michael Chernicoff], Hipcheck Developer at MITRE
+- [Cal Stepanian], Hipcheck Developer at MITRE
+- [Nino Agrawal], Hipcheck Developer at MITRE
+- [Aisha Mohammed], Hipcheck Developer at MITRE
+- [Brian Marr], Hipcheck Developer at MITRE
+- [Ashley Williams], Founder of Axo.dev
+
+
+[hc_3_6_2]: https://github.com/mitre/hipcheck/releases/tag/hipcheck-v3.6.2
+[policy file]: @/docs/guide/config/policy-file.md
+[rfd_10]: @/docs/rfds/0010-submit-chunking.md
+[rfd_9]: @/docs/rfds/0009-batch-queries.md
+[`mitre/activity`]: @/docs/guide/plugins/mitre-activity.md
+[`mitre/affiliation`]: @/docs/guide/plugins/mitre-affiliation.md
+[`mitre/binary`]: @/docs/guide/plugins/mitre-binary.md
+[`mitre/churn`]: @/docs/guide/plugins/mitre-churn.md
+[`mitre/entropy`]: @/docs/guide/plugins/mitre-entropy.md
+[`mitre/fuzz`]: @/docs/guide/plugins/mitre-fuzz.md
+[`mitre/git`]: @/docs/guide/plugins/mitre-git.md
+[`mitre/github`]: @/docs/guide/plugins/mitre-github.md
+[`mitre/identity`]: @/docs/guide/plugins/mitre-identity.md
+[`mitre/linguist`]: @/docs/guide/plugins/mitre-linguist.md
+[`mitre/npm`]: @/docs/guide/plugins/mitre-npm.md
+[`mitre/review`]: @/docs/guide/plugins/mitre-review.md
+[`mitre/typo`]: @/docs/guide/plugins/mitre-typo.md
+[Julian Lanson]: https://github.com/j-lanson
+[Patrick Casey]: https://github.com/patrickjcasey
+[Michael Chernicoff]: https://github.com/mchernicoff
+[Cal Stepanian]: https://github.com/cstepanian
+[Nino Agrawal]: https://github.com/ninaagrawal
+[Aisha Mohammed]: https://github.com/aamohd
+[Brian Marr]: https://github.com/bmarr-mitre
+[Ashley Williams]: https://github.com/ashleygwilliams
+[cisa_hipcheck]: https://www.cisa.gov/news-events/news/continued-progress-towards-secure-open-source-ecosystem
+[roadmap]: https://github.com/orgs/mitre/projects/33/views/15

--- a/site/templates/partials/prose-config.tera.html
+++ b/site/templates/partials/prose-config.tera.html
@@ -35,3 +35,12 @@ dark:prose-h2:text-neutral-100
 
 prose-h1:font-medium
 prose-h1:text-4xl
+
+prose-table:border
+prose-table:border-neutral-300
+prose-table:dark:border-neutral-700
+
+prose-td:p-3
+prose-th:p-3
+prose-th:bg-neutral-100
+prose-th:dark:bg-neutral-600


### PR DESCRIPTION
Don't publish until `hc` 3.8.0 and `hipcheck-sdk` 0.2.0 are released.