### PR TITLE
fix: remove cmake build dep from git plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,15 +543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
+ "libz-sys",
  "miniz_oxide 0.8.0",
 ]
 
@@ -1480,7 +1471,6 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "prodash",
- "sha1",
  "sha1_smol",
  "thiserror 2.0.6",
  "walkdir",
@@ -2711,20 +2701,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-ng-sys"
+name = "libz-sys"
 version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -3882,16 +3862,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -12,10 +12,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 hipcheck-sdk = { version = "0.2.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-gix = { version = "0.68.0", default-features = false, features = [
-    "basic",
-    "max-performance",
-] }
+gix = { version = "0.68.0", default-features = false, features = ["basic", "max-control", "zlib-stock"] }
 jiff = { version = "0.1.14", features = ["serde"] }
 log = "0.4.22"
 once_cell = "1.10.0"


### PR DESCRIPTION
Resolves #733 .

Replacing our custom nom parser for git data with `gix` implicitly introduced a dependency on `cmake` to build `zlib-ng`. This commit changes the features of `gix` to use the system zlib instead if present.