### PR TITLE
feat: Adds English language parsing for successful analyses

### DIFF
--- a/hipcheck/src/policy_exprs/env.rs
+++ b/hipcheck/src/policy_exprs/env.rs
@@ -16,6 +16,7 @@ use Expr::*;
 use Primitive::*;
 
 /// Environment, containing bindings of names to functions and variables.
+#[derive(Clone)]
 pub struct Env<'parent> {
 	/// Map of bindings,.
 	bindings: HashMap<String, Binding>,

--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -330,16 +330,24 @@ impl Analysis {
 	}
 
 	pub fn explanation(&self) -> String {
-		self.message.clone()
-	}
-
-	pub fn failing_explanation(&self) -> Result<String> {
 		let input = &self.policy_expr;
 		let message = &self.message;
 		let value = &self.value;
-		Ok(policy_exprs::parse_failing_expr_to_english(
-			input, message, value,
-		)?)
+		let passed = self.passed;
+
+		// Try to parse the policy expression to an English language explanation of why the plugin's analysis succeded or failed
+		// If it cannot be parsed, return the default explanation text
+		match policy_exprs::parse_expr_to_english(input, message, value, passed) {
+			Ok(explanation) => explanation,
+			Err(e) => {
+				log::error!(
+					"Could not parse policy expression for {} plugin: {}",
+					&self.name,
+					e
+				);
+				self.message.clone()
+			}
+		}
 	}
 }
 

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -358,7 +358,10 @@ fn print_human(report: Report) -> Result<()> {
 				Title::Passed,
 				analysis.statement()
 			);
+
+			// If we can parse a successful expression to English, print a full English explanation. Otherwise print the default explanation text.
 			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
+
 			// Empty line at end to space out analyses.
 			macros::println!();
 		}
@@ -383,12 +386,8 @@ fn print_human(report: Report) -> Result<()> {
 				analysis.statement()
 			);
 
-			// If we can parse failed expression to English, print a full English explanation. Otherwise print the default explanation text.
-			if let Ok(failing_explanation) = analysis.failing_explanation() {
-				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", failing_explanation);
-			} else {
-				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
-			}
+			// If we can parse a failed expression to English, print a full English explanation. Otherwise print the default explanation text.
+			macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", analysis.explanation());
 
 			for concern in failing_analysis.concerns() {
 				macros::println!("{EMPTY:LEFT_COL_WIDTH$} {}", concern);


### PR DESCRIPTION
Resolves #837 We now attempt to parse policy expressions into English-language explanations whether the plugin's analysis succeeded or failed (but not if it errored). If a policy expression cannot be parsed, an error message is logged and the default plugin explanation text is displayed instead.