### PR TITLE
chore: bump plugin versions in Hipcheck confs and Hipcheck version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,12 +1,12 @@
 plugins {
-    plugin "mitre/activity" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/affiliation" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/binary" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/churn" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
-    plugin "mitre/fuzz" version="0.1.1" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/review" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/activity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/affiliation" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/binary" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/churn" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/fuzz" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/review" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
 }
 
 patch {
@@ -22,7 +22,7 @@ analyze {
     category "practices" {
         analysis "mitre/activity" policy="(lte $ P52w)" weight=3
         analysis "mitre/binary" {
-			binary-file #rel("Binary.toml")
+			binary-file #rel("Binary.kdl")
 			binary-file-threshold 0
 		}
         analysis "mitre/fuzz" policy="(eq #t $)"
@@ -31,7 +31,7 @@ analyze {
 
     category "attacks" {
         analysis "mitre/typo" {
-            typo-file #rel("Typos.toml")
+            typo-file #rel("Typos.kdl")
             count-threshold 0
         }
 
@@ -42,12 +42,12 @@ analyze {
             }
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
-				langs-file #rel("Langs.toml")
+				langs-file #rel("Langs.kdl")
 				entropy-threshold 10.0
 				commit-percentage 0.0
 	 		}
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
-				langs-file #rel("Langs.toml")
+				langs-file #rel("Langs.kdl")
 			}
         }
     }

--- a/dist/Containerfile
+++ b/dist/Containerfile
@@ -2,7 +2,7 @@
 
 FROM node:bookworm-slim
 
-ARG HC_VERSION="3.9.1"
+ARG HC_VERSION="3.10.0"
 
 WORKDIR /app
 

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -6,7 +6,7 @@ Automatically assess and score software packages for supply chain risk.
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"
-version = "3.9.1"
+version = "3.10.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://hipcheck.mitre.org"

--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -214,7 +214,7 @@ pub struct AffiliationConfig {
 #[serde(default)]
 pub struct BinaryConfig {
 	/// Binary file extension configuration file.
-	#[default = "Binary.toml"]
+	#[default = "Binary.kdl"]
 	pub binary_config_file: String,
 
 	/// Whether the analysis is active.
@@ -369,7 +369,7 @@ pub struct TypoConfig {
 	pub count_threshold: u64,
 
 	/// Path to a "typos file" containing necessary information for typo detection.
-	#[default = "Typos.toml"]
+	#[default = "Typos.kdl"]
 	pub typo_file: String,
 }
 
@@ -378,7 +378,7 @@ pub struct TypoConfig {
 #[serde(default)]
 pub struct LanguagesConfig {
 	/// The file to pull language information from.
-	#[default = "Langs.toml"]
+	#[default = "Langs.kdl"]
 	pub langs_file: String,
 }
 

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -24,9 +24,6 @@ use std::{
 };
 use url::Url;
 
-const PLUGIN_VERSION: &str = "0.1.0";
-const FUZZ_PLUGIN_VERSION: &str = "0.1.1";
-
 struct Context {
 	path: PathBuf,
 }
@@ -164,7 +161,7 @@ fn parse_activity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl").unwrap(),
 			)),
@@ -213,7 +210,7 @@ fn parse_binary(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/binary").unwrap(),
-			PluginVersion::new(PLUGIN_VERSION.to_string()),
+			PluginVersion::new("0.2.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl").unwrap(),
 			)),
@@ -247,7 +244,7 @@ fn parse_fuzz(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/fuzz").unwrap(),
-			PluginVersion::new(FUZZ_PLUGIN_VERSION.to_string()),
+			PluginVersion::new("0.2.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl").unwrap(),
 			)),
@@ -285,7 +282,7 @@ fn parse_identity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/identity").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl").unwrap(),
 			)),
@@ -323,7 +320,7 @@ fn parse_review(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/review").unwrap(),
-			PluginVersion::new(PLUGIN_VERSION.to_string()),
+			PluginVersion::new("0.2.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl").unwrap(),
 			)),
@@ -367,7 +364,7 @@ fn parse_typo(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/typo").unwrap(),
-			PluginVersion::new(PLUGIN_VERSION.to_string()),
+			PluginVersion::new("0.2.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl").unwrap(),
 			)),
@@ -411,7 +408,7 @@ fn parse_affiliation(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/affiliation").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl").unwrap(),
 			)),
@@ -447,7 +444,7 @@ fn parse_churn(
 			value_threshold, percent_threshold,
 		);
 		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.toml"];
+		let langs_path = pathbuf![&context.path, "Langs.kdl"];
 		config
 			.insert(
 				"langs-file".to_string(),
@@ -458,7 +455,7 @@ fn parse_churn(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/churn").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl").unwrap(),
 			)),
@@ -494,7 +491,7 @@ fn parse_entropy(
 			value_threshold, percent_threshold
 		);
 		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.toml"];
+		let langs_path = pathbuf![&context.path, "Langs.kdl"];
 		config
 			.insert(
 				"langs-file".to_string(),
@@ -505,7 +502,7 @@ fn parse_entropy(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/entropy").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl").unwrap(),
 			)),

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -1,13 +1,13 @@
 plugins {
-    plugin "mitre/activity" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/binary" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/fuzz" version="0.1.1" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/identity" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
-    plugin "mitre/review" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="0.1.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
-    plugin "mitre/affiliation" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/churn" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/activity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/binary" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/fuzz" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/identity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
+    plugin "mitre/review" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/affiliation" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/churn" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
 }
 patch {
 	plugin "mitre/github" {
@@ -20,7 +20,7 @@ analyze {
     category "practices" weight=1 {
         analysis "mitre/activity" policy="(lte $ P71w)" weight=1
         analysis "mitre/binary" policy="(lte $ 0)" weight=1 {
-			binary-file "./config/Binary.toml"
+			binary-file "./config/Binary.kdl"
 		}
         analysis "mitre/fuzz" policy="(eq #t $)" weight=1
         analysis "mitre/identity" policy="(lte (divz (count (filter (eq #t) $)) (count $)) 0.2)" weight=1
@@ -29,7 +29,7 @@ analyze {
 
     category "attacks" weight=1 {
         analysis "mitre/typo" policy="(lte (count (filter (eq #t) $)) 0)" weight=1 {
-            typo-file "./config/Typos.toml"
+            typo-file "./config/Typos.kdl"
         }
 
         category "commit" weight=1 {
@@ -38,10 +38,10 @@ analyze {
             }
 
             analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" weight=1 {
-				langs-file "./config/Langs.toml"
+				langs-file "./config/Langs.kdl"
 			}
             analysis "mitre/entropy" policy="(lte (divz (count (filter (gt 10) $)) (count $)) 0)" weight=1 {
-				langs-file "./config/Langs.toml"
+				langs-file "./config/Langs.kdl"
 			}
         }
     }

--- a/site/config.toml
+++ b/site/config.toml
@@ -59,7 +59,7 @@ footer = [
         { name = "Release Notes", url = "https://github.com/mitre/hipcheck/releases", external = true },
         { name = "Changelog", url = "https://github.com/mitre/hipcheck/blob/main/CHANGELOG.md", external = true },
         { name = "Packages", title = true },
-        { name = "Hipcheck", url = "https://github.com/mitre/hipcheck/releases/tag/hipcheck-v3.9.1", external = true },
+        { name = "Hipcheck", url = "https://github.com/mitre/hipcheck/releases/tag/hipcheck-v3.10.0", external = true },
         { name = "Rust Plugin SDK", url = "https://crates.io/crates/hipcheck-sdk", external = true },
     ],
     [

--- a/site/static/dl/install.ps1
+++ b/site/static/dl/install.ps1
@@ -2,7 +2,7 @@
 # This installer delegates to the "real" installer included with each new
 # release of Hipcheck.
 
-$hc_version = "3.9.1"
+$hc_version = "3.10.0"
 $repo = "https://github.com/mitre/hipcheck"
 $installer = "$repo/releases/download/hipcheck-v${hc_version}/hipcheck-installer.ps1"
 

--- a/site/static/dl/install.sh
+++ b/site/static/dl/install.sh
@@ -3,7 +3,7 @@
 # This installer delegates to the "real" installer included with each new
 # release of Hipcheck.
 
-HC_VERSION="3.9.1"
+HC_VERSION="3.10.0"
 REPO="https://github.com/mitre/hipcheck"
 INSTALLER="$REPO/releases/download/hipcheck-v$HC_VERSION/hipcheck-installer.sh"
 

--- a/site/static/dl/plugin/mitre/activity.kdl
+++ b/site/static/dl/plugin/mitre/activity.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1275548
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/activity-v0.3.0/activity-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="ec1088d3f69dc1fe8a54bb30a77e0ccbe1199430dae066e0814571d5b915f38d"
+    compress format="tar.xz"
+    size bytes=1115204
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/activity-v0.3.0/activity-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="322e08ded6494cf21ac19b1fbd445aadbc6c599b504fe40e8bdc5d127ac1e141"
+    compress format="tar.xz"
+    size bytes=1208332
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/activity-v0.3.0/activity-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="9b4e941f92993065df2f41b21cd2d3e6c65fa434e425e012b2f506e367632f94"
+    compress format="zip"
+    size bytes=4000443
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/activity-v0.3.0/activity-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="43fc1445391fbf323dc6dd5c0675f95e3d7def0974336d955a3aa4ba64362591"
+    compress format="tar.xz"
+    size bytes=1289344
+}

--- a/site/static/dl/plugin/mitre/affiliation.kdl
+++ b/site/static/dl/plugin/mitre/affiliation.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1333288
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.3.0/affiliation-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="d9b7f7e011bf06026c18f55912c1ea83dcaf2b4ebfbdf2c9e0164b133df5e993"
+    compress format="tar.xz"
+    size bytes=1156872
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.3.0/affiliation-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="85882389b3cff006344af30903f71b74b65006fa3a15d51abda12c7e02d2c901"
+    compress format="tar.xz"
+    size bytes=1256044
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.3.0/affiliation-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="f06a5149255f9f9512c22f6cf213f0196f9191dd0b1c756c52748e8ce2b31d24"
+    compress format="zip"
+    size bytes=4104400
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/affiliation-v0.3.0/affiliation-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="763c94c9ee2674f195f54f1f2c11bb6adfa1aca87b2b2bc8d3a720fda08c331b"
+    compress format="tar.xz"
+    size bytes=1338212
+}

--- a/site/static/dl/plugin/mitre/binary.kdl
+++ b/site/static/dl/plugin/mitre/binary.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1382112
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/binary-v0.2.0/binary-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="c4285a08a829a18b68e5c678dff00333e1150c00a94c7326eba3970a4519b733"
+    compress format="tar.xz"
+    size bytes=1156136
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/binary-v0.2.0/binary-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="0689448a70e0c01ac62428113760eeb717756ef2b74079c4092996ed2e5d9832"
+    compress format="tar.xz"
+    size bytes=1256796
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/binary-v0.2.0/binary-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="896ae92d03e6452fa25bcec8c54027431d533d41aaf7c0ef954cca0534fae14b"
+    compress format="zip"
+    size bytes=4103220
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/binary-v0.2.0/binary-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="f3d74b2d66923413c69826a733e268509e00015044bb4c93a3dbcfbf281ff365"
+    compress format="tar.xz"
+    size bytes=1339456
+}

--- a/site/static/dl/plugin/mitre/churn.kdl
+++ b/site/static/dl/plugin/mitre/churn.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1444328
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/churn-v0.3.0/churn-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="91322de16d0d3f32658ab5d218632a1dbc16a969a52b9c76e756df2efb4ac6a2"
+    compress format="tar.xz"
+    size bytes=1214608
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/churn-v0.3.0/churn-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="c0c05b6f62d4463b65b84aa6b1036f9b9bf01992d928228e0737e0aaa6e36e14"
+    compress format="tar.xz"
+    size bytes=1318340
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/churn-v0.3.0/churn-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="b271865da7531caeec42531310b617019876bb91ae28363b5e259ff9ce8c3463"
+    compress format="zip"
+    size bytes=4347046
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/churn-v0.3.0/churn-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="6c7a93fc0083f2a4759e50146bcae356057106a2a09b91a801fe26c75a7263b0"
+    compress format="tar.xz"
+    size bytes=1402944
+}

--- a/site/static/dl/plugin/mitre/entropy.kdl
+++ b/site/static/dl/plugin/mitre/entropy.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1544012
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.3.0/entropy-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="4ade074a5b892875ce98fb203fd00480800e8d2a884ad8f81c534938f7fa163b"
+    compress format="tar.xz"
+    size bytes=1305684
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.3.0/entropy-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="9d51642b763c49c947f9e290d04be8664dacd379f0650409d8c5342430aca23e"
+    compress format="tar.xz"
+    size bytes=1413428
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.3.0/entropy-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="7409b895aaee828bfc948f941d387099daabec802059f1f2ba94d43571e969e7"
+    compress format="zip"
+    size bytes=4654772
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/entropy-v0.3.0/entropy-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="e7538bb35f99ce42808106d6863937013ba1c263fa4f7a51d8112cd84a755912"
+    compress format="tar.xz"
+    size bytes=1498784
+}

--- a/site/static/dl/plugin/mitre/fuzz.kdl
+++ b/site/static/dl/plugin/mitre/fuzz.kdl
@@ -54,3 +54,31 @@ plugin version="0.1.1" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1243712
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.2.0/fuzz-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="50725e7f778d04e8a7dad1c0e083b44151e8fd1d75c0bd87f04b36c21cc448ea"
+    compress format="tar.xz"
+    size bytes=1087100
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.2.0/fuzz-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="cdf9f937999fd7735e7af586863bc23340b4efa245f76b62770274a460f5ead0"
+    compress format="tar.xz"
+    size bytes=1180504
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.2.0/fuzz-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="c9c379ee27ea91ac632afe2afa049c1d3a0b66e68c540d2c6896b0fe7f02daa6"
+    compress format="zip"
+    size bytes=3893413
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/fuzz-v0.2.0/fuzz-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="49fb02c96c4f01bb0bc7b11275f6c78ee294def800966ff960ec5242c8ee3744"
+    compress format="tar.xz"
+    size bytes=1258512
+}

--- a/site/static/dl/plugin/mitre/git.kdl
+++ b/site/static/dl/plugin/mitre/git.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=2229756
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/git-v0.3.0/git-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="6c3c6a932109054f9bbdbae12d53ac1de9d34e5dd0240c2342c4fb7e77bbac0f"
+    compress format="tar.xz"
+    size bytes=1961624
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/git-v0.3.0/git-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="617fc4b9cf1acae41c4747050295c5cc69a11f8683889fe51aeef713ca3cc821"
+    compress format="tar.xz"
+    size bytes=2103784
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/git-v0.3.0/git-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="ea14396a44d3daeeb825c69ea4be72d830bc848ae0f07afcc096db88b38e6bce"
+    compress format="zip"
+    size bytes=6897183
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/git-v0.3.0/git-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="c3a2aa6fce26cef264d2969c1359a5b1065aae87b389fe106208296fb195e83f"
+    compress format="tar.xz"
+    size bytes=2244344
+}

--- a/site/static/dl/plugin/mitre/github.kdl
+++ b/site/static/dl/plugin/mitre/github.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=2029200
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/github-v0.2.0/github-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="25d922185d296055ee4b69683fb7af5fc105839ea0b783191c91443e773cb194"
+    compress format="tar.xz"
+    size bytes=1762708
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/github-v0.2.0/github-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="c2b8b442d42fca7862948df36db209c15af97efba12caf874b323198cb59d25f"
+    compress format="tar.xz"
+    size bytes=1923852
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/github-v0.2.0/github-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="4fda6c0523911e5cca9c46fb0feac47d81b99c654331c9e5bb816a7652c751ce"
+    compress format="zip"
+    size bytes=5723700
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/github-v0.2.0/github-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="627461d29c7b2e2db2861cdb54f1fddf786d9104db8fbe9d8cbafd8186b41601"
+    compress format="tar.xz"
+    size bytes=2048416
+}

--- a/site/static/dl/plugin/mitre/identity.kdl
+++ b/site/static/dl/plugin/mitre/identity.kdl
@@ -54,3 +54,31 @@ plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1262112
 }
+
+plugin version="0.3.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/identity-v0.3.0/identity-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="270e2d54cba3cb7e97cb09db0bde6b053ea1bed96ee8d029fc349f46e5c133dd"
+    compress format="tar.xz"
+    size bytes=1102332
+}
+
+plugin version="0.3.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/identity-v0.3.0/identity-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="e62cb2685664f029d3bbc42cc7b1be4e37d5508a63d23ac18cca970224a2d87d"
+    compress format="tar.xz"
+    size bytes=1195524
+}
+
+plugin version="0.3.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/identity-v0.3.0/identity-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="192c26424be28f63a0c14bdd1c29a5d8038b276837dbadc5fec8d35e97ab47b8"
+    compress format="zip"
+    size bytes=3964101
+}
+
+plugin version="0.3.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/identity-v0.3.0/identity-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="343d011e222c18fb341f34d924850932266a79cc939d3279e907609d72aed8f1"
+    compress format="tar.xz"
+    size bytes=1275076
+}

--- a/site/static/dl/plugin/mitre/linguist.kdl
+++ b/site/static/dl/plugin/mitre/linguist.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1242572
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.2.0/linguist-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="125adf06b60e010fce470ee7a0547aa6d078b7c62214c934d0a24dfbd6ae2ad5"
+    compress format="tar.xz"
+    size bytes=1026964
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.2.0/linguist-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="f75ab6bbd2b55fa872ed37bb6ba6d0d6a0739cc890d482b91c654d6d9e950d5a"
+    compress format="tar.xz"
+    size bytes=1111996
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.2.0/linguist-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="2d1ee1c93c28677e15ee5b19f976402de21c804a6e55a215273c488b997d9af3"
+    compress format="zip"
+    size bytes=3588162
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/linguist-v0.2.0/linguist-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="96c0dd79fb5815874a1249bbbbcaaa105845661175b9d3c3a2f86557695f7deb"
+    compress format="tar.xz"
+    size bytes=1190188
+}

--- a/site/static/dl/plugin/mitre/npm.kdl
+++ b/site/static/dl/plugin/mitre/npm.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1654852
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/npm-v0.2.0/npm-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="e9e2e1d17a83c88781e60198edd9ff65e56862369ecdb95b0c5ed62e9f6b51be"
+    compress format="tar.xz"
+    size bytes=1399252
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/npm-v0.2.0/npm-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="adadaaf0f614d37b5e07a3fa5699c89da4110880ba38b2fbe75ad0cb02571885"
+    compress format="tar.xz"
+    size bytes=1544968
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/npm-v0.2.0/npm-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="be77d38e10a6a9375789bd47ac12f4bbecb0c72ddbf2e380d714df9b4ac7ca1e"
+    compress format="zip"
+    size bytes=5361695
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/npm-v0.2.0/npm-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="8c0d04846c896fc172b121e0867745600bc36edb2174421e6248218a07966c5c"
+    compress format="tar.xz"
+    size bytes=1671180
+}

--- a/site/static/dl/plugin/mitre/review.kdl
+++ b/site/static/dl/plugin/mitre/review.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1257140
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/review-v0.2.0/review-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="d7410f484299b74745236ea09922a8d4068321f351c41dd68b53b92d3f69bd52"
+    compress format="tar.xz"
+    size bytes=1098336
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/review-v0.2.0/review-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="63fb34502640aa59185de722438b8d4b12dd887327fa44f3a4228b95ba2abbc3"
+    compress format="tar.xz"
+    size bytes=1189784
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/review-v0.2.0/review-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="94d83f9828e95778d4143afef86d475e1a384cec701460602d98614411603d30"
+    compress format="zip"
+    size bytes=3927219
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/review-v0.2.0/review-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="7e473918d627744ba22e071de8e302d68b3e7ce52a840d4254e64cca8f5398cf"
+    compress format="tar.xz"
+    size bytes=1271188
+}

--- a/site/static/dl/plugin/mitre/typo.kdl
+++ b/site/static/dl/plugin/mitre/typo.kdl
@@ -26,3 +26,31 @@ plugin version="0.1.0" arch="x86_64-unknown-linux-gnu" {
     compress format="tar.xz"
     size bytes=1392500
 }
+
+plugin version="0.2.0" arch="aarch64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/typo-v0.2.0/typo-aarch64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="50b68e480d1d2c8e647a4b9f3a4ed010e9a214475c57e54e2fee8a74bee2604e"
+    compress format="tar.xz"
+    size bytes=1168568
+}
+
+plugin version="0.2.0" arch="x86_64-apple-darwin" {
+    url "https://github.com/mitre/hipcheck/releases/download/typo-v0.2.0/typo-x86_64-apple-darwin.tar.xz"
+    hash alg="SHA256" digest="71a1c7570dd33dd53fd80c5c1807d05d6d997a0d0161a0379af3d462f7f5acc3"
+    compress format="tar.xz"
+    size bytes=1269336
+}
+
+plugin version="0.2.0" arch="x86_64-pc-windows-msvc" {
+    url "https://github.com/mitre/hipcheck/releases/download/typo-v0.2.0/typo-x86_64-pc-windows-msvc.zip"
+    hash alg="SHA256" digest="e1d624118b5ab16e9f838dc9972475e521423965af6c6524e315b7f8c01e8562"
+    compress format="zip"
+    size bytes=4163231
+}
+
+plugin version="0.2.0" arch="x86_64-unknown-linux-gnu" {
+    url "https://github.com/mitre/hipcheck/releases/download/typo-v0.2.0/typo-x86_64-unknown-linux-gnu.tar.xz"
+    hash alg="SHA256" digest="3b7b19327c45a15ccf5bb7fa48073d7b1bed9b6cce0e8c0b2e543f7f690895a3"
+    compress format="tar.xz"
+    size bytes=1352932
+}


### PR DESCRIPTION
Resolves #798 .

Still todo: run `cargo xtask manifest` once plugins finish releasing.

We should make sure that running `hc --config ./config ...` works with this branch before committing.