### PR TITLE
CLRU added for git plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,10 +1221,12 @@ dependencies = [
  "hipcheck-sdk",
  "jiff",
  "log",
+ "lru",
  "once_cell",
  "schemars",
  "semver",
  "serde",
+ "serde_json",
  "tokio",
  "which",
 ]
@@ -2061,6 +2069,11 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2874,6 +2887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
 ]
 
 [[package]]

--- a/plugins/activity/local-plugin.kdl
+++ b/plugins/activity/local-plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/activity/plugin.kdl
+++ b/plugins/activity/plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/affiliation/local-plugin.kdl
+++ b/plugins/affiliation/local-plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/churn/local-plugin.kdl
+++ b/plugins/churn/local-plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/churn/plugin.kdl
+++ b/plugins/churn/plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/entropy/local-plugin.kdl
+++ b/plugins/entropy/local-plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/entropy/plugin.kdl
+++ b/plugins/entropy/plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
+lru = "0.12.5"
 gix = { version = "0.69.1", default-features = false, features = [
     "basic",
     "max-control",
@@ -22,6 +23,7 @@ log = "0.4.22"
 once_cell = "1.10.0"
 schemars = { version = "0.8.21", features = ["url"] }
 semver = "1.0.24"
+serde_json = "1.0.134"
 serde = { version = "1.0.215", features = ["derive", "rc"] }
 tokio = { version = "1.42.0", features = ["rt"] }
 which = { version = "7.0.1", default-features = false }

--- a/plugins/identity/local-plugin.kdl
+++ b/plugins/identity/local-plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-    plugin "mitre/git" version="0.2.0" manifest="./plugins/git/local-plugin.kdl"
+    plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/identity/plugin.kdl
+++ b/plugins/identity/plugin.kdl
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-    plugin "mitre/git" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+    plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/site/content/docs/guide/plugins/mitre-git.md
+++ b/site/content/docs/guide/plugins/mitre-git.md
@@ -8,3 +8,9 @@ extra:
 
 Provides access to Git commit history data. Does not define a default query
 and can't be used as a top-level plugin in a policy file.
+
+## Configuration
+
+| Parameter           | Type    | Explanation   |
+|:--------------------|:--------|:--------------|
+| `commit-cache-size` | `Integer` | Optional number of repositories to retain in cache. Defaults to one. |


### PR DESCRIPTION
12/30 - The PR has changes to the `git` plugin that uses an LRU cache functionality. The configurability of the size of the cache would come after the #662 changes are pulled.