### PR TITLE
chore(docs): update docs to reflect 3.11 changes

### DIFF
--- a/site/content/blog/2025-02-21-hipcheck-3.11.0-release.md
+++ b/site/content/blog/2025-02-21-hipcheck-3.11.0-release.md
@@ -36,7 +36,7 @@ those requirements. In the new plugin-based context, the set of analyses that
 Hipcheck will run depends on the input policy file, which may involve
 third-party analysis plugins with unknown requirements.  Hipcheck's "readiness"
 is now directly dependent on the readiness of the plugins a user will employ in
-a given analysis; we are in turn defining a plugin's "readinesss" as whether it
+a given analysis; we are in turn defining a plugin's "readiness" as whether it
 successfully completes the configuration step. We encourage plugin developers to
 use this step to do all necessary file parsing and environment checking, and not
 to report configuration success unless your criteria are met.

--- a/site/content/docs/guide/plugins/mitre-churn.md
+++ b/site/content/docs/guide/plugins/mitre-churn.md
@@ -13,7 +13,6 @@ in a project's history.
 
 | Parameter           | Type     | Explanation   |
 |:--------------------|:---------|:--------------|
-| `langs-file`        | `String` | Path to a file specifying how to infer languages. |
 | `churn-freq`        | `Float`  | Threshold for a Z-score, above which a commit is considered "high churn" |
 | `commit-percentage` | `Float`  | Threshold for a percentage of "high churn" commits permitted. |
 
@@ -30,9 +29,9 @@ in a project's history.
 ## Default Query: `mitre/churn`
 
 Returns an array of churn Z-scores for all commits identified as modifying
-source files. This is not _all_ commits, as the analysis uses heuristics based
-on the provided `langs-file` to identify which files are likely source files,
-and excludes commits which do not modify any likely source files.
+source files. This is not _all_ commits, as the analysis uses the
+`mitre/linguist` plugin to identify which files are likely source files, and
+excludes commits which do not modify any likely source files.
 
 ## Explanation
 

--- a/site/content/docs/guide/plugins/mitre-entropy.md
+++ b/site/content/docs/guide/plugins/mitre-entropy.md
@@ -13,7 +13,6 @@ history.
 
 | Parameter           | Type     | Explanation   |
 |:--------------------|:---------|:--------------|
-| `langs-file`        | `String` | Path to a file specifying how to infer languages. |
 | `entropy-threshold` | `Float`  | Threshold for a Z-score, above which a commit is considered "high entropy" |
 | `commit-percentage` | `Float`  | Threshold for a percentage of "high entropy" commits permitted. |
 
@@ -31,7 +30,8 @@ history.
 ## Default Query: `mitre/entropy`
 
 Returns an array of commit entropies for commits identified as impacting
-likely source files.
+likely source files. Uses the `mitre/linguist` plugin to determine the likely
+source files of the repository.
 
 ## Explanation
 


### PR DESCRIPTION
Not to be merged until just prior to 3.11 release, contains changes to docs that become live with the new batch of plugins and new Hipcheck crate / binary releases.