### PR TITLE
feat: Improve English phrasing of count and percent policy expressions.

### DIFF
--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -290,7 +290,7 @@ impl Plugin for ChurnPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"the churn frequency of each commit in the repository".to_owned(),
+			"churn frequencies of each commit in the repository".to_owned(),
 		))
 	}
 

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -10,12 +10,7 @@ use clap::Parser;
 use hipcheck_sdk::{prelude::*, types::Target};
 use serde::Deserialize;
 
-use std::{
-	collections::HashSet,
-	path::PathBuf,
-	result::Result as StdResult,
-	sync::OnceLock,
-};
+use std::{collections::HashSet, path::PathBuf, result::Result as StdResult, sync::OnceLock};
 
 #[derive(Deserialize)]
 struct RawConfig {
@@ -114,11 +109,11 @@ async fn commit_entropies(
 
 	// Calculate the grapheme frequencies for each commit which contains code.
 	commit_diffs.retain(|cd| {
-			cd.diff
-				.file_diffs
-				.iter()
-				.any(|x| source_files.contains(&x.file_name))
-		});
+		cd.diff
+			.file_diffs
+			.iter()
+			.any(|x| source_files.contains(&x.file_name))
+	});
 	let commit_freqs = commit_diffs
 		.iter()
 		.map(|x| grapheme_freqs(&source_files, x))
@@ -203,7 +198,7 @@ impl Plugin for EntropyPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"the entropy calculation of each commit in the repository".to_owned(),
+			"entropy calculations of each commit in the repository".to_owned(),
 		))
 	}
 


### PR DESCRIPTION
Finishing resolving #838 Adds simpler English phrases for the commonly occurring "count" and "percent" patterns. Changes default explanations for `churn` and `entropy` to better fit the new phrasing.