### PR TITLE
Jlanson/config file with rel path

### DIFF
--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -214,7 +214,7 @@ pub struct AffiliationConfig {
 #[serde(default)]
 pub struct BinaryConfig {
 	/// Binary file extension configuration file.
-	#[default = "Binary.kdl"]
+	#[default = "Binary.toml"]
 	pub binary_config_file: String,
 
 	/// Whether the analysis is active.
@@ -369,7 +369,7 @@ pub struct TypoConfig {
 	pub count_threshold: u64,
 
 	/// Path to a "typos file" containing necessary information for typo detection.
-	#[default = "Typos.kdl"]
+	#[default = "Typos.toml"]
 	pub typo_file: String,
 }
 
@@ -378,7 +378,7 @@ pub struct TypoConfig {
 #[serde(default)]
 pub struct LanguagesConfig {
 	/// The file to pull language information from.
-	#[default = "Langs.kdl"]
+	#[default = "Langs.toml"]
 	pub langs_file: String,
 }
 

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -176,7 +176,7 @@ fn cmd_print_weights(config: &CliConfig) -> Result<()> {
 	} else if let Some(c) = config.config() {
 		let config = Config::load_from(c)
 		.context("Failed to load configuration. If you have not yet done so on this system, try running `hc setup`. Otherwise, please make sure the config files are in the config directory.")?;
-		config_to_policy(config)?
+		config_to_policy(config, c)?
 	} else {
 		return Err(hc_error!("No policy file or (deprecated) config file found. Please provide a policy file before running Hipcheck."));
 	};

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -447,7 +447,7 @@ fn parse_churn(
 			value_threshold, percent_threshold,
 		);
 		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.kdl"];
+		let langs_path = pathbuf![&context.path, "Langs.toml"];
 		config
 			.insert(
 				"langs-file".to_string(),
@@ -494,7 +494,7 @@ fn parse_entropy(
 			value_threshold, percent_threshold
 		);
 		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.kdl"];
+		let langs_path = pathbuf![&context.path, "Langs.toml"];
 		config
 			.insert(
 				"langs-file".to_string(),

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -20,7 +20,7 @@ analyze {
     category "practices" weight=1 {
         analysis "mitre/activity" policy="(lte $ P71w)" weight=1
         analysis "mitre/binary" policy="(lte $ 0)" weight=1 {
-			binary-file "./config/Binary.kdl"
+			binary-file "./config/Binary.toml"
 		}
         analysis "mitre/fuzz" policy="(eq #t $)" weight=1
         analysis "mitre/identity" policy="(lte (divz (count (filter (eq #t) $)) (count $)) 0.2)" weight=1
@@ -29,7 +29,7 @@ analyze {
 
     category "attacks" weight=1 {
         analysis "mitre/typo" policy="(lte (count (filter (eq #t) $)) 0)" weight=1 {
-            typo-file "./config/Typos.kdl"
+            typo-file "./config/Typos.toml"
         }
 
         category "commit" weight=1 {
@@ -38,10 +38,10 @@ analyze {
             }
 
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" weight=1 {
-				langs-file "./config/Langs.kdl"
+				langs-file "./config/Langs.toml"
 			}
             analysis "mitre/entropy" policy="(lte (divz (count (filter (gt 10) $)) (count $)) 0)" weight=1 {
-				langs-file "./config/Langs.kdl"
+				langs-file "./config/Langs.toml"
 			}
         }
     }

--- a/hipcheck/src/policy/tests.rs
+++ b/hipcheck/src/policy/tests.rs
@@ -344,7 +344,8 @@ mod test {
 	fn test_config_to_policy() {
 		let config_path = pathbuf![&env::current_dir().unwrap(), "..", "config"];
 		let config = Config::load_from(&config_path).unwrap();
-		let policy_file = config_to_policy(config).unwrap();
+		let test_cfg_path = pathbuf!["./config"];
+		let policy_file = config_to_policy(config, &test_cfg_path).unwrap();
 
 		let expected_path = pathbuf![
 			&env::current_dir().unwrap(),

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -247,7 +247,7 @@ pub fn load_config_and_data(config_path: PathBuf) -> Result<(PolicyFile, PathBuf
 		.context("Failed to load configuration. If you have not yet done so on this system, try running `hc setup`. Otherwise, please make sure the config files are in the config directory.")?;
 
 	// Convert the Config struct to a PolicyFile struct
-	let policy = config_to_policy(config)?;
+	let policy = config_to_policy(config, &config_path)?;
 
 	phase.finish_successful();
 


### PR DESCRIPTION
Resolves #781 .

This PR updates `config_to_policy.rs` to set plugin config paths as relative to the location from which `Config` was loaded. This is closer to how things used to work for config before we added the policy file conversion.

In a separate commit, I also walked back what `Config` and `config_to_policy.rs` expect as the file format for all config files except `Orgs.kdl`, since `Config` targets the remote plugins that don't have the new .kdl format yet. My plan is to walk this back once the plugins are released but before Hipcheck 3.10 is released.