### PR TITLE
update mitre/git and mitre/affiliation for RFD9

### DIFF
--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -20,7 +20,7 @@ use hipcheck_sdk::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
-	collections::{HashMap, HashSet},
+	collections::HashMap,
 	fmt::{self, Display, Formatter},
 	path::PathBuf,
 	result::Result as StdResult,
@@ -87,20 +87,6 @@ pub struct DetailedGitRepo {
 	pub details: Option<String>,
 }
 
-/// A locally stored git repo, with a list of additional details
-/// The details will vary based on the query (e.g. a date, a committer e-mail address, a commit hash)
-///
-/// This struct exists for using the temproary "batch" queries until proper batching is implemented
-/// TODO: Remove this struct once batching works
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct BatchGitRepo {
-	/// The local repo
-	local: LocalGitRepo,
-
-	/// Optional additional information for the query
-	pub details: Vec<String>,
-}
-
 /// Commits as understood in Hipcheck's data model.
 /// The `written_on` and `committed_on` datetime fields contain Strings that are created from `jiff:Timestamps`.
 /// Because `Timestamp` does not `impl JsonSchema`, we display the datetimes as Strings for passing out of this plugin.
@@ -141,6 +127,18 @@ pub struct CommitContributorView {
 	pub commit: Commit,
 	pub author: Contributor,
 	pub committer: Contributor,
+}
+
+impl CommitContributorView {
+	/// get the author of the commit
+	pub fn author(&self) -> &Contributor {
+		&self.author
+	}
+
+	/// get the committer of the commit
+	pub fn committer(&self) -> &Contributor {
+		&self.committer
+	}
 }
 
 /// Temporary data structure for looking up the commits associated with a contributor
@@ -187,97 +185,32 @@ impl<'haystack> Affiliator<'haystack> {
 	}
 }
 
-/// A commit and which of its contributors meets the affiliation criteria
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
-pub struct AffiliationDetails {
-	pub commit: Commit,
-	pub affiliated_type: AffiliatedType,
-}
+/// struct for counting number of contributions made by each contributor in the repo
+struct ContributorFrequencyMap<'a>(HashMap<&'a Contributor, u64>);
 
-#[derive(Debug, Eq, PartialEq, Serialize, Clone, Copy)]
-pub enum AffiliatedType {
-	Author,
-	Committer,
-	Both,
-	Neither,
-}
-
-impl AffiliatedType {
-	fn is(affiliator: &Affiliator, commit_view: &CommitContributorView) -> AffiliatedType {
-		let author_is_match = affiliator.is_match(&commit_view.author.email);
-		let committer_is_match = affiliator.is_match(&commit_view.committer.email);
-
-		match (author_is_match, committer_is_match) {
-			(true, true) => AffiliatedType::Both,
-			(true, false) => AffiliatedType::Author,
-			(false, true) => AffiliatedType::Committer,
-			(false, false) => AffiliatedType::Neither,
+impl<'a> ContributorFrequencyMap<'a> {
+	fn new(capacity: Option<usize>) -> Self {
+		match capacity {
+			Some(capacity) => Self(HashMap::with_capacity(capacity)),
+			None => Self(HashMap::new()),
 		}
 	}
 
-	pub fn is_affiliated(&self) -> bool {
-		!matches!(self, AffiliatedType::Neither)
-	}
-}
-
-// Can be hopefully removed once Submit has chunking
-mod chunk {
-	use super::*;
-
-	pub const GRPC_MAX_SIZE: usize = 1024 * 1024 * 4; // 4MB
-	pub const GRPC_EFFECTIVE_MAX_SIZE: usize = 3 * (GRPC_MAX_SIZE / 4); // 1024; // Minus one KB
-
-	pub fn chunk_hashes(
-		mut hashes: Vec<String>,
-		max_chunk_size: usize,
-	) -> Result<Vec<Vec<String>>> {
-		let mut out = vec![];
-
-		let mut made_progress = true;
-		while !hashes.is_empty() && made_progress {
-			made_progress = false;
-			let mut curr = vec![];
-			let mut remaining = max_chunk_size;
-
-			// While we still want to steal more bytes and we have more elements of
-			// `concern` to possibly steal
-			while remaining > 0 && !hashes.is_empty() {
-				let c_bytes = hashes.last().unwrap().bytes().len();
-
-				if c_bytes > max_chunk_size {
-					log::error!("Query cannot be chunked, there is a concern that is larger than max chunk size");
-					return Err(Error::UnspecifiedQueryState);
-				} else if c_bytes <= remaining {
-					// steal this concern
-					let concern = hashes.pop().unwrap();
-					curr.push(concern);
-					remaining -= c_bytes;
-					made_progress = true;
-				} else {
-					// Unlike concern chunking, hashes are likely to all be same size, no need to
-					// keep checking if we fail on one
-					break;
-				}
-			}
-			out.push(curr);
-		}
-
-		Ok(out)
+	/// Add an affiliated_contributor to the map, update frequency for affiliated_contributor
+	/// appropriately
+	///
+	/// If the contributor is not in the HashMap, then insert and set frequency to 1
+	/// Otherwise, increment frequency by 1
+	fn insert(&mut self, affiliated_contributor: &'a Contributor) {
+		self.0
+			.entry(affiliated_contributor)
+			.and_modify(|count| *count += 1)
+			.or_insert(1);
 	}
 
-	#[cfg(test)]
-	mod test {
-		use super::*;
-
-		#[test]
-		fn test_hash_chunk() {
-			let hashes: Vec<String> = vec!["1234", "1234", "1234", "1234", "1234"]
-				.into_iter()
-				.map(String::from)
-				.collect();
-			let res = chunk_hashes(hashes, 10).unwrap();
-			assert_eq!(res.len(), 3);
-		}
+	/// Retrieve a non-mutable handle to the internal HashMap
+	fn inner(&self) -> &HashMap<&'a Contributor, u64> {
+		&self.0
 	}
 }
 
@@ -295,15 +228,14 @@ async fn affiliation(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>
 
 	// Get the commits for the source.
 	let repo = key.local;
-	let commits_value = engine
-		.query("mitre/git/commits", repo.clone())
-		.await
+
+	// query the git plugin for a summary of all git contributors in the repo
+	let contributors_value = engine.query("mitre/git/contributor_summary", repo).await?;
+	let contributors: Vec<CommitContributorView> = serde_json::from_value(contributors_value)
 		.map_err(|e| {
-			log::error!("failed to get last commits for affiliation metric: {}", e);
-			Error::UnspecifiedQueryState
+			log::error!("Error parsing output from mitre/git/contributor_summary: {e}");
+			Error::UnexpectedPluginQueryInputFormat
 		})?;
-	let commits: Vec<Commit> = serde_json::from_value(commits_value)
-		.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
 
 	// Use the OrgSpec to build an Affiliator.
 	let affiliator = Affiliator::from_spec(org_spec).map_err(|e| {
@@ -311,175 +243,30 @@ async fn affiliation(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>
 		Error::UnspecifiedQueryState
 	})?;
 
-	// Temporary solution to retrieve afilliated commits until batching is implemented
-	// TODO: Once batching works, revert to using looped calls of contributors_to_commit() in the commented out code
-	// @Note - this lacks a way to chunk the commits into `contributors_for_commit`. Until this
-	// code is updated ot do so or outbound PluginQuerys get a SubmitInProgress state, this will be
-	// broken when analyzing large repos.
+	// attempt to reduce allocations by pre-allocating room for 500 unique contributors
+	let mut contributor_freq_map = ContributorFrequencyMap::new(Some(500));
+	contributors.iter().for_each(|contributor| {
+		contributor_freq_map.insert(contributor.author());
+		// prevent double counting a person if they are both the author and committer of a commit
+		if contributor.author() != contributor.committer() {
+			contributor_freq_map.insert(contributor.committer());
+		}
+	});
 
-	// for commit in commits.iter() {
-	// 	// Check if a commit matches the affiliation rules.
-	// 	let hash = commit.hash.clone();
-	// 	let detailed_repo = DetailedGitRepo {
-	// 		local: repo.clone(),
-	// 		details: Some(hash.clone()),
-	// 	};
-	// 	let view_value = engine
-	// 		.query("mitre/git/contributors_for_commit", detailed_repo)
-	// 		.await
-	// 		.map_err(|e| {
-	// 			log::error!("failed to get contributors for commit {}: {}", hash, e);
-	// 			Error::UnspecifiedQueryState
-	// 		})?;
-	// 	let commit_view: CommitContributorView = serde_json::from_value(view_value)
-	// 		.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
-	// for commit_view in commit_views {
-	// Get the affiliation type for the commit
-	// affiliations.push(AffiliationDetails {
-	// 	commit: commit.clone(),
-	// 	affiliated_type,
-	// });
-	// }
-	// let affiliated_iter = affiliations
-	// 	.into_iter()
-	// 	.filter(|a| a.affiliated_type.is_affiliated())
-
-	let mut contributors = HashSet::new();
-	let mut contributor_freq_map = HashMap::new();
-
-	// Get the hashes for each commit
-	let hashes = commits.iter().map(|c| c.hash.clone()).collect();
-
-	// Chunk hashes because for large repos the request message would be too large
-	let chunked_hashes = chunk::chunk_hashes(hashes, chunk::GRPC_EFFECTIVE_MAX_SIZE)?;
-
-	let mut commit_views: Vec<CommitContributorView> = vec![];
-	for hashes in chunked_hashes {
-		// Repo with the hash of every commit
-		let commit_batch_repo = BatchGitRepo {
-			local: repo.clone(),
-			details: hashes,
-		};
-		// Get a list of lookup structs for linking contributors to each commit
-		let commit_values = engine
-			.query("mitre/git/batch_contributors_for_commit", commit_batch_repo)
-			.await
-			.map_err(|e| {
-				log::error!("failed to get contributors for commits: {}", e);
-				Error::UnspecifiedQueryState
-			})?;
-		let views: Vec<CommitContributorView> = serde_json::from_value(commit_values)
-			.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
-		commit_views.extend(views.into_iter());
-	}
-
-	// For each commit, collect contributors that fail the affiliation rules
-	for commit_view in commit_views {
-		// Get the affiliation type for the commit
-		let affiliated_type = AffiliatedType::is(&affiliator, &commit_view);
-
-		// If the contributors fail the rules, add them to the contributor hash set
-		if affiliated_type.is_affiliated() {
-			match affiliated_type {
-				AffiliatedType::Author => {
-					contributors.insert((commit_view.author.name, commit_view.author.email));
-				}
-				AffiliatedType::Committer => {
-					contributors.insert((commit_view.committer.name, commit_view.committer.email));
-				}
-				AffiliatedType::Neither => (),
-				// Add both author and committer to the hash set if both are affiliated, in case they are distinct
-				AffiliatedType::Both => {
-					contributors.insert((commit_view.author.name, commit_view.author.email));
-					contributors.insert((commit_view.committer.name, commit_view.committer.email));
-				}
-			};
+	// by default initialize to false, only need to update if a contributor is affiliated
+	let mut affiliations = vec![false; contributor_freq_map.inner().keys().len()];
+	for (idx, (contributor, count)) in contributor_freq_map.inner().iter().enumerate() {
+		if affiliator.is_match(contributor.email.as_str()) {
+			let concern = format!(
+				"Contributor {} ({}) has count {}",
+				contributor.name, contributor.email, count
+			);
+			engine.record_concern(concern);
+			// SAFETY: affiliations has the same length as contributor_freq_map
+			*affiliations.get_mut(idx).unwrap() = true;
 		}
 	}
-
-	// Temporary solution to retrieve afilliated commits until batching is implemented
-	// TODO: Once batching works, revert to using looped calls of commits_for_contributor() in the commented out code
-
-	// let mut contributors = HashSet::new();
-	// let mut contributor_freq_map = HashMap::new();
-
-	// // Get the affiliated contributors from the commits
-	// for affiliation in affiliated_iter {
-	// 	let hash = affiliation.commit.hash;
-	// 	let commit_repo = DetailedGitRepo {
-	// 		local: repo.clone(),
-	// 		details: Some(hash.clone()),
-	// 	};
-	// 	let view_value = engine
-	// 		.query("mitre/git/contributors_for_commit", commit_repo)
-	// 		.await
-	// 		.map_err(|e| {
-	// 			log::error!("failed to get contributors for commit {}: {}", hash, e);
-	// 			Error::UnspecifiedQueryState
-	// 		})?;
-	// 	let commit_view: CommitContributorView = serde_json::from_value(view_value)
-	// 		.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
-
-	// Get the emails for each affiliated contributor
-	let emails = contributors.iter().map(|c| c.1.clone()).collect();
-	// Repo with the email of every affiliated contributor
-	let contributor_batch_repo = BatchGitRepo {
-		local: repo.clone(),
-		details: emails,
-	};
-
-	// Get a list of lookup structs for linking commits to each affiliated contributor
-	let contributor_values = engine
-		.query(
-			"mitre/git/batch_commits_for_contributor",
-			contributor_batch_repo,
-		)
-		.await
-		.map_err(|e| {
-			log::error!("failed to get commits for contributors: {}", e);
-			Error::UnspecifiedQueryState
-		})?;
-	let contributor_views: Vec<ContributorView> = serde_json::from_value(contributor_values)
-		.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
-
-	// For each affiliated contributor, count how many commits they contributed to,
-	// then add the contributor's name and its commit count to the contributor frequency hash map
-	for contributor_view in contributor_views {
-		let count = contributor_view.commits.len();
-		contributor_freq_map.insert(
-			format!(
-				"{} ({})",
-				contributor_view.contributor.name, contributor_view.contributor.email
-			),
-			count,
-		);
-	}
-
-	let all_contributors_value = engine
-		.query("mitre/git/contributors", repo.clone())
-		.await
-		.map_err(|e| {
-			log::error!("failed to get list of all contributors to repo: {}", e);
-			Error::UnspecifiedQueryState
-		})?;
-	let all_contributors: Vec<Contributor> = serde_json::from_value(all_contributors_value)
-		.map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
-	let all_emails: Vec<String> = all_contributors.iter().map(|c| c.email.clone()).collect();
-
-	let affiliated_emails: Vec<String> = contributors.iter().map(|c| c.1.clone()).collect();
-	let affiliations = all_emails
-		.iter()
-		.map(|e| affiliated_emails.contains(e))
-		.collect();
-
-	// Add each contributor-count pair as a concern
-	for (contributor, count) in contributor_freq_map.into_iter() {
-		let concern = format!("Contributor {} has count {}", contributor, count);
-		engine.record_concern(concern);
-	}
-
 	log::info!("completed affiliation metric");
-
 	Ok(affiliations)
 }
 
@@ -612,85 +399,14 @@ mod test {
 			committer: contributor_2.clone(),
 		};
 
-		let contributor_1_view = ContributorView {
-			contributor: contributor_1.clone(),
-			commits: vec![commit_1.clone(), commit_2.clone()],
-		};
-
-		let contributor_2_view = ContributorView {
-			contributor: contributor_2.clone(),
-			commits: vec![commit_2.clone(), commit_3.clone()],
-		};
-
-		let commits_repo = BatchGitRepo {
-			local: repo.clone(),
-			details: vec![
-				"ghi-789".to_string(),
-				"def-456".to_string(),
-				"abc-123".to_string(),
-			],
-		};
-
-		let contributors_repo = BatchGitRepo {
-			local: repo.clone(),
-			details: vec!["jsmith@mitre.org".to_string(), "jdoe@gmail.com".to_string()],
-		};
-
-		let contributor_1_repo = BatchGitRepo {
-			local: repo.clone(),
-			details: vec!["jsmith@mitre.org".to_string()],
-		};
-
-		let contributor_2_repo = BatchGitRepo {
-			local: repo.clone(),
-			details: vec!["jdoe@gmail.com".to_string()],
-		};
-
 		let mut mock_responses = MockResponses::new();
-
 		mock_responses
 			.insert(
-				"mitre/git/commits",
+				"mitre/git/contributor_summary",
 				repo.clone(),
-				Ok(vec![commit_1, commit_2, commit_3]),
+				Ok(vec![commit_1_view, commit_2_view, commit_3_view]),
 			)
 			.unwrap();
-		mock_responses
-			.insert(
-				"mitre/git/contributors",
-				repo,
-				Ok(vec![contributor_1, contributor_2]),
-			)
-			.unwrap();
-		mock_responses
-			.insert(
-				"mitre/git/batch_contributors_for_commit",
-				commits_repo,
-				Ok(vec![commit_3_view, commit_2_view, commit_1_view]),
-			)
-			.unwrap();
-		mock_responses
-			.insert(
-				"mitre/git/batch_commits_for_contributor",
-				contributors_repo,
-				Ok(vec![contributor_1_view.clone(), contributor_2_view.clone()]),
-			)
-			.unwrap();
-		mock_responses
-			.insert(
-				"mitre/git/batch_commits_for_contributor",
-				contributor_1_repo,
-				Ok(vec![contributor_1_view]),
-			)
-			.unwrap();
-		mock_responses
-			.insert(
-				"mitre/git/batch_commits_for_contributor",
-				contributor_2_repo,
-				Ok(vec![contributor_2_view]),
-			)
-			.unwrap();
-
 		Ok(mock_responses)
 	}
 
@@ -710,9 +426,7 @@ mod test {
 
 		let mut engine = PluginEngine::mock(mock_responses().unwrap());
 		let output = affiliation(&mut engine, target).await.unwrap();
-
 		let concerns = engine.get_concerns();
-
 		assert_eq!(output.len(), 2);
 		let num_affiliated = output.iter().filter(|&n| *n).count();
 		assert_eq!(num_affiliated, 1);
@@ -720,5 +434,18 @@ mod test {
 			concerns[0],
 			"Contributor Jane Doe (jdoe@gmail.com) has count 2"
 		)
+	}
+
+	#[test]
+	fn test_affiliated_contributor_freq_map() {
+		let mut map = ContributorFrequencyMap::new(Some(2));
+		let contributor = Contributor {
+			name: "John Smith".to_owned(),
+			email: "john.smith@example.com".to_owned(),
+		};
+		map.insert(&contributor);
+		assert_eq!(*map.inner().get(&contributor).unwrap(), 1);
+		map.insert(&contributor);
+		assert_eq!(*map.inner().get(&contributor).unwrap(), 2);
 	}
 }

--- a/plugins/git/src/data.rs
+++ b/plugins/git/src/data.rs
@@ -112,12 +112,26 @@ pub struct CommitContributor {
 	pub committer_id: usize,
 }
 
-/// Temporary data structure for looking up the contributors of a commit
+/// Data structure for looking up the contributors of a commit
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, JsonSchema)]
 pub struct CommitContributorView {
 	pub commit: Commit,
 	pub author: Contributor,
 	pub committer: Contributor,
+}
+
+impl From<RawCommit> for CommitContributorView {
+	fn from(value: RawCommit) -> Self {
+		Self {
+			commit: Commit {
+				hash: value.hash,
+				written_on: value.written_on.map(|x| x.to_string()),
+				committed_on: value.committed_on.map(|x| x.to_string()),
+			},
+			author: value.author,
+			committer: value.committer,
+		}
+	}
 }
 
 /// Temporary data structure for looking up the commits associated with a contributor

--- a/sdk/rust/src/engine.rs
+++ b/sdk/rust/src/engine.rs
@@ -165,7 +165,7 @@ impl PluginEngine {
 	/// Query another Hipcheck plugin `target` with Vec of `inputs`. On success, the JSONified result
 	/// of the query is returned. `target` will often be a string of the format
 	/// `"publisher/plugin[/query]"`, where the bracketed substring is optional if the plugin's
-	/// default query endpoint is desired. `input` must be a Vec containing a type which implements `serde::Serialize`,
+	/// default query endpoint is desired. `keys` must be a Vec containing a type which implements `serde::Serialize`,
 	pub async fn batch_query<T, V>(&mut self, target: T, keys: Vec<V>) -> Result<Vec<JsonValue>>
 	where
 		T: TryInto<QueryTarget, Error: Into<Error>>,


### PR DESCRIPTION
This PR completes the implementation of RFD9 outside of #821.

## What Changed

I experimented with using `batch_query` in `mitre/affiliation`, but on real repos, I found it was typically about 10x slower than our current implementation, due the sheer number of GRPC calls that were needed.

Based on this, I updated `mitre/affiliation` and removed the `TODO` sections around batching and also removed code related to custom chunking, as `hipcheck-common` now fully handles that. I also added a query to `mitre/git` that enables querying for all commits, as well as the author and committer of each commit. I also improved the ergonomics of checking each contributor for affiliation and reduced the amount of comparisons that are needed. I spent a few minutes benchmarking this branch with `hyperfine` and found this branch was about 5% faster when only running the affiliation plugin!


## Future Work
Working on this branch highlighted potential need for a `hipcheck-git-types` or similarly-named crate. This common crate would hold struct definitions and implementations of common traits (Serialize, Deserialize, Debug, From, ...) and would limit the amount of work that would be needed to reproduced in each of our plugins.