### PR TITLE
docs: Fixed spelling and updated link in docs

### DIFF
--- a/site/content/docs/guide/config/policy-file.md
+++ b/site/content/docs/guide/config/policy-file.md
@@ -140,8 +140,8 @@ other plugins could be written to consume and process their output. However,
 the scoring system of Hipcheck relies on turning the output of each top-level
 plugin into a pass/fail evalution. In order to facilitate transforming plugin
 data into a boolean value, Hipcheck provides "policy expressions", which are a
-small expression language. See [here](policy-expr) for a reference on the policy
-expression language.
+small expression language. See [here](@/docs/guide/config/policy-expr.md) for a
+reference on the policy expression language.
 
 Users can define the pass/fail policy for an analysis node in the score tree
 with a `policy` key. As described in more detail in the policy expression

--- a/site/content/docs/guide/plugins/mitre-entropy.md
+++ b/site/content/docs/guide/plugins/mitre-entropy.md
@@ -36,13 +36,13 @@ likely source files.
 ## Explanation
 
 Entropy analysis attempts to identify commits which contain a high degree of
-textual randomness, in the believe that high textual randomness may indicate
+textual randomness, in the belief that high textual randomness may indicate
 the presence of packed malware or obfuscated code which ought to be assessed
 for possible malicious content.
 
 Entropy analysis works by determining the total number of occurrences for all
 unicode graphemes which appear in a repository's Git diffs for commits which
-include code. In then converts these occurence counts into frequencies based on
+include code. It then converts these occurrence counts into frequencies based on
 the total number of each individual grapheme divided by the total number of
 all graphemes in the combined set of Git diffs. It also determines grapheme
 frequencies for each commit individually. These individual and total grapheme


### PR DESCRIPTION
Resolves #711 . Resolves #712.

Fixed spelling errors in `mitre-entropy.md` file and updated the policy-expressions link in `policy-file.md` file in the Complete Guide.