### PR TITLE
fix: Stop site deploy on merge queue.

### DIFF
--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,17 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: DCO
+on:
+  merge_group:
+
+permissions:  # set top-level default permissions as security best practice
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -5,8 +5,6 @@ name: Website Deploy
 on:
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 # Sets permissions of the `GITHUB_TOKEN` to allow deployment to GitHub Pages


### PR DESCRIPTION
A prior fix mistakenly added site deploys to run on merge queues. This fixes that by removing the workflow config item for it.