### PR TITLE
feat: Track plugin name and version when reporting startup errors

### DIFF
--- a/hipcheck/src/engine.rs
+++ b/hipcheck/src/engine.rs
@@ -269,6 +269,7 @@ pub fn start_plugins(
 
 		let plugin = Plugin {
 			name: plugin_id.to_policy_file_plugin_identifier(),
+			version: plugin_id.version().clone(),
 			working_dir,
 			entrypoint,
 		};

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -28,7 +28,7 @@ use crate::{
 	config::{normalized_unresolved_analysis_tree_from_policy, Config},
 	error::{Context as _, Error, Result},
 	exec::ExecConfig,
-	plugin::{try_set_arch, Plugin, PluginWithConfig},
+	plugin::{try_set_arch, Plugin, PluginVersion, PluginWithConfig},
 	policy::{config_to_policy, PolicyFile},
 	report::report_builder::{build_report, Report},
 	score::score_results,
@@ -443,17 +443,20 @@ fn cmd_plugin(args: PluginArgs, config: &CliConfig) -> ExitCode {
 	use std::sync::Arc;
 	use tokio::task::JoinSet;
 
+	let version = PluginVersion("0.0.0".to_string());
 	let working_dir = PathBuf::from("./target/debug");
 
 	let entrypoint1 = pathbuf!["dummy_rand_data"];
 	let entrypoint2 = pathbuf!["dummy_sha256"];
 	let plugin1 = Plugin {
 		name: "dummy/rand_data".to_owned(),
+		version: version.clone(),
 		working_dir: working_dir.clone(),
 		entrypoint: entrypoint1.display().to_string(),
 	};
 	let plugin2 = Plugin {
 		name: "dummy/sha256".to_owned(),
+		version: version.clone(),
 		working_dir: working_dir.clone(),
 		entrypoint: entrypoint2.display().to_string(),
 	};

--- a/hipcheck/src/plugin/manager.rs
+++ b/hipcheck/src/plugin/manager.rs
@@ -66,6 +66,9 @@ impl PluginExecutor {
 	}
 
 	pub async fn start_plugins(&self, plugins: Vec<Plugin>) -> Result<Vec<PluginContext>> {
+		let num_plugins = plugins.len();
+		log::info!("Starting {} plugins", num_plugins);
+
 		join_all(plugins.into_iter().map(|p| self.start_plugin(p)))
 			.await
 			.into_iter()

--- a/hipcheck/src/plugin/retrieval.rs
+++ b/hipcheck/src/plugin/retrieval.rs
@@ -35,6 +35,9 @@ pub fn retrieve_plugins(
 
 	let mut required_plugins = HashSet::new();
 
+	let num_plugins = policy_plugins.len();
+	log::info!("Retrieving {} plugins", num_plugins);
+
 	for policy_plugin in policy_plugins.iter() {
 		retrieve_plugin(
 			policy_plugin.get_plugin_id(),


### PR DESCRIPTION
Resolves #880

Add plugin version to the `Plugin` struct so that it's available when starting plugins.

Also add logging when Hipcheck retrieves and starts plugins.