### PR TITLE
fix: forward plugin logging output to Hipcheck core stderr/stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "finl_unicode",
  "futures",
  "hipcheck-sdk",
+ "log",
  "ordered-float",
  "pathbuf",
  "rayon",
@@ -1192,6 +1193,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
+ "log",
  "serde",
  "serde_json",
  "tokio",
@@ -2255,6 +2257,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "console",
+ "env_logger",
  "futures",
  "hipcheck-common",
  "hipcheck-sdk-macros",

--- a/hipcheck/src/plugin/manager.rs
+++ b/hipcheck/src/plugin/manager.rs
@@ -8,7 +8,7 @@ use crate::{
 use futures::future::join_all;
 use hipcheck_common::proto::plugin_service_client::PluginServiceClient;
 use rand::Rng;
-use std::{ffi::OsString, ops::Range, path::Path, process::Command};
+use std::{ffi::OsString, ops::Range, path::Path, process::{Command, Stdio}};
 use tokio::time::{sleep_until, Duration, Instant};
 
 #[derive(Clone, Debug)]
@@ -151,9 +151,9 @@ impl PluginExecutor {
 			let Ok(mut proc) = Command::new(&canon_bin_path)
 				.env("PATH", &cmd_path)
 				.args(spawn_args)
-				// @Temporary - directly forward stdout/stderr from plugin to shell
-				.stdout(std::io::stdout())
-				.stderr(std::io::stderr())
+				// directly forward stdout/stderr from plugin to shell with logging levels
+				.stdout(Stdio::inherit())
+				.stderr(Stdio::inherit())
 				.spawn()
 			else {
 				spawn_attempts += 1;

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3.31"
 hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
+log = "0.4.25"
 ordered-float = { version = "4.5.0", features = ["serde"] }
 pathbuf = "1.0.0"
 rayon = "1.10.0"

--- a/plugins/fuzz/Cargo.toml
+++ b/plugins/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
+log = "0.4.25"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
 tokio = { version = "1.43.0", features = ["rt"] }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -27,11 +27,14 @@ url = { version = "2.5.4", features = ["serde"] }
 log = "0.4.25"
 hipcheck-common = { version = "0.2.0", path = "../../hipcheck-common" }
 console = "0.15.10"
+env_logger = { version = "0.11.6", optional = true }
 
 [features]
+default = ["init_logger"]
 macros = ["dep:hipcheck-sdk-macros"]
 mock_engine = []
 print-timings = []
+init_logger = ["env_logger"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -131,7 +131,7 @@ impl TryInto<QueryTarget> for &str {
 	}
 }
 
-/// Descrbies the signature of a particular `NamedQuery`.
+/// Describes the signature of a particular `NamedQuery`.
 ///
 /// Instances of this type are usually created by the default implementation of `Plugin::schemas()`
 /// and would not need to be created by hand unless you are doing something very unorthodox.
@@ -231,4 +231,20 @@ pub trait Plugin: Send + Sync + 'static {
 			output_schema: query.inner.output_schema(),
 		})
 	}
+}
+
+/// Initializes `env_logger` for plugin logging via the `log` crate facade.
+///
+/// Initializes an `env_longer` which writes log messages produced via the standard `log`crate macros to stdout/stderr. 
+/// These plugin logs are then piped to Hipcheck core's stdout/stderr log output during execution. 
+/// 
+/// `env_logger` adheres to the standard Hipcheck logging standards, using the `HC_LOG` and `HC_LOG_STYLE`
+/// environment variables. 
+/// 
+/// init_logger() is enabled as a default feature, but could be disabled and replaced by setting `default-features = false`
+/// in the `dependencies` section of a plugin's `Cargo.toml`.
+#[cfg(feature = "init_logger")]
+pub fn init_logger() {
+	let env = env_logger::Env::new().filter("HC_LOG").write_style("HC_LOG_STYLE");
+	env_logger::Builder::from_env(env).init();
 }

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-	engine::HcSessionSocket,
-	error::{Error, Result},
-	Plugin, QuerySchema,
+	engine::HcSessionSocket, error::{Error, Result}, Plugin, QuerySchema
 };
 use hipcheck_common::proto::{
 	plugin_service_server::{PluginService, PluginServiceServer},
@@ -32,6 +30,10 @@ pub struct PluginServer<P> {
 impl<P: Plugin> PluginServer<P> {
 	/// Create a new plugin server for the provided plugin.
 	pub fn register(plugin: P) -> PluginServer<P> {
+		#[cfg(feature = "init_logger")]
+		{
+			crate::init_logger();
+		}
 		PluginServer {
 			plugin: Arc::new(plugin),
 		}

--- a/site/content/docs/guide/debugging/logging.md
+++ b/site/content/docs/guide/debugging/logging.md
@@ -87,5 +87,4 @@ with the log messages.
 
 ## Where do Logs Write?
 
-Log messages output to `stderr`. They can be redirected using standard shell redirection
-techniques.
+Log messages of Hipcheck and its plugins output to Hipcheck core's `stderr`. They can be redirected using standard shell redirection techniques.

--- a/site/content/docs/guide/making-plugins/rust-sdk.md
+++ b/site/content/docs/guide/making-plugins/rust-sdk.md
@@ -245,3 +245,11 @@ on the returned `PluginServer` instance. This function will not return until
 the gRPC channel with Hipcheck core is closed.
 
 And that's all there is to it! Happy plugin development!
+
+### Note on Plugin Logging
+
+Plugins use the SDK's [init_logger](https://docs.rs/hipcheck-sdk/latest/hipcheck_sdk/fn.init_logger.html) default feature to set up an `env_logger`, which logs messages using Rust’s `log` crate macros like `info!()` and `error!()`. It also uses Hipcheck's logging environmental variables.
+
+To enable logging in your plugin, call `hipcheck_sdk::init_logger();` in your application and all produced log messages will be shown in the `stderr` of Hipcheck core. 
+
+If you prefer a different logger, disable the default feature by setting `default-features = false` in the plugin's `Cargo.toml` dependencies section.


### PR DESCRIPTION
Resolves #381.
This PR forwards the logging output of plugins to the stderr/stdout output of Hipcheck core. 
It does this through:
- Creating a feature in hipcheck_sdk to initialize an env_logger
- Calling the init_logger() feature from each plugin
- When plugins are launched as a child process, having them inherit the Stderr/Stdout of the parent Hipcheck core process.

It also adds docs in the sdk on how to use the init_logger() feature.