### PR TITLE
fix: improve user experience when unable to find plugin download manifest

### DIFF
--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -111,9 +111,10 @@ fn retrieve_plugin_from_network(
 		}
 	}
 	Err(hc_error!(
-		"Could not find download manifest entry for arch '{}' with version '{}'",
+		"Could not find download manifest entry for '{}' [{}] with version '{}'",
+		plugin_id.to_policy_file_plugin_identifier(),
 		current_arch,
-		version.0
+		plugin_id.version().as_ref(),
 	))
 }
 


### PR DESCRIPTION
I improved the error message that is printed when a `hc` is unable to find a plugin manifest for a particular plugin.

Original output:
![image](https://github.com/user-attachments/assets/ff0fb988-9009-46ec-9cb3-dd1518e880c3)

Updated output:
![image](https://github.com/user-attachments/assets/b47053d8-48af-4038-b50a-7b0653d79def)
