### PR TITLE
chore: bump plugin versions for release

### DIFF
--- a/plugins/activity/plugin.kdl
+++ b/plugins/activity/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "activity"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "affiliation"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/binary/plugin.kdl
+++ b/plugins/binary/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "binary"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/churn/plugin.kdl
+++ b/plugins/churn/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "churn"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/entropy/plugin.kdl
+++ b/plugins/entropy/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "entropy"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/fuzz/plugin.kdl
+++ b/plugins/fuzz/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "fuzz"
-version "0.1.1"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/git/plugin.kdl
+++ b/plugins/git/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "git"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/github/plugin.kdl
+++ b/plugins/github/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "github"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/identity/plugin.kdl
+++ b/plugins/identity/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "identity"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/linguist/plugin.kdl
+++ b/plugins/linguist/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "linguist"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/npm/plugin.kdl
+++ b/plugins/npm/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "npm"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/review/plugin.kdl
+++ b/plugins/review/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "review"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/typo/plugin.kdl
+++ b/plugins/typo/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "typo"
-version "0.1.0"
+version "0.2.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/npm" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
+  plugin "mitre/npm" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
 }


### PR DESCRIPTION
Updating plugins' plugin.kdl versions and dependencies ahead of release.

All plugins had already had their `Cargo.toml` versions bumped earlier in the dev cycle, so this was just a process of updating the plugin.kdl files to match.