### PR TITLE
feat: adds config files for testing release binaries

### DIFF
--- a/config/local.release.Hipcheck.kdl
+++ b/config/local.release.Hipcheck.kdl
@@ -1,0 +1,55 @@
+
+plugins {
+    plugin "mitre/activity" version="0.2.0" manifest="plugins/activity/local-release-plugin.kdl"
+    plugin "mitre/affiliation" version="0.2.0" manifest="plugins/affiliation/local-release-plugin.kdl"
+    plugin "mitre/binary" version="0.1.0" manifest="plugins/binary/local-release-plugin.kdl"
+    plugin "mitre/churn" version="0.2.0" manifest="plugins/churn/local-release-plugin.kdl"
+    plugin "mitre/entropy" version="0.2.0" manifest="plugins/entropy/local-release-plugin.kdl"
+    plugin "mitre/fuzz" version="0.1.1" manifest="plugins/fuzz/local-release-plugin.kdl"
+    plugin "mitre/review" version="0.1.0" manifest="plugins/review/local-release-plugin.kdl"
+    plugin "mitre/typo" version="0.1.0" manifest="plugins/typo/local-release-plugin.kdl"
+}
+
+patch {
+	plugin "mitre/github" {
+		api-token-var "HC_GITHUB_TOKEN"
+	}
+}
+
+analyze {
+    investigate policy="(gt 0.5 $)"
+    investigate-if-fail "mitre/typo" "mitre/binary"
+
+    category "practices" {
+        analysis "mitre/activity" policy="(lte $ P52w)" weight=3
+        analysis "mitre/binary" {
+			binary-file #rel("Binary.toml")
+			binary-file-threshold 0
+		}
+        analysis "mitre/fuzz" policy="(eq #t $)"
+        analysis "mitre/review" policy="(lte (divz (count (filter (eq #f) $)) (count $)) 0.05)"
+    }
+
+    category "attacks" {
+        analysis "mitre/typo" {
+            typo-file #rel("Typos.toml")
+            count-threshold 0
+        }
+
+        category "commit" {
+            analysis "mitre/affiliation" {
+                orgs-file #rel("Orgs.kdl")
+                count-threshold 0
+            }
+
+            analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
+				langs-file #rel("Langs.toml")
+				entropy-threshold 10.0
+				commit-percentage 0.0
+	 		}
+            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
+				langs-file #rel("Langs.toml")
+			}
+        }
+    }
+}

--- a/plugins/activity/local-release-plugin.kdl
+++ b/plugins/activity/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "activity"
+version "0.2.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/activity"
+  on arch="x86_64-apple-darwin" "./target/release/activity"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/activity"
+  on arch="x86_64-pc-windows-msvc" "./target/release/activity.exe"
+}
+
+dependencies {
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+}

--- a/plugins/affiliation/local-release-plugin.kdl
+++ b/plugins/affiliation/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "affiliation"
+version "0.2.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/affiliation"
+  on arch="x86_64-apple-darwin" "./target/release/affiliation"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/affiliation"
+  on arch="x86_64-pc-windows-msvc" "./target/release/affiliation.exe"
+}
+
+dependencies {
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+}

--- a/plugins/binary/local-release-plugin.kdl
+++ b/plugins/binary/local-release-plugin.kdl
@@ -1,0 +1,11 @@
+publisher "mitre"
+name "binary"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/binary"
+  on arch="x86_64-apple-darwin" "./target/release/binary"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/binary"
+  on arch="x86_64-pc-windows-msvc" "./target/release/binary.exe"
+}

--- a/plugins/churn/local-release-plugin.kdl
+++ b/plugins/churn/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "churn"
+version "0.2.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/churn"
+  on arch="x86_64-apple-darwin" "./target/release/churn"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/churn"
+  on arch="x86_64-pc-windows-msvc" "./target/release/churn.exe"
+}
+
+dependencies {
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+}

--- a/plugins/entropy/local-release-plugin.kdl
+++ b/plugins/entropy/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "entropy"
+version "0.2.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/entropy"
+  on arch="x86_64-apple-darwin" "./target/release/entropy"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/entropy"
+  on arch="x86_64-pc-windows-msvc" "./target/release/entropy.exe"
+}
+
+dependencies {
+  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+}

--- a/plugins/fuzz/local-release-plugin.kdl
+++ b/plugins/fuzz/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "fuzz"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/fuzz"
+  on arch="x86_64-apple-darwin" "./target/release/fuzz"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/fuzz"
+  on arch="x86_64-pc-windows-msvc" "./target/release/fuzz.exe"
+}
+
+dependencies {
+  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-release-plugin.kdl"
+}

--- a/plugins/git/local-release-plugin.kdl
+++ b/plugins/git/local-release-plugin.kdl
@@ -1,0 +1,11 @@
+publisher "mitre"
+name "git"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/git"
+  on arch="x86_64-apple-darwin" "./target/release/git"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/git"
+  on arch="x86_64-pc-windows-msvc" "./target/release/git.exe"
+}

--- a/plugins/github/local-release-plugin.kdl
+++ b/plugins/github/local-release-plugin.kdl
@@ -1,0 +1,11 @@
+publisher "mitre"
+name "github"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/github"
+  on arch="x86_64-apple-darwin" "./target/release/github"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/github"
+  on arch="x86_64-pc-windows-msvc" "./target/release/github.exe"
+}

--- a/plugins/identity/local-release-plugin.kdl
+++ b/plugins/identity/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "identity"
+version "0.2.0"
+license "Apache-2.0"
+
+entrypoint {
+    on arch="aarch64-apple-darwin" "./target/release/identity"
+    on arch="x86_64-apple-darwin" "./target/release/identity"
+    on arch="x86_64-unknown-linux-gnu" "./target/release/identity"
+    on arch="x86_64-pc-windows-msvc" "./target/release/identity.exe"
+}
+
+dependencies {
+    plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+}

--- a/plugins/linguist/local-release-plugin.kdl
+++ b/plugins/linguist/local-release-plugin.kdl
@@ -1,0 +1,11 @@
+publisher "mitre"
+name "linguist"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/linguist"
+  on arch="x86_64-apple-darwin" "./target/release/linguist"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/linguist"
+  on arch="x86_64-pc-windows-msvc" "./target/release/linguist.exe"
+}

--- a/plugins/npm/local-release-plugin.kdl
+++ b/plugins/npm/local-release-plugin.kdl
@@ -1,0 +1,11 @@
+publisher "mitre"
+name "npm"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/npm"
+  on arch="x86_64-apple-darwin" "./target/release/npm"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/npm"
+  on arch="x86_64-pc-windows-msvc" "./target/release/npm.exe"
+}

--- a/plugins/review/local-release-plugin.kdl
+++ b/plugins/review/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "review"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/review"
+  on arch="x86_64-apple-darwin" "./target/release/review"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/review"
+  on arch="x86_64-pc-windows-msvc" "./target/release/review.exe"
+}
+
+dependencies {
+  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-release-plugin.kdl"
+}

--- a/plugins/typo/local-release-plugin.kdl
+++ b/plugins/typo/local-release-plugin.kdl
@@ -1,0 +1,15 @@
+publisher "mitre"
+name "typo"
+version "0.1.0"
+license "Apache-2.0"
+
+entrypoint {
+  on arch="aarch64-apple-darwin" "./target/release/typo"
+  on arch="x86_64-apple-darwin" "./target/release/typo"
+  on arch="x86_64-unknown-linux-gnu" "./target/release/typo"
+  on arch="x86_64-pc-windows-msvc" "./target/release/typo.exe"
+}
+
+dependencies {
+  plugin "mitre/npm" version="0.1.0" manifest="./plugins/npm/local-release-plugin.kdl"
+}


### PR DESCRIPTION
- adds `local.release.Hipcheck.kdl` , which is a copy of `local.Hipcheck.kdl` with paths to `local-release-plugin.kdl` instead of `local-plugin.kdl`
- adds `local-release-plugin.kdl` file to each plugin, which specifies release binary paths

The above changes make it more convenient to test the release versions of binaries

I tested these files by doing the following:

```bash
rm -rf ~/.cache/hipcheck/plugins && cargo clean # to ensure there are no cached plugins or build artifacts
cargo build --release --workspace
./target/release/hc check --policy ./config/local.release.Hipcheck.kdl https://github.com/mitre/hipcheck
```