### PR TITLE
fix: rel macro on windows inserting backslashes

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -311,9 +311,7 @@ impl CliConfig {
 		CliConfig {
 			path_args: PathArgs {
 				cache: dirs::home_dir().map(|dir| pathbuf![&dir, "hipcheck", "cache"]),
-				policy: std::env::current_dir()
-					.ok()
-					.map(|dir| pathbuf![&dir, "Hipcheck.kdl"]),
+				policy: None,
 				exec: None,
 			},
 			deprecated_args: DeprecatedArgs {

--- a/hipcheck/src/policy/macros.rs
+++ b/hipcheck/src/policy/macros.rs
@@ -26,7 +26,10 @@ fn rel(opt_var: Option<&str>, file_path: &Path) -> Result<String> {
 	// Dir of policy file + relative path parsed above
 	let new_path = pathbuf![file_path.parent().unwrap(), s];
 
-	let path_node = format!("\"{}\"", new_path.to_string_lossy().into_owned());
+	let path_node = format!("\"{}\"", new_path.to_string_lossy().into_owned())
+		// @Note - necessary because `to_string_lossy()` will insert backslashes on windows and
+		// the KDL parser will complain
+		.replace("\\", "/");
 
 	Ok(path_node)
 }


### PR DESCRIPTION
Resolves #814 .

Macro `#rel()` replaces paths, but the logic uses `to_string_lossy()` which uses backslashes on windows, which upsets the KDL parser.