### PR TITLE
fix: Updates indicatif to v. 0.17.11 to resolve thread safety error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -70,7 +70,7 @@ hipcheck-macros = { path = "../hipcheck-macros", version = "0.3.1" }
 http = "1.2.0"
 indexmap = "2.7.0"
 indextree = "4.7.3"
-indicatif = { version = "0.17.9", features = ["rayon"] }
+indicatif = { version = "0.17.11", features = ["rayon"] }
 itertools = "0.13.0"
 jiff = "0.1.16"
 kdl = "6.2.2"


### PR DESCRIPTION
Resolves #840 by updating the version of the `indicatif` crate to 0.17.11.