### PR TITLE
plugin download/execution improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,7 +1333,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
Resolves #706 . Resolves #707 .

Some quality of life changes for plugins.

- Add the plugin's cache path to the plugin's process PATH to help plugin process find artifacts when running
- Add `force: bool` to plugin downloading function, and use existing plugin with right version in cache if exists and `force=false` instead of pulling and decompressing every time
- Change plugin bundle extraction to only copy up artifacts from a subdir if it matches name of the bundle minus the compression extension. Previous impl could accidently copy unrelated files if passed `extract_dir` contained other subdirs already. 