### PR TITLE
rfd9 implementation

### DIFF
--- a/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
+++ b/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
@@ -176,16 +176,20 @@ message Query {
 
     // The key for the query, as a JSON object. This is the data that Hipcheck's
     // incremental computation system will use to cache the response.
-    string key = 6;
+    repeated string key = 6;
 
     // The response for the query, as a JSON object. This will be cached by
     // Hipcheck for future queries matching the publisher name, plugin name,
     // query name, and key.
-    string output = 7;
+    repeated string output = 7;
 
 	// An unstructured concern raised during the query that will be raised
 	// in the final Hipcheck report.
 	repeated string concern = 8;
+
+    // Used to indicate whether or not a string field present in a `repeated string` field
+    // was split between two messages
+    bool split = 9;
 }
 
 enum QueryState {

--- a/hipcheck/src/cache/plugin.rs
+++ b/hipcheck/src/cache/plugin.rs
@@ -291,13 +291,9 @@ mod tests {
 			version: String::from("0.0.5"),
 			modified: SystemTime::now(),
 		};
-		let mut entries: Vec<PluginCacheEntry> = Vec::new();
-		entries.push(cache_entry_1);
-		entries.push(cache_entry_2);
-		entries.push(cache_entry_3);
-		entries.push(cache_entry_4);
-		entries
+		vec![cache_entry_1, cache_entry_2, cache_entry_3, cache_entry_4]
 	}
+
 	#[test]
 	fn test_scope_works_as_expected() {
 		let time_sort = PluginCacheListScope {

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -105,8 +105,8 @@ impl ActivePlugin {
 			publisher: publisher.to_owned(),
 			plugin: plugin.to_owned(),
 			query: name,
-			key,
-			output: serde_json::json!(null),
+			key: vec![key],
+			output: vec![],
 			concerns: vec![],
 		};
 
@@ -116,7 +116,7 @@ impl ActivePlugin {
 	pub async fn resume_query(
 		&self,
 		state: AwaitingResult,
-		output: Value,
+		output: Vec<Value>,
 	) -> Result<PluginResponse> {
 		let query = Query {
 			id: state.id,
@@ -124,7 +124,7 @@ impl ActivePlugin {
 			publisher: state.publisher,
 			plugin: state.plugin,
 			query: state.query,
-			key: serde_json::json!(null),
+			key: vec![],
 			output,
 			concerns: vec![],
 		};

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -469,7 +469,7 @@ pub struct AwaitingResult {
 	pub publisher: String,
 	pub plugin: String,
 	pub query: String,
-	pub key: Value,
+	pub key: Vec<Value>,
 }
 
 impl From<Query> for AwaitingResult {
@@ -486,7 +486,7 @@ impl From<Query> for AwaitingResult {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct QueryResult {
-	pub value: Value,
+	pub value: Vec<Value>,
 	pub concerns: Vec<String>,
 }
 

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -711,7 +711,7 @@ mod test {
 		let mut engine = PluginEngine::mock(mock_responses().unwrap());
 		let output = affiliation(&mut engine, target).await.unwrap();
 
-		let concerns = engine.take_concerns();
+		let concerns = engine.get_concerns();
 
 		assert_eq!(output.len(), 2);
 		let num_affiliated = output.iter().filter(|&n| *n).count();

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -222,7 +222,7 @@ mod test {
 		let num_typos = output.iter().filter(|&n| *n).count();
 		assert_eq!(num_typos, 2);
 
-		let concerns = engine.take_concerns();
+		let concerns = engine.get_concerns();
 		assert!(concerns.contains(&"chakl".to_string()));
 		assert!(concerns.contains(&"reacct".to_string()));
 	}


### PR DESCRIPTION
This pull request implements the majority of the guts of RFD #0009

- `hipcheck.proto` has been updated to make Query.key and Query.output
"repeated string fields"
- `hipcheck.proto` has been updated to add a new field, split, to Query
- chunking of GRPC messages now maintains initial ordering of fields
when chunking is required
- additional unit tests added for chunking algorithm
- added `batch_query` function to rust SDK

