### PR TITLE
fix minor issues in Containerfile for v3.9.0

### DIFF
--- a/dist/Containerfile
+++ b/dist/Containerfile
@@ -2,7 +2,7 @@
 
 FROM node:bookworm-slim
 
-ARG HC_VERSION="3.7.0"
+ARG HC_VERSION="3.9.0"
 
 WORKDIR /app
 
@@ -17,8 +17,8 @@ USER hc_user
 
 RUN set -eux \
     && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mitre/hipcheck/releases/download/hipcheck-v${HC_VERSION}/hipcheck-installer.sh | sh \
-    && $HOME/.cargo/bin/hc setup
+    && $HOME/.local/bin/hc setup
 
-ENV HC_CONFIG="$HOME/.config/hipcheck"
-ENTRYPOINT "$HOME/.cargo/bin/hc"
-CMD "help"
+ENV HC_CONFIG="/home/hc_user/.config/hipcheck"
+ENTRYPOINT ["/home/hc_user/.local/bin/hc"]
+CMD ["help"]


### PR DESCRIPTION
While attempting to locally build and run the docker image from the v3.9.0 release tag, I found several minor issues, addressed below. I also found one that I'm not sure how to fix, and will open an Issue for it.

- Both the `ENTRYPOINT` and `CMD` lines should be written in JSON notation to allow interactive use of "docker run". The current non-JSON form prevents user from running any CMD other than "help".

- in the source code on the v3.9.0 release tag, the version string in `dist/Containerfile` is still 3.7.0

- Between v3.7.0 and v3.8.0, the installed path changes from $HOME/.cache to $HOME/.local

After correcting the above issues, a default policy file is not found, but this is easily remedied now that `CMD` uses JSON notation and interactive `docker run` commands are possible:
```
docker run -it --rm sha256:9cae59257cca559025ebbbc958fa5b614396ab7e7de8c32cad016e90b077a056  --policy /home/hc_user/.config/hipcheck/Hipcheck.kdl ready
Hipcheck Version: hipcheck 3.9.0
Git Version:      git version 2.39.5
NPM Version:      10.9.2
Cache Path:       /home/hc_user/.cache/hipcheck
Policy Path:      /home/hc_user/.config/hipcheck/Hipcheck.kdl
Hipcheck is ready to run!
``