### PR TITLE
feat: Add English language parsing of failure messages

### DIFF
--- a/hipcheck/src/policy_exprs/env.rs
+++ b/hipcheck/src/policy_exprs/env.rs
@@ -363,45 +363,45 @@ impl Env<'_> {
 		let mut env = Env::empty();
 
 		// Comparison functions.
-		env.add_fn("gt", gt, 2, ty_comp);
-		env.add_fn("lt", lt, 2, ty_comp);
-		env.add_fn("gte", gte, 2, ty_comp);
-		env.add_fn("lte", lte, 2, ty_comp);
-		env.add_fn("eq", eq, 2, ty_comp);
-		env.add_fn("neq", neq, 2, ty_comp);
+		env.add_fn("gt", "greater than", gt, 2, ty_comp);
+		env.add_fn("lt", "less than", lt, 2, ty_comp);
+		env.add_fn("gte", "greater than or equal to", gte, 2, ty_comp);
+		env.add_fn("lte", "less than or equal to", lte, 2, ty_comp);
+		env.add_fn("eq", "equal to", eq, 2, ty_comp);
+		env.add_fn("neq", "not equal to", neq, 2, ty_comp);
 
 		// Math functions.
-		env.add_fn("add", add, 2, ty_arithmetic_binary_ops);
-		env.add_fn("sub", sub, 2, ty_arithmetic_binary_ops);
-		env.add_fn("divz", divz, 2, ty_divz);
+		env.add_fn("add", "plus", add, 2, ty_arithmetic_binary_ops);
+		env.add_fn("sub", "minus", sub, 2, ty_arithmetic_binary_ops);
+		env.add_fn("divz", "divided by", divz, 2, ty_divz);
 
 		// Additional datetime math functions
-		env.add_fn("duration", duration, 2, ty_duration);
+		env.add_fn("duration", "minus", duration, 2, ty_duration);
 
 		// Logical functions.
-		env.add_fn("and", and, 2, ty_bool_binary);
-		env.add_fn("or", or, 2, ty_bool_binary);
-		env.add_fn("not", not, 1, ty_bool_unary);
+		env.add_fn("and", "and", and, 2, ty_bool_binary);
+		env.add_fn("or", "or", or, 2, ty_bool_binary);
+		env.add_fn("not", "not", not, 1, ty_bool_unary);
 
 		// Array math functions.
-		env.add_fn("max", max, 1, ty_from_first_arr);
-		env.add_fn("min", min, 1, ty_from_first_arr);
-		env.add_fn("avg", avg, 1, ty_avg);
-		env.add_fn("median", median, 1, ty_from_first_arr);
-		env.add_fn("count", count, 1, ty_count);
+		env.add_fn("max", "the maximum of", max, 1, ty_from_first_arr);
+		env.add_fn("min", "the minimum of", min, 1, ty_from_first_arr);
+		env.add_fn("avg", "the mean of", avg, 1, ty_avg);
+		env.add_fn("median", "the median of", median, 1, ty_from_first_arr);
+		env.add_fn("count", "the number of elements in", count, 1, ty_count);
 
 		// Array logic functions.
-		env.add_fn("all", all, 1, ty_higher_order_bool_fn);
-		env.add_fn("nall", nall, 1, ty_higher_order_bool_fn);
-		env.add_fn("some", some, 1, ty_higher_order_bool_fn);
-		env.add_fn("none", none, 1, ty_higher_order_bool_fn);
+		env.add_fn("all", "all of", all, 1, ty_higher_order_bool_fn);
+		env.add_fn("nall", "not all of", nall, 1, ty_higher_order_bool_fn);
+		env.add_fn("some", "some of", some, 1, ty_higher_order_bool_fn);
+		env.add_fn("none", "none of", none, 1, ty_higher_order_bool_fn);
 
 		// Array higher-order functions.
-		env.add_fn("filter", filter, 2, ty_filter);
-		env.add_fn("foreach", foreach, 2, ty_foreach);
+		env.add_fn("filter", "filtered on", filter, 2, ty_filter);
+		env.add_fn("foreach", "each to be", foreach, 2, ty_foreach);
 
 		// Debugging functions.
-		env.add_fn("dbg", dbg, 1, ty_inherit_first);
+		env.add_fn("dbg", "debugging", dbg, 1, ty_inherit_first);
 
 		env
 	}
@@ -423,6 +423,7 @@ impl Env<'_> {
 	pub fn add_fn(
 		&mut self,
 		name: &str,
+		english: &str,
 		op: Op,
 		expected_args: usize,
 		ty_checker: TypeChecker,
@@ -431,6 +432,7 @@ impl Env<'_> {
 			name.to_owned(),
 			Binding::Fn(FunctionDef {
 				name: name.to_owned(),
+				english: english.to_owned(),
 				expected_args,
 				ty_checker,
 				op,

--- a/hipcheck/src/policy_exprs/error.rs
+++ b/hipcheck/src/policy_exprs/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
 	#[error("expression returned '{0:?}', not a boolean")]
 	DidNotReturnBool(Expr),
 
+	#[error("evaluation of inner expression returned '{0:?}', not a primitive")]
+	BadReturnType(Expr),
+
 	#[error("tried to call unknown function '{0}'")]
 	UnknownFunction(String),
 

--- a/hipcheck/src/policy_exprs/expr.rs
+++ b/hipcheck/src/policy_exprs/expr.rs
@@ -64,6 +64,7 @@ pub type TypeChecker = fn(&[Type]) -> Result<ReturnableType>;
 #[derive(Clone, PartialEq, Debug, Eq)]
 pub struct FunctionDef {
 	pub name: String,
+	pub english: String,
 	pub expected_args: usize,
 	pub ty_checker: TypeChecker,
 	pub op: Op,
@@ -133,6 +134,21 @@ impl Function {
 			args,
 			opt_def: Some(op_info),
 		})
+	}
+
+	// If the function has exactly 2 arguments, switch their order
+	pub fn swap_args(&self) -> Self {
+		let args = &self.args;
+		let new_args = match args.len() {
+			2 => vec![args[1].clone(), args[0].clone()],
+			_ => args.clone(),
+		};
+
+		Function {
+			ident: self.ident.clone(),
+			args: new_args,
+			opt_def: self.opt_def.clone(),
+		}
 	}
 }
 impl From<Function> for Expr {

--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -14,12 +14,13 @@ pub mod report_builder;
 use crate::{
 	cli::Format,
 	error::{Context, Error, Result},
-	policy_exprs::{std_exec, Expr},
+	policy_exprs::{self, std_exec, Expr},
 	version::VersionQuery,
 };
 use chrono::prelude::*;
 use schemars::JsonSchema;
 use serde::{Serialize, Serializer};
+use serde_json::Value;
 use std::{
 	default::Default,
 	fmt,
@@ -284,6 +285,12 @@ pub struct Analysis {
 	#[schemars(schema_with = "String::json_schema")]
 	policy_expr: Expr,
 
+	/// The value returned by the analysis, if any, that was used in computing the policy expression
+	///
+	/// We use this when printing the result to help explain to the user
+	/// *why* an analysis failed.
+	value: Option<Value>,
+
 	/// The default query explanation pulled from RPC with the plugin.
 	message: String,
 }
@@ -294,11 +301,18 @@ pub struct Analysis {
 // }
 
 impl Analysis {
-	pub fn plugin(name: String, passed: bool, policy_expr: Expr, message: String) -> Self {
+	pub fn plugin(
+		name: String,
+		passed: bool,
+		policy_expr: Expr,
+		value: Option<Value>,
+		message: String,
+	) -> Self {
 		Analysis {
 			name,
 			passed,
 			policy_expr,
+			value,
 			message,
 		}
 	}
@@ -317,6 +331,15 @@ impl Analysis {
 
 	pub fn explanation(&self) -> String {
 		self.message.clone()
+	}
+
+	pub fn failing_explanation(&self) -> Result<String> {
+		let input = &self.policy_expr;
+		let message = &self.message;
+		let value = &self.value;
+		Ok(policy_exprs::parse_failing_expr_to_english(
+			input, message, value,
+		)?)
 	}
 }
 

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -44,7 +44,13 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 					.unwrap_or("no query explanation provided".to_owned());
 
 				builder.add_analysis(
-					Analysis::plugin(name, stored.passed, stored.policy.clone(), message),
+					Analysis::plugin(
+						name,
+						stored.passed,
+						stored.policy.clone(),
+						stored.value.clone(),
+						message,
+					),
 					res.concerns.clone(),
 				)?;
 			}

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -382,7 +382,13 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Failed,
 				analysis.statement()
 			);
-			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
+
+			// If we can parse failed expression to English, print a full English explanation. Otherwise print the default explanation text.
+			if let Ok(failing_explanation) = analysis.failing_explanation() {
+				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", failing_explanation);
+			} else {
+				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
+			}
 
 			for concern in failing_analysis.concerns() {
 				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", concern);

--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -81,7 +81,7 @@ impl Plugin for ActivityPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Span of time that has elapsed since last activity in repo".to_string(),
+			"span of time that has elapsed since last activity in repo".to_string(),
 		))
 	}
 

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -528,8 +528,7 @@ impl Plugin for AffiliationPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Returns whether each of the repository's contributors was flagged as affiliated or not"
-				.to_string(),
+			"the repository's contributors flagged as affiliated".to_string(),
 		))
 	}
 

--- a/plugins/binary/src/main.rs
+++ b/plugins/binary/src/main.rs
@@ -113,7 +113,7 @@ impl Plugin for BinaryPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Returns number of detected binary files in a repo".to_owned(),
+			"the number of detected binary files in a repo".to_owned(),
 		))
 	}
 

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -298,7 +298,7 @@ impl Plugin for ChurnPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"The churn frequency calculation of each commit in a repo".to_owned(),
+			"the churn frequency of each commit in the repository".to_owned(),
 		))
 	}
 

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -210,7 +210,7 @@ impl Plugin for EntropyPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"The entropy calculation of each commit in a repo".to_owned(),
+			"the entropy calculation of each commit in the repository".to_owned(),
 		))
 	}
 

--- a/plugins/fuzz/src/main.rs
+++ b/plugins/fuzz/src/main.rs
@@ -37,7 +37,7 @@ impl Plugin for FuzzAnalysisPlugin {
 	}
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
-		Ok(Some("Does the target repo do fuzzing".to_owned()))
+		Ok(Some("'Does the target repo do fuzzing?'".to_owned()))
 	}
 
 	queries! {}

--- a/plugins/review/src/main.rs
+++ b/plugins/review/src/main.rs
@@ -100,7 +100,7 @@ impl Plugin for ReviewPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Percentage of unreviewed commits to the repo".to_string(),
+			"commits to the repo indicating review or not".to_string(),
 		))
 	}
 

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -144,8 +144,7 @@ impl Plugin for TypoPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Returns whether each of the repository's package dependencies has a typo in its name"
-				.to_string(),
+			"the repository's dependencies flagged as typos".to_string(),
 		))
 	}
 


### PR DESCRIPTION
Part of Issue #383 . Adds primitive English-language summaries of policy expressions for failed plugins.

The policy expression level English parser requires that the "top level" of a policy expression be a function that takes two arguments (as the comparison operator functions that return a Boolean all do) where at least one argument is a Primitive type. It then applies a recursive English parser to each component of the policy expression, drilling into nested functions and lambdas as needed. After that, it evaluates whichever of the top level function's arguments is not a Primitive as a policy expression using the value returned by the plugin, to get the Primitive that the top level function is comparing the other Primitive to. The English language description of the function and the returned Primitive are then used to construct a final String describing why the plugin failed.

To facilitate parsing functions to English, the `FunctionDef` in an `Env` `Binding` now includes both a short, internal-use name and a longer English description as strings for each function. The descriptions are added when creating the standard environment.

All of the current Hipcheck plugins have had their default query explanations updated to work with the current form of the English parser.

Future work for this issue will entail adding a similar parser for successful plugins and adding additional code to the English parsers to clean up the language and better handle expected special cases that currently parse into awkward sentences.