### PR TITLE
fix: local plugins no longer overwrite released plugins

### DIFF
--- a/config/local.Hipcheck.kdl
+++ b/config/local.Hipcheck.kdl
@@ -1,12 +1,12 @@
 plugins {
-    plugin "mitre/activity" version="0.2.0" manifest="plugins/activity/local-plugin.kdl"
-    plugin "mitre/affiliation" version="0.2.0" manifest="plugins/affiliation/local-plugin.kdl"
-    plugin "mitre/binary" version="0.1.0" manifest="plugins/binary/local-plugin.kdl"
-    plugin "mitre/churn" version="0.2.0" manifest="plugins/churn/local-plugin.kdl"
-    plugin "mitre/entropy" version="0.2.0" manifest="plugins/entropy/local-plugin.kdl"
-    plugin "mitre/fuzz" version="0.1.1" manifest="plugins/fuzz/local-plugin.kdl"
-    plugin "mitre/review" version="0.1.0" manifest="plugins/review/local-plugin.kdl"
-    plugin "mitre/typo" version="0.1.0" manifest="plugins/typo/local-plugin.kdl"
+    plugin "mitre/activity" version="0.0.0" manifest="plugins/activity/local-plugin.kdl"
+    plugin "mitre/affiliation" version="0.0.0" manifest="plugins/affiliation/local-plugin.kdl"
+    plugin "mitre/binary" version="0.0.0" manifest="plugins/binary/local-plugin.kdl"
+    plugin "mitre/churn" version="0.0.0" manifest="plugins/churn/local-plugin.kdl"
+    plugin "mitre/entropy" version="0.0.0" manifest="plugins/entropy/local-plugin.kdl"
+    plugin "mitre/fuzz" version="0.0.0" manifest="plugins/fuzz/local-plugin.kdl"
+    plugin "mitre/review" version="0.0.0" manifest="plugins/review/local-plugin.kdl"
+    plugin "mitre/typo" version="0.0.0" manifest="plugins/typo/local-plugin.kdl"
 }
 
 patch {

--- a/config/local.release.Hipcheck.kdl
+++ b/config/local.release.Hipcheck.kdl
@@ -1,13 +1,13 @@
 
 plugins {
-    plugin "mitre/activity" version="0.2.0" manifest="plugins/activity/local-release-plugin.kdl"
-    plugin "mitre/affiliation" version="0.2.0" manifest="plugins/affiliation/local-release-plugin.kdl"
-    plugin "mitre/binary" version="0.1.0" manifest="plugins/binary/local-release-plugin.kdl"
-    plugin "mitre/churn" version="0.2.0" manifest="plugins/churn/local-release-plugin.kdl"
-    plugin "mitre/entropy" version="0.2.0" manifest="plugins/entropy/local-release-plugin.kdl"
-    plugin "mitre/fuzz" version="0.1.1" manifest="plugins/fuzz/local-release-plugin.kdl"
-    plugin "mitre/review" version="0.1.0" manifest="plugins/review/local-release-plugin.kdl"
-    plugin "mitre/typo" version="0.1.0" manifest="plugins/typo/local-release-plugin.kdl"
+    plugin "mitre/activity" version="0.0.0" manifest="plugins/activity/local-release-plugin.kdl"
+    plugin "mitre/affiliation" version="0.0.0" manifest="plugins/affiliation/local-release-plugin.kdl"
+    plugin "mitre/binary" version="0.0.0" manifest="plugins/binary/local-release-plugin.kdl"
+    plugin "mitre/churn" version="0.0.0" manifest="plugins/churn/local-release-plugin.kdl"
+    plugin "mitre/entropy" version="0.0.0" manifest="plugins/entropy/local-release-plugin.kdl"
+    plugin "mitre/fuzz" version="0.0.0" manifest="plugins/fuzz/local-release-plugin.kdl"
+    plugin "mitre/review" version="0.0.0" manifest="plugins/review/local-release-plugin.kdl"
+    plugin "mitre/typo" version="0.0.0" manifest="plugins/typo/local-release-plugin.kdl"
 }
 
 patch {
@@ -23,7 +23,7 @@ analyze {
     category "practices" {
         analysis "mitre/activity" policy="(lte $ P52w)" weight=3
         analysis "mitre/binary" {
-			binary-file #rel("Binary.toml")
+			binary-file #rel("Binary.kdl")
 			binary-file-threshold 0
 		}
         analysis "mitre/fuzz" policy="(eq #t $)"
@@ -32,7 +32,7 @@ analyze {
 
     category "attacks" {
         analysis "mitre/typo" {
-            typo-file #rel("Typos.toml")
+            typo-file #rel("Typos.kdl")
             count-threshold 0
         }
 
@@ -43,12 +43,12 @@ analyze {
             }
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
-				langs-file #rel("Langs.toml")
+				langs-file #rel("Langs.kdl")
 				entropy-threshold 10.0
 				commit-percentage 0.0
 	 		}
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
-				langs-file #rel("Langs.toml")
+				langs-file #rel("Langs.kdl")
 			}
         }
     }

--- a/plugins/activity/local-plugin.kdl
+++ b/plugins/activity/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "activity"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/activity/local-release-plugin.kdl
+++ b/plugins/activity/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "activity"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-release-plugin.kdl"
 }

--- a/plugins/affiliation/local-plugin.kdl
+++ b/plugins/affiliation/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "affiliation"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/affiliation/local-release-plugin.kdl
+++ b/plugins/affiliation/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "affiliation"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-release-plugin.kdl"
 }

--- a/plugins/binary/local-plugin.kdl
+++ b/plugins/binary/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "binary"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/binary/local-release-plugin.kdl
+++ b/plugins/binary/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "binary"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/churn/local-plugin.kdl
+++ b/plugins/churn/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "churn"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/churn/local-release-plugin.kdl
+++ b/plugins/churn/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "churn"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-release-plugin.kdl"
 }

--- a/plugins/entropy/local-plugin.kdl
+++ b/plugins/entropy/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "entropy"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/entropy/local-release-plugin.kdl
+++ b/plugins/entropy/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "entropy"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+  plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-release-plugin.kdl"
 }

--- a/plugins/fuzz/local-plugin.kdl
+++ b/plugins/fuzz/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "fuzz"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-plugin.kdl"
+  plugin "mitre/github" version="0.0.0" manifest="./plugins/github/local-plugin.kdl"
 }

--- a/plugins/fuzz/local-release-plugin.kdl
+++ b/plugins/fuzz/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "fuzz"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-release-plugin.kdl"
+  plugin "mitre/github" version="0.0.0" manifest="./plugins/github/local-release-plugin.kdl"
 }

--- a/plugins/git/local-plugin.kdl
+++ b/plugins/git/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "git"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/git/local-release-plugin.kdl
+++ b/plugins/git/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "git"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/github/local-plugin.kdl
+++ b/plugins/github/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "github"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/github/local-release-plugin.kdl
+++ b/plugins/github/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "github"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/identity/local-plugin.kdl
+++ b/plugins/identity/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "identity"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-    plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-plugin.kdl"
+    plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-plugin.kdl"
 }

--- a/plugins/identity/local-release-plugin.kdl
+++ b/plugins/identity/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "identity"
-version "0.2.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-    plugin "mitre/git" version="0.3.0" manifest="./plugins/git/local-release-plugin.kdl"
+    plugin "mitre/git" version="0.0.0" manifest="./plugins/git/local-release-plugin.kdl"
 }

--- a/plugins/linguist/local-plugin.kdl
+++ b/plugins/linguist/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "linguist"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/linguist/local-release-plugin.kdl
+++ b/plugins/linguist/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "linguist"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/npm/local-plugin.kdl
+++ b/plugins/npm/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "npm"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/npm/local-release-plugin.kdl
+++ b/plugins/npm/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "npm"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/review/local-plugin.kdl
+++ b/plugins/review/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "review"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-plugin.kdl"
+  plugin "mitre/github" version="0.0.0" manifest="./plugins/github/local-plugin.kdl"
 }

--- a/plugins/review/local-release-plugin.kdl
+++ b/plugins/review/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "review"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="./plugins/github/local-release-plugin.kdl"
+  plugin "mitre/github" version="0.0.0" manifest="./plugins/github/local-release-plugin.kdl"
 }

--- a/plugins/typo/local-plugin.kdl
+++ b/plugins/typo/local-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "typo"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/npm" version="0.1.0" manifest="./plugins/npm/local-plugin.kdl"
+  plugin "mitre/npm" version="0.0.0" manifest="./plugins/npm/local-plugin.kdl"
 }

--- a/plugins/typo/local-release-plugin.kdl
+++ b/plugins/typo/local-release-plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "typo"
-version "0.1.0"
+version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/npm" version="0.1.0" manifest="./plugins/npm/local-release-plugin.kdl"
+  plugin "mitre/npm" version="0.0.0" manifest="./plugins/npm/local-release-plugin.kdl"
 }


### PR DESCRIPTION
- updated all local.*.kdl files to use version `0.0.0` to prevent overwriting released plugins

By doing this, I see two main benefits:
- all of the `local.*.kdl` files no longer need to be updated each time a plugin version is bumped
- cached released plugins are not overwritten with development plugins

closes #844