### PR TITLE
chore: revert this prior to 3.10 release

### DIFF
--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -22,7 +22,7 @@ analyze {
     category "practices" {
         analysis "mitre/activity" policy="(lte $ P52w)" weight=3
         analysis "mitre/binary" {
-			binary-file #rel("Binary.kdl")
+			binary-file #rel("Binary.toml")
 			binary-file-threshold 0
 		}
         analysis "mitre/fuzz" policy="(eq #t $)"
@@ -31,7 +31,7 @@ analyze {
 
     category "attacks" {
         analysis "mitre/typo" {
-            typo-file #rel("Typos.kdl")
+            typo-file #rel("Typos.toml")
             count-threshold 0
         }
 
@@ -42,12 +42,12 @@ analyze {
             }
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
-				langs-file #rel("Langs.kdl")
+				langs-file #rel("Langs.toml")
 				entropy-threshold 10.0
 				commit-percentage 0.0
 	 		}
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
-				langs-file #rel("Langs.kdl")
+				langs-file #rel("Langs.toml")
 			}
         }
     }


### PR DESCRIPTION
Additional change to make `Hipcheck.kdl` work until 3.10