### PR TITLE
feat: Enable merge queues for CI actions.

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -3,6 +3,8 @@ name: Commit Checks
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -33,6 +33,8 @@ on:
       - "hipcheck-common/**"
       - "hipcheck-macros/**"
       - "hipcheck-sdk-macros/**"
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -5,6 +5,8 @@ name: Website Deploy
 on:
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 # Sets permissions of the `GITHUB_TOKEN` to allow deployment to GitHub Pages

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - "site/**"
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
Make all current PR-enabled CI actions also run within merge groups. This is part of introducing merge queues to the Hipcheck CI process, which should help ensure we avoid breakage where changes pass on a branch in CI, but then fail post-merge because of how the change interacts with changes on `main` since the feature branch for the PR diverged.