### PR TITLE
cargo xtask buf fixes

### DIFF
--- a/hipcheck/src/target/purl.rs
+++ b/hipcheck/src/target/purl.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 use super::TargetType;
 use packageurl::PackageUrl;
 

--- a/xtask/src/task/buf.rs
+++ b/xtask/src/task/buf.rs
@@ -9,6 +9,11 @@ use xshell::{cmd, Shell};
 /// Run the `buf lint` command
 pub fn run() -> Result<()> {
 	let sh = Shell::new().context("could not init shell")?;
+	run_buf_lint(&sh)
+}
+
+/// Use existing `xshell::Shell` to run `buf lint`
+pub fn run_buf_lint(sh: &Shell) -> Result<()> {
 	which("buf").context("could not find 'buf'")?;
 
 	let root = workspace::root()?;

--- a/xtask/src/task/buf.rs
+++ b/xtask/src/task/buf.rs
@@ -13,7 +13,7 @@ pub fn run() -> Result<()> {
 
 	let root = workspace::root()?;
 	let config = pathbuf![&root, ".buf.yaml"];
-	let target = pathbuf![&root, "hipcheck", "proto"];
+	let target = pathbuf![&root, "hipcheck-common", "proto"];
 
 	cmd!(sh, "buf lint --config {config} {target}").run()?;
 

--- a/xtask/src/task/ci.rs
+++ b/xtask/src/task/ci.rs
@@ -2,6 +2,7 @@
 
 //! A task to simulate a CI run locally.
 
+use super::buf::run_buf_lint;
 use anyhow::{anyhow, Error, Result};
 use std::{mem::drop, ops::Not as _};
 use xshell::{cmd, Shell};
@@ -29,6 +30,7 @@ pub fn run() -> Result<()> {
 		task!(run_build),
 		task!(run_test),
 		task!(run_clippy),
+		task!(run_buf_lint),
 		task!(run_xtask_check),
 		task!(done),
 	];
@@ -123,6 +125,7 @@ fn print_versions(sh: &Shell) -> Result<()> {
 	print_fmt_version(sh)?;
 	print_clippy_version(sh)?;
 	print_xtask_version(sh)?;
+	print_buf_version(sh)?;
 
 	Ok(())
 }
@@ -167,6 +170,14 @@ fn print_xtask_version(sh: &Shell) -> Result<()> {
 	.run()
 	.map(drop)
 	.map_err(reason("call to cargo xtask failed. Make sure rust is installed and path to home-dir-here/.cargo/bin is on your path."))
+}
+
+/// Print the version of `buf`
+fn print_buf_version(sh: &Shell) -> Result<()> {
+	cmd!(sh, "buf --version")
+		.run()
+		.map(drop)
+		.map_err(reason("call to buf failed. Make sure buf is installed."))
 }
 
 /// Run `cargo fmt`.


### PR DESCRIPTION
I noticed `cargo xtask buf` was not working on `main`, so I resolved the issues. While I was resolving the issue, I also added support to `cargo xtask ci` to run the `buf lint` command and print out `buf --version`. I also noticed a missing SPDX License Identifier and added that, while I was here