### PR TITLE
feat: Improve error message context from plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "log",
+ "miette 7.4.0",
  "pathbuf",
  "schemars",
  "serde",
@@ -304,6 +305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +340,7 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "log",
+ "miette 7.4.0",
  "pathbuf",
  "schemars",
  "serde",
@@ -2159,6 +2170,7 @@ dependencies = [
  "log",
  "logos",
  "maplit",
+ "miette 7.4.0",
  "nom",
  "num-traits",
  "num_enum",
@@ -2669,6 +2681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2854,7 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "log",
+ "miette 7.4.0",
  "pathbuf",
  "serde",
  "serde_json",
@@ -3006,8 +3025,16 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
 dependencies = [
+ "backtrace",
+ "backtrace-ext",
  "cfg-if",
  "miette-derive 7.4.0",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.1.11",
 ]
@@ -3307,6 +3334,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "packageurl"
@@ -4309,6 +4342,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,6 +4466,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "test-log"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4431,6 +4495,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -4830,6 +4904,7 @@ dependencies = [
  "hipcheck-sdk",
  "log",
  "maplit",
+ "miette 7.4.0",
  "pathbuf",
  "serde",
  "serde_json",
@@ -4858,6 +4933,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -77,6 +77,7 @@ jiff = "0.1.16"
 log = "0.4.22"
 logos = "0.15.0"
 maplit = "1.0.2"
+miette = { version = "7.4.0", features = ["fancy"] }
 nom = "7.1.3"
 num-traits = "0.2.19"
 num_enum = "0.7.3"

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -128,17 +128,16 @@ impl ConfigError {
 impl std::fmt::Display for ConfigError {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> StdResult<(), std::fmt::Error> {
 		use ConfigErrorType::*;
-		let msg = match &self.message {
-			Some(s) => format!(": {s}"),
-			None => "".to_owned(),
-		};
 		let err = match self.error {
-			Unknown => "unknown configuration error occurred",
+			Unknown => "configuration error",
 			MissingRequiredConfig => "configuration is missing required fields",
 			UnrecognizedConfig => "configuration contains unrecognized fields",
 			InvalidConfigValue => "configuration contains invalid values",
 		};
-		write!(f, "{}{}", msg, err)
+		match &self.message {
+			Some(msg) => write!(f, "{}: {}", err, msg),
+			None => write!(f, "{}", err),
+		}
 	}
 }
 

--- a/hipcheck/src/policy/mod.rs
+++ b/hipcheck/src/policy/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use hipcheck_kdl::extract_data;
 use hipcheck_kdl::kdl::KdlDocument;
+use miette::Report;
 use serde_json::Value;
 use std::{collections::HashMap, path::Path, str::FromStr};
 
@@ -32,7 +33,8 @@ impl FromStr for PolicyFile {
 
 	fn from_str(s: &str) -> Result<Self> {
 		let document =
-			KdlDocument::from_str(s).map_err(|e| hc_error!("Error parsing policy file: {}", e))?;
+			// Print miette::Report with Debug for full help text
+			KdlDocument::from_str(s).map_err(|e| hc_error!("Policy file doesn't parse as valid KDL:\n{:?}", Report::from(e)))?;
 		let nodes = document.nodes();
 
 		let plugins: PolicyPluginList =

--- a/hipcheck/src/util/fs.rs
+++ b/hipcheck/src/util/fs.rs
@@ -52,10 +52,7 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
 pub fn exists<P: AsRef<Path>>(path: P) -> Result<()> {
 	fn inner(path: &Path) -> Result<()> {
 		if path.exists().not() {
-			Err(hc_error!(
-				"'{}' not found at current directory",
-				path.display()
-			))
+			Err(hc_error!("'{}' not found", path.display()))
 		} else {
 			Ok(())
 		}

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -14,6 +14,7 @@ hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.22"
+miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 schemars = { version = "0.8.21", features = ["url"] }
 serde = { version = "1.0.217", features = ["derive", "rc"] }

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -50,17 +50,15 @@ impl TryFrom<RawConfig> for Config {
 		if let Some(ofv) = value.orgs_file_path {
 			// Get the Orgs file path and confirm it exists
 			let orgs_file = PathBuf::from(&ofv);
-			file::exists(&orgs_file).map_err(|_e| ConfigError::InvalidConfigValue {
-				field_name: "orgs-file".to_owned(),
-				value: ofv.clone(),
-				reason: "could not find an orgs file with that name".to_owned(),
+			file::exists(&orgs_file).map_err(|_e| ConfigError::Unspecified {
+				// Print error with Debug for full context
+				message: format!("could not find an orgs file at path {:?}", ofv),
 			})?;
 			// Parse the Orgs file and construct an OrgSpec.
 			let orgs_spec =
-				OrgSpec::load_from(&orgs_file).map_err(|e| ConfigError::InvalidConfigValue {
-					field_name: "orgs-file".to_owned(),
-					value: ofv.clone(),
-					reason: format!("Failed to load org spec: {}", e),
+				OrgSpec::load_from(&orgs_file).map_err(|e| ConfigError::Unspecified {
+					// Print error with Debug for full context
+					message: format!("{:?}", e),
 				})?;
 			Ok(Config {
 				orgs_spec,

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -14,6 +14,7 @@ hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.22"
+miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 schemars = "0.8.21"
 serde = "1.0.217"

--- a/plugins/binary/src/error/mod.rs
+++ b/plugins/binary/src/error/mod.rs
@@ -77,6 +77,10 @@ impl Error {
 	pub fn chain(&self) -> Chain {
 		Chain::new(self)
 	}
+
+	pub fn to_string_pretty_multiline(&self) -> String {
+		format!("{:#?}", self)
+	}
 }
 
 /// Allows use of `?` operator on query system entry.

--- a/plugins/binary/src/main.rs
+++ b/plugins/binary/src/main.rs
@@ -95,7 +95,7 @@ impl Plugin for BinaryPlugin {
 		// Use the langs file to create a SourceFileDetector and init the salsa db
 		let bfd =
 			BinaryFileDetector::load(conf.binary_file).map_err(|e| ConfigError::Unspecified {
-				message: e.to_string(),
+				message: e.to_string_pretty_multiline(),
 			})?;
 
 		// Make the salsa db globally accessible

--- a/plugins/churn/src/error/mod.rs
+++ b/plugins/churn/src/error/mod.rs
@@ -77,6 +77,10 @@ impl Error {
 	pub fn chain(&self) -> Chain {
 		Chain::new(self)
 	}
+
+	pub fn to_string_pretty_multiline(&self) -> String {
+		format!("{:#?}", self)
+	}
 }
 
 /// Allows use of `?` operator on query system entry.

--- a/plugins/entropy/src/error/mod.rs
+++ b/plugins/entropy/src/error/mod.rs
@@ -77,6 +77,10 @@ impl Error {
 	pub fn chain(&self) -> Chain {
 		Chain::new(self)
 	}
+
+	pub fn to_string_pretty_multiline(&self) -> String {
+		format!("{:#?}", self)
+	}
 }
 
 /// Allows use of `?` operator on query system entry.

--- a/plugins/github/src/main.rs
+++ b/plugins/github/src/main.rs
@@ -33,16 +33,16 @@ impl TryFrom<RawConfig> for Config {
 	fn try_from(value: RawConfig) -> StdResult<Config, ConfigError> {
 		if let Some(atv) = value.api_token_var {
 			let api_token =
-				std::env::var(atv.as_str()).map_err(|_e| ConfigError::InvalidConfigValue {
+				std::env::var(&atv).map_err(|_e| ConfigError::InvalidConfigValue {
 					field_name: "api-token-var".to_owned(),
-					value: atv,
-					reason: "could not find an env var with that name".to_owned(),
+					value: atv.clone(),
+					reason: format!("Could not find an environment variable with the name \"{}\". This environment variable must contain a GitHub API token.", atv),
 				})?;
 			Ok(Config { api_token })
 		} else {
 			Err(ConfigError::MissingRequiredConfig {
 				field_name: "api-token-var".to_owned(),
-				field_type: "name of env var containing GitHub API token".to_owned(),
+				field_type: "name of environment variable containing GitHub API token".to_owned(),
 				possible_values: vec![],
 			})
 		}

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -14,6 +14,7 @@ hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.22"
+miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"

--- a/plugins/linguist/src/error/mod.rs
+++ b/plugins/linguist/src/error/mod.rs
@@ -77,6 +77,10 @@ impl Error {
 	pub fn chain(&self) -> Chain {
 		Chain::new(self)
 	}
+
+	pub fn to_string_pretty_multiline(&self) -> String {
+		format!("{:#?}", self)
+	}
 }
 
 /// Allows use of `?` operator on query system entry.

--- a/plugins/linguist/src/main.rs
+++ b/plugins/linguist/src/main.rs
@@ -43,7 +43,7 @@ impl Plugin for LinguistPlugin {
 			})?;
 		let sfd = match conf.langs_file {
 			Some(p) => SourceFileDetector::load(p).map_err(|e| ConfigError::Unspecified {
-				message: e.to_string(),
+				message: e.to_string_pretty_multiline(),
 			})?,
 			None => {
 				return Err(ConfigError::MissingRequiredConfig {

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -15,6 +15,7 @@ hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
 ] }
 log = "0.4.22"
 maplit = "1.0.2"
+miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 serde_json = "1.0.134"

--- a/plugins/typo/src/languages.rs
+++ b/plugins/typo/src/languages.rs
@@ -35,7 +35,8 @@ impl ParseKdlNode for TypoFile {
 impl TypoFile {
 	pub fn load_from(typo_path: &Path) -> Result<TypoFile> {
 		file::exists(typo_path).context("typo file does not exist")?;
-		let typo_file = file::read_kdl(typo_path).context("failed to open typo file")?;
+		let typo_file = file::read_kdl(typo_path)
+			.with_context(|| format!("failed to read typo file at path {:?}", typo_path))?;
 
 		Ok(typo_file)
 	}

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -46,11 +46,11 @@ impl TryFrom<RawConfig> for Config {
 		// Parse typo TOML file
 		let typo_path = PathBuf::from(raw_typo_path);
 		let typo_file = TypoFile::load_from(&typo_path).map_err(|e| {
-			log::error!("failed to load typo file: {}", e);
-			ConfigError::InvalidConfigValue {
-				field_name: "typo-file".to_owned(),
-				value: "string".to_owned(),
-				reason: format!("failed to load typo file: {}", e),
+			// Print error with Debug for full context
+			log::error!("{:?}", e);
+			ConfigError::Unspecified {
+				// Print error with Debug for full context
+				message: format!("{:?}", e),
 			}
 		})?;
 

--- a/plugins/typo/src/util/fs.rs
+++ b/plugins/typo/src/util/fs.rs
@@ -3,6 +3,7 @@
 use anyhow::{anyhow, Context as _, Result};
 use hipcheck_kdl::kdl::KdlDocument;
 use hipcheck_kdl::{extract_data, ParseKdlNode};
+use miette::Report;
 use std::{fs, path::Path, str::FromStr};
 
 /// Read a file to a string.
@@ -19,7 +20,9 @@ pub fn read_string<P: AsRef<Path>>(path: P) -> Result<String> {
 pub fn read_kdl<P: AsRef<Path>, T: ParseKdlNode>(path: P) -> Result<T> {
 	let path = path.as_ref();
 	let contents = read_string(path)?;
-	let document = KdlDocument::from_str(&contents).map_err(|e| anyhow!(e))?;
+	// Print miette::Report with Debug for full help text
+	let document = KdlDocument::from_str(&contents)
+		.map_err(|e| anyhow!("File doesn't parse as valid KDL:\n{:?}", Report::from(e)))?;
 	let nodes = document.nodes();
 	extract_data(nodes).ok_or(anyhow!("Could not parse typo KDL 'format'"))
 }
@@ -28,10 +31,7 @@ pub fn read_kdl<P: AsRef<Path>, T: ParseKdlNode>(path: P) -> Result<T> {
 pub fn exists<P: AsRef<Path>>(path: P) -> Result<()> {
 	fn inner(path: &Path) -> Result<()> {
 		if !path.exists() {
-			Err(anyhow!(
-				"'{}' not found at current directory",
-				path.display()
-			))
+			Err(anyhow!("'{}' not found", path.display()))
 		} else {
 			Ok(())
 		}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -190,7 +190,7 @@ impl From<ConfigError> for SetConfigurationResponse {
 			},
 			ConfigError::Unspecified { message } => SetConfigurationResponse {
 				status: ConfigurationStatus::Unspecified as i32,
-				message: format!("unknown error; {message}"),
+				message,
 			},
 		}
 	}


### PR DESCRIPTION
Relates to #880, in that this improves the error message, but doesn't fix the problem that plugin errors aren't attributed to the failing plugin.

- Print plugin errors with full context, like which file could not be opened.
- Clarify wording of some error messages.
- Add `miette` dependency to print helpful KDL parsing errors.