### PR TITLE
chore: add policy location info to standard check output

### DIFF
--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -222,6 +222,16 @@ impl Shell {
 		}
 	}
 
+    /// Print "Config {msg}" with the proper color/styling.
+    pub fn print_config(source: impl AsRef<str>) {
+		match Shell::get_verbosity() {
+			Verbosity::Normal => {
+				macros::println!("{:>LEFT_COL_WIDTH$} {}", Title::Config, source.as_ref());
+			}
+			Verbosity::Quiet | Verbosity::Silent => {}
+        }
+    }
+
 	/// Print a hipcheck [Error]. Human readable errors will go to the standard error, JSON (regular or full) will go to the standard output.
 	pub fn print_error(err: &Error, format: Format) {
 		match format {
@@ -452,6 +462,8 @@ enum Title {
 	Analyzing,
 	/// "Analyzed"
 	Analyzed,
+	/// "Config"
+	Config,
 	/// The name of the section.
 	Section(&'static str),
 	/// An analysis passed.
@@ -479,6 +491,7 @@ impl Title {
 		match self {
 			Analyzing => "Analyzing",
 			Analyzed => "Analyzed",
+			Config => "Config",
 			Section(s) => s,
 			Passed => "+",
 			Failed => "-",
@@ -497,7 +510,7 @@ impl Title {
 
 		let color = match self {
 			Analyzed | Section(..) => Some(Blue),
-			Analyzing | Done => Some(Cyan),
+			Analyzing | Done | Config => Some(Cyan),
 			InProgress => Some(Magenta),
 			Passed | Pass => Some(Green),
 			Failed | Investigate => Some(Red),


### PR DESCRIPTION
Added a `Config` title to the Hipcheck output that indicates in each `check` run where the policy/config comes from to further help users track where their policy comes from. `HC_CONFIG` may be set by a previous user or forgotten, but it still treated as `FromUser` in provenance determination, so this kind of a message will inform the user of where the config is being pulled from.

Also standardized use of lowercase strings to `SpinnerPhase::start()`