### PR TITLE
chore: replace VersionQuery with OnceLock and functions

### DIFF
--- a/hipcheck/src/init/mod.rs
+++ b/hipcheck/src/init/mod.rs
@@ -17,6 +17,7 @@ pub fn init() {
 	init_logging();
 	init_libgit2();
 	init_cryptography();
+	init_software_versions();
 }
 
 fn init_shell() {
@@ -46,4 +47,10 @@ fn init_cryptography() {
 	// Install a process-wide default crypto provider.
 	CryptoProvider::install_default(ring::default_provider())
 		.expect("installed process-wide default crypto provider");
+}
+
+fn init_software_versions() {
+	if let Err(e) = crate::version::init_software_versions() {
+		panic!("Error saving off dependent binary versions: {}", e);
+	}
 }

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -369,13 +369,11 @@ impl Display for PathCheckError {
 
 fn check_hipcheck_version() -> StdResult<String, VersionCheckError> {
 	let pkg_name = env!("CARGO_PKG_NAME", "can't find Hipcheck package name");
-
 	let version = env!("CARGO_PKG_VERSION", "can't find Hipcheck package version");
-	let version = version::get_version(version).map_err(|_| VersionCheckError {
+	let version = version::parse_hc_version(version).map_err(|_| VersionCheckError {
 		cmd_name: "hc",
 		kind: VersionCheckErrorKind::CmdNotFound,
 	})?;
-
 	Ok(format!("{} {}", pkg_name, version))
 }
 

--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -15,7 +15,6 @@ use crate::{
 	cli::Format,
 	error::{Context, Error, Result},
 	policy_exprs::{self, std_exec, Expr},
-	version::VersionQuery,
 };
 use chrono::prelude::*;
 use schemars::JsonSchema;
@@ -42,7 +41,7 @@ pub struct Report {
 	pub repo_head: Arc<String>,
 
 	/// The version of Hipcheck used to analyze the repo.
-	pub hipcheck_version: String,
+	pub hipcheck_version: Arc<String>,
 
 	/// When the analysis was performed.
 	pub analyzed_at: Timestamp,
@@ -483,7 +482,7 @@ impl Serialize for Timestamp {
 
 /// Queries for how Hipcheck reports session results
 #[salsa::query_group(ReportParamsStorage)]
-pub trait ReportParams: VersionQuery {
+pub trait ReportParams {
 	/// Returns the time the current Hipcheck session started
 	#[salsa::input]
 	fn started_at(&self) -> DateTime<FixedOffset>;

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -11,7 +11,7 @@ use crate::{
 	score::*,
 	session::Session,
 	source::SourceQuery,
-	version::VersionQuery,
+	version::hc_version,
 };
 use std::{collections::HashSet, default::Default};
 
@@ -167,7 +167,7 @@ impl<'sess> ReportBuilder<'sess> {
 	pub fn build(self) -> Result<Report> {
 		let repo_name = self.session.name();
 		let repo_head = self.session.head();
-		let hipcheck_version = self.session.hc_version().to_string();
+		let hipcheck_version = hc_version();
 		let analyzed_at = Timestamp::from(self.session.started_at());
 		let passing = self.passing;
 		let failing = self.failing;

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -20,13 +20,10 @@ use crate::{
 		resolve::{TargetResolver, TargetResolverConfig},
 		Target, TargetSeed, TargetSeedKind,
 	},
-	util::command::DependentProgram,
-	util::{git::get_git_version, npm::get_npm_version},
-	version::{VersionQuery, VersionQueryStorage},
 };
 use chrono::prelude::*;
 use std::{
-	env, fmt,
+	fmt,
 	path::{Path, PathBuf},
 	rc::Rc,
 	result::Result as StdResult,
@@ -42,7 +39,6 @@ use std::{
 	RiskConfigQueryStorage,
 	ScoringProviderStorage,
 	SourceQueryStorage,
-	VersionQueryStorage,
 	WeightTreeQueryStorage
 )]
 pub struct Session {
@@ -97,15 +93,6 @@ impl Session {
 		 *-----------------------------------------------------------------*/
 
 		Shell::print_prelude(target.to_string());
-
-		/*===================================================================
-		 *  Loading current versions of needed software git, npm, and eslint into salsa.
-		 *-----------------------------------------------------------------*/
-
-		let (git_version, npm_version) = load_software_versions()?;
-
-		session.set_git_version(Rc::new(git_version));
-		session.set_npm_version(Rc::new(npm_version));
 
 		/*===================================================================
 		 *  Loading configuration.
@@ -163,13 +150,6 @@ impl Session {
 		session.set_target(Arc::new(target));
 
 		/*===================================================================
-		 *  Resolving the Hipcheck version.
-		 *-----------------------------------------------------------------*/
-
-		let raw_version = env!("CARGO_PKG_VERSION", "can't find Hipcheck package version");
-		session.set_hc_version(Rc::new(raw_version.to_string()));
-
-		/*===================================================================
 		 *  Remaining input queries.
 		 *-----------------------------------------------------------------*/
 
@@ -222,16 +202,6 @@ fn use_policy(policy_path: PathBuf, session: &mut Session) -> Result<()> {
 	session.set_policy(Rc::new(policy));
 	session.set_policy_path(Some(Rc::new(policy_path)));
 	Ok(())
-}
-
-fn load_software_versions() -> Result<(String, String)> {
-	let git_version = get_git_version()?;
-	DependentProgram::Git.check_version(&git_version)?;
-
-	let npm_version = get_npm_version()?;
-	DependentProgram::Npm.check_version(&npm_version)?;
-
-	Ok((git_version, npm_version))
 }
 
 pub fn load_config_and_data(config_path: PathBuf) -> Result<(PolicyFile, PathBuf)> {


### PR DESCRIPTION
This is the first step in removing unnecessary uses of `salsa` in hipcheck core.

closes #881 