### PR TITLE
feat: improved version-to-git-tag matching scheme

### DIFF
--- a/hipcheck/src/source/git.rs
+++ b/hipcheck/src/source/git.rs
@@ -157,15 +157,12 @@ pub fn checkout(repo_path: &Path, refspec: Option<String>) -> HcResult<String> {
 		let tgt_ref: AnnotatedCommit = match repo.revparse_single(&refspec_str) {
 			Ok(object) => repo.find_annotated_commit(object.peel_to_commit()?.id())?,
 			// If that refspec is not found, try it again with a leading "v"
-			Err(e) => match repo.revparse_single(&format!("v{refspec_str}")) {
-				Ok(new_object) => repo.find_annotated_commit(new_object.peel_to_commit()?.id())?,
-				Err(_) => {
-					return Err(hc_error!(
-					"Could not find repo with provided refspec with or without a leading 'v': {}",
+			Err(e) => {
+				return Err(hc_error!(
+					"Could not find repo with provided refspec: {}",
 					e
-				))
-				}
-			},
+				));
+			}
 		};
 
 		repo.set_head_detached_from_annotated(tgt_ref)?;

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -139,11 +139,14 @@ impl Display for TargetSeedKind {
 				}
 				_ => write!(f, "remote repo at {}", remote.url.as_str()),
 			},
-			Package(package) => write!(
-				f,
-				"{} package {}@{}",
-				package.host, package.name, package.version
-			),
+			Package(package) => {
+				let ver_str = if package.has_version() {
+					format!("@{}", package.version)
+				} else {
+					format!(" ({})", package.version)
+				};
+				write!(f, "{} package {}{}", package.host, package.name, ver_str)
+			}
 			MavenPackage(package) => {
 				write!(f, "Maven package {}", package.url.as_str())
 			}


### PR DESCRIPTION
Resolves #753, #755, and #256 .

If during resolution we have a `Package` with a non-null version, we try to resolve to a tag in the repo with a variety of combinations of version specifier and package name. Verified that this works against `-t nmp duplexer2@0.1.4`, which previously gave us problems. Our previous dirty fix of checking `v<VERSION>` inside of `git::checkout()` has been removed.

Edit: Based on discussion in the Slack channel, I've augmented the logic. If a package is specified with no version and no ref, we will use a forgiving semver regex to try and find the "latest" version tag in the repo.