### PR TITLE
fix: backwards compatibility between RFD9 and prior plugins

### DIFF
--- a/hipcheck-common/Cargo.toml
+++ b/hipcheck-common/Cargo.toml
@@ -18,3 +18,7 @@ tonic = "0.12.3"
 anyhow = "1.0.95"
 pathbuf = "1.0.0"
 tonic-build = "0.12.3"
+
+[features]
+default = ["rfd9-compat"]
+rfd9-compat = []

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -141,7 +141,7 @@ xz2 = "0.1.7"
 zip = "2.2.2"
 zip-extensions = "0.8.1"
 zstd = "0.13.2"
-hipcheck-common = { version = "0.2.0", path = "../hipcheck-common" }
+hipcheck-common = { version = "0.2.0", path = "../hipcheck-common", features = ["rfd9-compat"] }
 serde_with = "3.12.0"
 
 [build-dependencies]


### PR DESCRIPTION
Resolves #821 .

Fixes some logic in hipcheck-common to support backwards compatibility in the form of communication with plugins using the pre-RF9 hipcheck-common. I have wrapped the behavior in a `rfd9-compat` feature so that it can be turned off / removed in the future if we decide backwards compatibility is no longer important.

I will spend time this week fleshing out ways to test that this is correct more concretely, but this does pass the following:
- all pre-RFD9 plugins
- all post-RFD9 plugins
- pre-RFD9 `git`, post-RFD9 `churn`
- post-RFD9 `git`, pre-RFD9 `churn`