### PR TITLE
feat: Improve logging of policy file error messages

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -19,6 +19,7 @@ use clap::{Parser as _, ValueEnum};
 use hipcheck_macros as hc;
 use pathbuf::pathbuf;
 use std::{
+	fmt::{self, Display, Formatter},
 	path::{Path, PathBuf},
 	str::FromStr,
 };
@@ -189,6 +190,23 @@ pub enum ConfigMode {
 	ForcePolicy { policy: PathBuf },
 	/// Only attempt to load from config.
 	ForceConfig { config: PathBuf },
+}
+
+impl Display for ConfigMode {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		use ConfigMode::*;
+		match &self {
+			PreferPolicy { policy, config } => {
+				write!(f, "Default to Policy KDL file at path:\n{:?}\nFallback Legacy Config TOML directory at path:\n{:?}", policy, config)
+			}
+			ForcePolicy { policy } => {
+				write!(f, "Policy KDL file at path:\n{:?}", policy)
+			}
+			ForceConfig { config } => {
+				write!(f, "Legacy Config TOML directory at path:\n{:?}", config)
+			}
+		}
+	}
 }
 
 impl CliConfig {

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -137,6 +137,8 @@ fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
 		}
 	};
 
+	log::info!("Using configuration source: {}", config_mode);
+
 	let report = run(
 		target,
 		config_mode,

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -103,10 +103,7 @@ impl Session {
 			PreferPolicy { policy, config } => {
 				let res = use_policy(policy, &mut session);
 				if let Some(err) = res.err() {
-					Shell::print_error(&err, Format::Human);
-					Shell::println(
-						"Warning: failed to load policy; defaulting to config TOML instead",
-					);
+					log::error!("Failed to load default policy KDL file; trying legacy config TOML directory instead. Error: {:#?}", err);
 
 					use_config(config, &mut session)?;
 				}
@@ -234,7 +231,7 @@ pub fn load_policy_and_data(policy_path: PathBuf) -> Result<(PolicyFile, PathBuf
 
 	// Load the policy file.
 	let policy = PolicyFile::load_from(&policy_path)
-		.context("Failed to load policy. Please make sure the policy file is in the provided location and is formatted correctly.")?;
+		.with_context(|| format!("Failed to load policy file at path {:?}. Please make sure the policy file is in the provided location and is formatted correctly.", policy_path))?;
 
 	phase.finish_successful();
 


### PR DESCRIPTION
- Add a `Display` impl for `ConfigMode`.
- Log the inferred `ConfigMode` at INFO level at startup of `check` command.
- Use logging instead of `Shell` methods when falling back to Config TOML.
- Include path to policy file in context when reporting errors.