### PR TITLE
feat: migrated to latest salsa v3 code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "append-only-vec"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7992085ec035cfe96992dd31bfd495a2ebd31969bb95f624471cb6c0b349e571"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,7 +797,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
  "rayon",
 ]
 
@@ -1510,7 +1525,7 @@ dependencies = [
  "gix-utils",
  "libc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prodash",
  "sha1_smol",
  "thiserror 2.0.11",
@@ -1579,7 +1594,7 @@ checksum = "189130bc372accd02e0520dc5ab1cef318dcc2bc829b76ab8d84bbe90ac212d1"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.5",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1671,7 +1686,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
- "parking_lot 0.12.3",
+ "parking_lot",
  "tempfile",
  "thiserror 2.0.11",
 ]
@@ -1894,7 +1909,7 @@ dependencies = [
  "gix-fs",
  "libc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "tempfile",
 ]
 
@@ -2101,12 +2116,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashlink"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "unicode-segmentation",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2669,15 +2684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3269,12 +3275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "oorandom"
-version = "11.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,37 +3364,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3573,7 +3548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a266d8d6020c61a437be704c5e618037588e1985c7dbb7bf8d265db84cffe325"
 dependencies = [
  "log",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3703,15 +3678,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3831,9 +3797,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3915,31 +3881,40 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "salsa"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b84d9f96071f3f3be0dc818eae3327625d8ebc95b58da37d6850724f31d3403"
+version = "0.18.0"
+source = "git+https://github.com/mitre/salsa.git?tag=hipcheck-v3.11.0#ea1b2bd9034081b617e86f9994bc362b69149391"
 dependencies = [
- "crossbeam-utils",
- "indexmap 1.9.3",
- "lock_api",
- "log",
- "oorandom",
- "parking_lot 0.11.2",
+ "append-only-vec",
+ "arc-swap",
+ "crossbeam-queue",
+ "dashmap",
+ "hashbrown 0.14.5",
+ "hashlink",
+ "indexmap 2.7.0",
+ "parking_lot",
+ "rayon",
  "rustc-hash",
+ "salsa-macro-rules",
  "salsa-macros",
  "smallvec",
+ "tracing",
 ]
 
 [[package]]
+name = "salsa-macro-rules"
+version = "0.1.0"
+source = "git+https://github.com/mitre/salsa.git?tag=hipcheck-v3.11.0#ea1b2bd9034081b617e86f9994bc362b69149391"
+
+[[package]]
 name = "salsa-macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3904a4ba0a9d0211816177fd34b04c7095443f8cdacd11175064fe541c8fe2"
+version = "0.18.0"
+source = "git+https://github.com/mitre/salsa.git?tag=hipcheck-v3.11.0#ea1b2bd9034081b617e86f9994bc362b69149391"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
+ "synstructure",
 ]
 
 [[package]]

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -101,7 +101,7 @@ rustls = { version = "0.23.10", default-features = false, features = [
     "ring",
 ] }
 rustls-native-certs = "0.8.1"
-salsa = "0.16.1"
+salsa = { git = "https://github.com/mitre/salsa.git", tag = "hipcheck-v3.11.0"}
 schemars = { version = "0.8.21", default-features = false, features = [
     "derive",
     "preserve_order",

--- a/hipcheck/src/engine/salsa_cache.rs
+++ b/hipcheck/src/engine/salsa_cache.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	engine::{HcEngine, RUNTIME},
+	hc_error,
+	plugin::{get_plugin_key, PluginResponse, QueryResult},
+	Result,
+};
+
+trait CloneFromSalsaDb {
+	/// the type being wrapped with a newtype for use with salsa
+	type Inner;
+
+	/// extract the value held within a `#[salsa::input]` newtype wrapper
+	fn clone_from_salsa_db(&self, engine: &dyn HcEngine) -> Self::Inner;
+}
+
+/// Salsa wants newtype wrappers with `#[salsa::input]` added to any arguments passed
+/// to `#[salsa::tracked]` functions.
+///
+/// This macro generates the required code needed for any argument passed to a
+/// `#[salsa::tracked]` function.
+///
+/// NOTE: `#[salsa::input]` creates a `::new(inner: $newtype) -> Self` function already so there is
+/// no need to generate one here
+macro_rules! salsa_query_newtype {
+	($struct_name:ident, $newtype:ty) => {
+		#[salsa::input]
+		pub struct $struct_name {
+			inner: $newtype,
+		}
+
+		impl CloneFromSalsaDb for $struct_name {
+			type Inner = $newtype;
+
+			fn clone_from_salsa_db(&self, engine: &dyn HcEngine) -> Self::Inner {
+				self.inner(engine)
+			}
+		}
+	};
+}
+
+salsa_query_newtype!(SalsaPublisher, String);
+salsa_query_newtype!(SalsaPlugin, String);
+salsa_query_newtype!(SalsaQuery, String);
+salsa_query_newtype!(SalsaKey, serde_json::Value);
+
+// Salsa doesn't natively support async functions, so our recursive `query()` function that
+// interacts with plugins (which use async) has to get a handle to the underlying runtime,
+// spawn and block on a task to query the plugin, then choose whether to recurse or return.
+
+#[salsa::tracked]
+/// query the plugin system and utilize salsa caching whenever possible
+pub fn query_with_salsa(
+	engine: &dyn HcEngine,
+	publisher: SalsaPublisher,
+	plugin: SalsaPlugin,
+	query: SalsaQuery,
+	key: SalsaKey,
+) -> Result<QueryResult> {
+	let hash_key = get_plugin_key(
+		publisher.clone_from_salsa_db(engine).as_str(),
+		plugin.clone_from_salsa_db(engine).as_str(),
+	);
+
+	#[cfg(feature = "print-timings")]
+	let _0 = crate::benchmarking::print_scope_time!(format!("{}/{}", &hash_key, &query_value));
+
+	let runtime = RUNTIME.handle();
+	let core = engine.core();
+
+	// Find the plugin
+	let Some(p_handle) = core.plugins.get(&hash_key) else {
+		return Err(hc_error!("No such plugin {}", hash_key));
+	};
+	// Initiate the query. If remote closed or we got our response immediately,
+	// return
+	let mut ar = match runtime.block_on(p_handle.query(
+		query.clone_from_salsa_db(engine),
+		key.clone_from_salsa_db(engine),
+	))? {
+		PluginResponse::RemoteClosed => {
+			return Err(hc_error!("Plugin channel closed unexpected"));
+		}
+		PluginResponse::Completed(v) => return Ok(v),
+		PluginResponse::AwaitingResult(a) => a,
+	};
+	// Otherwise, the plugin needs more data to continue. Recursively query
+	// (with salsa memo-ization) to get the needed data, and resume our
+	// current query by providing the plugin the answer.
+	loop {
+		log::trace!("Query needs more info, recursing...");
+		let mut answers = vec![];
+
+		// per RFD 0009, each key will be used to query `salsa` independently
+		for key in ar.key.clone() {
+			// since one key is used to query `salsa`, there will only be one value returned and
+			// the `pop().unwrap() is safe`
+			let value = engine
+				.query(
+					ar.publisher.clone(),
+					ar.plugin.clone(),
+					ar.query.clone(),
+					key,
+				)?
+				.value
+				.pop()
+				.unwrap();
+			answers.push(value);
+		}
+		log::trace!("Got answer, resuming");
+		ar = match runtime.block_on(p_handle.resume_query(ar, answers))? {
+			PluginResponse::RemoteClosed => {
+				return Err(hc_error!("Plugin channel closed unexpected"));
+			}
+			PluginResponse::Completed(v) => return Ok(v),
+			PluginResponse::AwaitingResult(a) => a,
+		};
+	}
+}

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -26,6 +26,7 @@ use crate::{
 	cache::repo::HcRepoCache,
 	cli::Format,
 	config::{normalized_unresolved_analysis_tree_from_policy, Config},
+	engine::HcEngine,
 	error::{Context as _, Error, Result},
 	exec::ExecConfig,
 	plugin::{try_set_arch, Plugin, PluginVersion, PluginWithConfig},
@@ -456,7 +457,7 @@ fn check_plugins(config: &CliConfig) -> StdResult<(), Error> {
 }
 
 fn cmd_plugin(args: PluginArgs, config: &CliConfig) -> ExitCode {
-	use crate::engine::{async_query, HcEngine, HcEngineImpl};
+	use crate::engine::{async_query, HcEngineImpl, PluginCore};
 	use std::sync::Arc;
 	use tokio::task::JoinSet;
 

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -222,15 +222,15 @@ impl Shell {
 		}
 	}
 
-    /// Print "Config {msg}" with the proper color/styling.
-    pub fn print_config(source: impl AsRef<str>) {
+	/// Print "Config {msg}" with the proper color/styling.
+	pub fn print_config(source: impl AsRef<str>) {
 		match Shell::get_verbosity() {
 			Verbosity::Normal => {
 				macros::println!("{:>LEFT_COL_WIDTH$} {}", Title::Config, source.as_ref());
 			}
 			Verbosity::Quiet | Verbosity::Silent => {}
-        }
-    }
+		}
+	}
 
 	/// Print a hipcheck [Error]. Human readable errors will go to the standard error, JSON (regular or full) will go to the standard output.
 	pub fn print_error(err: &Error, format: Format) {


### PR DESCRIPTION

## What Changed
- migrated from last `salsa` code on crates.io (0.16.1) to latest `salsa v3` code in https://github.com/salsa-rs/salsa
- moved engine.rs code into new engine module
- split out salsa caching logic into new file in `engine` module (`salsa_cache.rs`)
- all `salsa` events are logged at the `debug` level
- using `hipcheck-v<CURRENT_VERSION>` convention for tagging `mitre/salsa` to keep track of what commit of `salsa` is being used by `hipcheck`

## Notes about migrating to latest version of `salsa`

- `#[salsa::db]` on a struct requires the struct to also be `Clone`
- `salsa::ParallelDatabase` no longer exists in `salsa`, as it is no longer needed
- using `#[salsa::tracked]` to mark a function for tracking via `salsa` is the new way to track functions. 
- `#[salsa::input]` is used to track input to `#[salsa::tracked]` functions and requires types to be wrapped in a newtype pattern where the newtype has `#[salsa::input]` applied to the struct
- `#[salsa::query_group(HcEngineStorage)]` -like patterns are no longer necessary
- `salsa::Database` now requires the implementation of `fn salsa_event(&self, event: &dyn Fn() -> salsa::Event)`. This is where any logging of `salsa` events occurs
- the documentation for the repo is still for `salsa 2022` and has not been updated for the latest code

Here are some links that I found helpful when trying to integrate with the latest `salsa` code
- https://hackmd.io/@salsa/ry5ZGyBiA
- https://hackmd.io/7f8isuLzQ7CA1GiPqNDYfA
- https://hackmd.io/z5M6WYHFQ6qKxYF8Wwjv_w
- https://salsa.zulipchat.com/#narrow/search/zalsa_db
