### PR TITLE
fix: Removes panic when looking for multiple versions of the same plugin

### DIFF
--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -162,7 +162,7 @@ impl HcPluginCore {
 		let mapped_ctxs: Vec<PluginContextWithConfig> = ctxs
 			.into_iter()
 			.map(|c| {
-				let conf = conf_map.remove(&c.plugin.name).unwrap();
+				let conf = conf_map.get(&c.plugin.name).cloned().unwrap();
 				PluginContextWithConfig(c, conf)
 			})
 			.collect();


### PR DESCRIPTION
Resolves #846 by changing a `remove()` to a `get().cloned()`. This is a short term fix until we can fully implement tracking of plugins by version.