### PR TITLE
refactor: Improve clarity of ConfigError variants

### DIFF
--- a/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
+++ b/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
@@ -108,6 +108,16 @@ enum ConfigurationStatus {
     CONFIGURATION_STATUS_UNRECOGNIZED_CONFIGURATION = 3;
     // The user provided a configuration item whose value is invalid.
     CONFIGURATION_STATUS_INVALID_CONFIGURATION_VALUE = 4;
+    // The plugin encountered an internal error, probably due to incorrect assumptions.
+    CONFIGURATION_STATUS_INTERNAL_ERROR = 5;
+    // A necessary plugin input file was not found.
+    CONFIGURATION_STATUS_FILE_NOT_FOUND = 6;
+    // The plugin's input data could not be parsed correctly.
+    CONFIGURATION_STATUS_PARSE_ERROR = 7;
+    // An environment variable needed by the plugin was not set.
+    CONFIGURATION_STATUS_ENV_VAR_NOT_SET = 8;
+    // The plugin could not find or run a needed program.
+    CONFIGURATION_STATUS_MISSING_PROGRAM = 9;
 }
 
 /*===========================================================================

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -626,7 +626,7 @@ fn cmd_ready(config: &CliConfig) {
 	if ready.is_ready() {
 		println!("Hipcheck is ready to run!");
 	} else {
-		println!("Hipheck is NOT ready to run");
+		println!("Hipcheck is NOT ready to run");
 	}
 }
 

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -97,18 +97,27 @@ pub enum ConfigErrorType {
 	MissingRequiredConfig = 2,
 	UnrecognizedConfig = 3,
 	InvalidConfigValue = 4,
+	InternalError = 5,
+	FileNotFound = 6,
+	ParseError = 7,
+	EnvVarNotSet = 8,
+	MissingProgram = 9,
 }
 
 impl TryFrom<ConfigurationStatus> for ConfigErrorType {
 	type Error = crate::error::Error;
 	fn try_from(value: ConfigurationStatus) -> Result<Self> {
-		use ConfigErrorType::*;
 		use ConfigurationStatus::*;
 		Ok(match value as i32 {
-			x if x == Unspecified as i32 => Unknown,
-			x if x == MissingRequiredConfiguration as i32 => MissingRequiredConfig,
-			x if x == UnrecognizedConfiguration as i32 => UnrecognizedConfig,
-			x if x == InvalidConfigurationValue as i32 => InvalidConfigValue,
+			x if x == Unspecified as i32 => ConfigErrorType::Unknown,
+			x if x == MissingRequiredConfiguration as i32 => ConfigErrorType::MissingRequiredConfig,
+			x if x == UnrecognizedConfiguration as i32 => ConfigErrorType::UnrecognizedConfig,
+			x if x == InvalidConfigurationValue as i32 => ConfigErrorType::InvalidConfigValue,
+			x if x == InternalError as i32 => ConfigErrorType::InternalError,
+			x if x == FileNotFound as i32 => ConfigErrorType::FileNotFound,
+			x if x == ParseError as i32 => ConfigErrorType::ParseError,
+			x if x == EnvVarNotSet as i32 => ConfigErrorType::EnvVarNotSet,
+			x if x == MissingProgram as i32 => ConfigErrorType::MissingProgram,
 			x => {
 				return Err(hc_error!("status value '{}' is not an error", x));
 			}
@@ -135,6 +144,11 @@ impl std::fmt::Display for ConfigError {
 			MissingRequiredConfig => "configuration is missing required fields",
 			UnrecognizedConfig => "configuration contains unrecognized fields",
 			InvalidConfigValue => "configuration contains invalid values",
+			InternalError => "plugin experienced an internal error",
+			FileNotFound => "a necessary file was not found",
+			ParseError => "plugin failed to parse data",
+			EnvVarNotSet => "a necessary environment variable was not set",
+			MissingProgram => "plugin could not find or run a needed program",
 		};
 		match &self.message {
 			Some(msg) => write!(f, "{}: {}", err, msg),

--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -65,7 +65,7 @@ impl Plugin for ActivityPlugin {
 			serde_json::from_value::<Config>(config).map_err(|e| ConfigError::Unspecified {
 				message: e.to_string(),
 			})?;
-		CONFIG.set(conf).map_err(|_e| ConfigError::Unspecified {
+		CONFIG.set(conf).map_err(|_e| ConfigError::InternalError {
 			message: "config was already set".to_owned(),
 		})
 	}

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -50,13 +50,13 @@ impl TryFrom<RawConfig> for Config {
 		if let Some(ofv) = value.orgs_file_path {
 			// Get the Orgs file path and confirm it exists
 			let orgs_file = PathBuf::from(&ofv);
-			file::exists(&orgs_file).map_err(|_e| ConfigError::Unspecified {
-				// Print error with Debug for full context
-				message: format!("could not find an orgs file at path {:?}", ofv),
+			file::exists(&orgs_file).map_err(|_e| ConfigError::FileNotFound {
+				file_path: ofv.clone(),
 			})?;
 			// Parse the Orgs file and construct an OrgSpec.
 			let orgs_spec =
-				OrgSpec::load_from(&orgs_file).map_err(|e| ConfigError::Unspecified {
+				OrgSpec::load_from(&orgs_file).map_err(|e| ConfigError::ParseError {
+					source: format!("OrgSpec file at {}", ofv),
 					// Print error with Debug for full context
 					message: format!("{:?}", e),
 				})?;
@@ -288,13 +288,13 @@ impl Plugin for AffiliationPlugin {
 		// Store the policy conf to be accessed only in the `default_policy_expr()` impl
 		self.policy_conf
 			.set(conf.count_threshold)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})?;
 
 		ORGSSPEC
 			.set(conf.orgs_spec)
-			.map_err(|_e| ConfigError::Unspecified {
+			.map_err(|_e| ConfigError::InternalError {
 				message: "orgs spec was already set".to_owned(),
 			})
 	}

--- a/plugins/affiliation/src/org_spec.rs
+++ b/plugins/affiliation/src/org_spec.rs
@@ -78,8 +78,7 @@ impl OrgSpec {
 		}
 		file::exists(org_spec_path)?;
 		let org_spec_contents = file::read_string(org_spec_path)?;
-		let org_spec = OrgSpec::from_str(&org_spec_contents)
-			.with_context(|| format!("failed to read org spec file at path {:?}", org_spec_path))?;
+		let org_spec = OrgSpec::from_str(&org_spec_contents)?;
 
 		Ok(org_spec)
 	}

--- a/plugins/binary/src/binary_detector.rs
+++ b/plugins/binary/src/binary_detector.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-use crate::error::{Context, Result};
+use crate::error::Result;
 use crate::hc_error;
 use crate::util::fs::read_kdl;
 use content_inspector::{inspect, ContentType};
@@ -27,12 +27,7 @@ impl BinaryFileDetector {
 	/// Constructs a new `BinaryFileDetector` from the `Binary.kdl` file.
 	pub fn load<P: AsRef<Path>>(binary_config_file: P) -> crate::error::Result<BinaryFileDetector> {
 		fn inner(binary_config_file: &Path) -> crate::error::Result<BinaryFileDetector> {
-			let extensions_file = read_kdl(binary_config_file).with_context(|| {
-				format!(
-					"failed to read binary type definitions from Binary config file at path {:?}",
-					binary_config_file
-				)
-			})?;
+			let extensions_file = read_kdl(binary_config_file)?;
 
 			let extensions = extensions_file.into_extensions();
 

--- a/plugins/binary/src/main.rs
+++ b/plugins/binary/src/main.rs
@@ -88,18 +88,22 @@ impl Plugin for BinaryPlugin {
 		// Store the policy conf to be accessed only in the `default_policy_expr()` impl
 		self.policy_conf
 			.set(conf.opt_threshold)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})?;
 
 		// Use the langs file to create a SourceFileDetector and init the salsa db
 		let bfd =
-			BinaryFileDetector::load(conf.binary_file).map_err(|e| ConfigError::Unspecified {
+			BinaryFileDetector::load(&conf.binary_file).map_err(|e| ConfigError::ParseError {
+				source: format!(
+					"Binary type definitions file at {}",
+					conf.binary_file.display()
+				),
 				message: e.to_string_pretty_multiline(),
 			})?;
 
 		// Make the salsa db globally accessible
-		DETECTOR.set(bfd).map_err(|_e| ConfigError::Unspecified {
+		DETECTOR.set(bfd).map_err(|_e| ConfigError::InternalError {
 			message: "config was already set".to_owned(),
 		})
 	}

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -261,7 +261,7 @@ impl Plugin for ChurnPlugin {
 		// Store the PolicyExprConf to be accessed only in the `default_policy_expr()` impl
 		self.policy_conf
 			.set(conf.opt_policy)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})
 	}

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -169,7 +169,7 @@ impl Plugin for EntropyPlugin {
 		// Store the PolicyExprConf to be accessed only in the `default_policy_expr()` impl
 		self.policy_conf
 			.set(conf.opt_policy)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})
 	}

--- a/plugins/git/src/main.rs
+++ b/plugins/git/src/main.rs
@@ -335,7 +335,7 @@ impl Plugin for GitPlugin {
 
 		CACHE
 			.set(Mutex::new(LruCache::new(NonZero::new(cache_size).unwrap())))
-			.map_err(|_e| ConfigError::Unspecified {
+			.map_err(|_e| ConfigError::InternalError {
 				message: "config was already set".to_owned(),
 			})
 	}

--- a/plugins/github/src/main.rs
+++ b/plugins/github/src/main.rs
@@ -32,12 +32,11 @@ impl TryFrom<RawConfig> for Config {
 	type Error = ConfigError;
 	fn try_from(value: RawConfig) -> StdResult<Config, ConfigError> {
 		if let Some(atv) = value.api_token_var {
-			let api_token =
-				std::env::var(&atv).map_err(|_e| ConfigError::InvalidConfigValue {
-					field_name: "api-token-var".to_owned(),
-					value: atv.clone(),
-					reason: format!("Could not find an environment variable with the name \"{}\". This environment variable must contain a GitHub API token.", atv),
-				})?;
+			let api_token = std::env::var(&atv).map_err(|_e| ConfigError::EnvVarNotSet {
+				env_var_name: atv.clone(),
+				field_name: "api-token-var".to_owned(),
+				purpose: "This environment variable must contain a GitHub API token.".to_owned(),
+			})?;
 			Ok(Config { api_token })
 		} else {
 			Err(ConfigError::MissingRequiredConfig {
@@ -129,7 +128,7 @@ impl Plugin for GithubAPIPlugin {
 				message: e.to_string(),
 			})?
 			.try_into()?;
-		CONFIG.set(conf).map_err(|_e| ConfigError::Unspecified {
+		CONFIG.set(conf).map_err(|_e| ConfigError::InternalError {
 			message: "config was already set".to_owned(),
 		})
 	}

--- a/plugins/github/src/main.rs
+++ b/plugins/github/src/main.rs
@@ -34,7 +34,6 @@ impl TryFrom<RawConfig> for Config {
 		if let Some(atv) = value.api_token_var {
 			let api_token = std::env::var(&atv).map_err(|_e| ConfigError::EnvVarNotSet {
 				env_var_name: atv.clone(),
-				field_name: "api-token-var".to_owned(),
 				purpose: "This environment variable must contain a GitHub API token.".to_owned(),
 			})?;
 			Ok(Config { api_token })

--- a/plugins/identity/src/main.rs
+++ b/plugins/identity/src/main.rs
@@ -115,7 +115,7 @@ impl Plugin for IdentityPlugin {
 			})?;
 		self.policy_conf
 			.set(conf.percent_threshold)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})?;
 		Ok(())

--- a/plugins/linguist/src/linguist.rs
+++ b/plugins/linguist/src/linguist.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{Context, Result};
+use crate::error::Result;
 use crate::hc_error;
 use crate::util::fs::read_kdl;
 use hipcheck_kdl::kdl::{KdlDocument, KdlNode};
@@ -28,12 +28,7 @@ impl SourceFileDetector {
 	pub fn load<P: AsRef<Path>>(langs_file: P) -> Result<SourceFileDetector> {
 		fn inner(langs_file: &Path) -> Result<SourceFileDetector> {
 			// Load the file and parse it.
-			let language_file: LanguageFile = read_kdl(langs_file).with_context(|| {
-				format!(
-					"failed to read language definitions from langs file at path {:?}",
-					langs_file
-				)
-			})?;
+			let language_file: LanguageFile = read_kdl(langs_file)?;
 
 			// Get the list of extensions from it.
 			let extensions = language_file.into_extensions();

--- a/plugins/linguist/src/main.rs
+++ b/plugins/linguist/src/main.rs
@@ -42,7 +42,8 @@ impl Plugin for LinguistPlugin {
 				message: e.to_string(),
 			})?;
 		let sfd = match conf.langs_file {
-			Some(p) => SourceFileDetector::load(p).map_err(|e| ConfigError::Unspecified {
+			Some(p) => SourceFileDetector::load(&p).map_err(|e| ConfigError::ParseError {
+				source: format!("Language definitions file at {}", p.display()),
 				message: e.to_string_pretty_multiline(),
 			})?,
 			None => {
@@ -53,7 +54,7 @@ impl Plugin for LinguistPlugin {
 				});
 			}
 		};
-		DETECTOR.set(sfd).map_err(|_e| ConfigError::Unspecified {
+		DETECTOR.set(sfd).map_err(|_e| ConfigError::InternalError {
 			message: "config was already set".to_owned(),
 		})
 	}

--- a/plugins/review/src/main.rs
+++ b/plugins/review/src/main.rs
@@ -79,7 +79,7 @@ impl Plugin for ReviewPlugin {
 			serde_json::from_value::<Config>(config).map_err(|e| ConfigError::Unspecified {
 				message: e.to_string(),
 			})?;
-		CONFIG.set(conf).map_err(|_e| ConfigError::Unspecified {
+		CONFIG.set(conf).map_err(|_e| ConfigError::InternalError {
 			message: "config was already set".to_owned(),
 		})
 	}

--- a/plugins/typo/src/languages.rs
+++ b/plugins/typo/src/languages.rs
@@ -35,8 +35,7 @@ impl ParseKdlNode for TypoFile {
 impl TypoFile {
 	pub fn load_from(typo_path: &Path) -> Result<TypoFile> {
 		file::exists(typo_path).context("typo file does not exist")?;
-		let typo_file = file::read_kdl(typo_path)
-			.with_context(|| format!("failed to read typo file at path {:?}", typo_path))?;
+		let typo_file = file::read_kdl(typo_path)?;
 
 		Ok(typo_file)
 	}

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -48,7 +48,8 @@ impl TryFrom<RawConfig> for Config {
 		let typo_file = TypoFile::load_from(&typo_path).map_err(|e| {
 			// Print error with Debug for full context
 			log::error!("{:?}", e);
-			ConfigError::Unspecified {
+			ConfigError::ParseError {
+				source: format!("Typo file at path {}", typo_path.display()),
 				// Print error with Debug for full context
 				message: format!("{:?}", e),
 			}
@@ -125,13 +126,13 @@ impl Plugin for TypoPlugin {
 		// Store the policy conf to be accessed only in the `default_policy_expr()` impl
 		self.policy_conf
 			.set(conf.count_threshold)
-			.map_err(|_| ConfigError::Unspecified {
+			.map_err(|_| ConfigError::InternalError {
 				message: "plugin was already configured".to_string(),
 			})?;
 
 		TYPOFILE
 			.set(conf.typo_file)
-			.map_err(|_e| ConfigError::Unspecified {
+			.map_err(|_e| ConfigError::InternalError {
 				message: "config was already set".to_owned(),
 			})
 	}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -138,6 +138,32 @@ pub enum ConfigError {
 
 	/// An unspecified error
 	Unspecified { message: String },
+
+	/// The plugin encountered an error, probably due to incorrect assumptions.
+	InternalError { message: String },
+
+	/// A necessary plugin input file was not found.
+	FileNotFound { file_path: String },
+
+	/// The plugin's input data could not be parsed correctly.
+	ParseError {
+		// A short name or description of the data source.
+		source: String,
+		message: String,
+	},
+
+	/// An environment variable needed by the plugin was not set.
+	EnvVarNotSet {
+		/// Name of the environment variable
+		env_var_name: String,
+		/// Config field that set the variable name
+		field_name: String,
+		/// Message describing what the environment variable should contain
+		purpose: String,
+	},
+
+	/// The plugin could not run a needed program.
+	MissingProgram { program_name: String },
 }
 
 impl From<ConfigError> for SetConfigurationResponse {
@@ -191,6 +217,33 @@ impl From<ConfigError> for SetConfigurationResponse {
 			ConfigError::Unspecified { message } => SetConfigurationResponse {
 				status: ConfigurationStatus::Unspecified as i32,
 				message,
+			},
+			ConfigError::InternalError { message } => SetConfigurationResponse {
+				status: ConfigurationStatus::InternalError as i32,
+				message: format!("The plugin encountered an error, probably due to incorrect assumptions: {message}"),
+			},
+			ConfigError::FileNotFound { file_path } => SetConfigurationResponse {
+				status: ConfigurationStatus::FileNotFound as i32,
+				message: format!("File not found at path {file_path}"),
+			},
+			ConfigError::ParseError {
+				source,
+				message,
+			} => SetConfigurationResponse {
+				status: ConfigurationStatus::ParseError as i32,
+				message: format!("The plugin's data from \"{source}\" could not be parsed correctly: {message}"),
+			},
+			ConfigError::EnvVarNotSet {
+				env_var_name,
+				field_name,
+				purpose,
+			} => SetConfigurationResponse {
+				status: ConfigurationStatus::EnvVarNotSet as i32,
+				message: format!("Could not find an environment variable with the name \"{env_var_name}\" (set by config field '{field_name}'). Purpose: {purpose}"),
+			},
+			ConfigError::MissingProgram { program_name } => SetConfigurationResponse {
+				status: ConfigurationStatus::MissingProgram as i32,
+				message: format!("The plugin could not find or run a needed program: {program_name}"),
 			},
 		}
 	}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -156,8 +156,6 @@ pub enum ConfigError {
 	EnvVarNotSet {
 		/// Name of the environment variable
 		env_var_name: String,
-		/// Config field that set the variable name
-		field_name: String,
 		/// Message describing what the environment variable should contain
 		purpose: String,
 	},
@@ -175,7 +173,7 @@ impl From<ConfigError> for SetConfigurationResponse {
 				reason,
 			} => SetConfigurationResponse {
 				status: ConfigurationStatus::InvalidConfigurationValue as i32,
-				message: format!("invalid value '{value}' for '{field_name}', reason: '{reason}'"),
+				message: format!("'{value}' for '{field_name}', reason: '{reason}'"),
 			},
 			ConfigError::MissingRequiredConfig {
 				field_name,
@@ -185,7 +183,7 @@ impl From<ConfigError> for SetConfigurationResponse {
 				status: ConfigurationStatus::MissingRequiredConfiguration as i32,
 				message: {
 					let mut message = format!(
-						"missing required config item '{field_name}' of type '{field_type}'"
+						"'{field_name}' of type '{field_type}'"
 					);
 
 					if possible_values.is_empty().not() {
@@ -204,7 +202,7 @@ impl From<ConfigError> for SetConfigurationResponse {
 				status: ConfigurationStatus::UnrecognizedConfiguration as i32,
 				message: {
 					let mut message =
-						format!("unrecognized field '{field_name}' with value '{field_value}'");
+						format!("'{field_name}' with value '{field_value}'");
 
 					if possible_confusables.is_empty().not() {
 						message.push_str("; possible field names: ");
@@ -220,30 +218,29 @@ impl From<ConfigError> for SetConfigurationResponse {
 			},
 			ConfigError::InternalError { message } => SetConfigurationResponse {
 				status: ConfigurationStatus::InternalError as i32,
-				message: format!("The plugin encountered an error, probably due to incorrect assumptions: {message}"),
+				message: format!("the plugin encountered an error, probably due to incorrect assumptions: {message}"),
 			},
 			ConfigError::FileNotFound { file_path } => SetConfigurationResponse {
 				status: ConfigurationStatus::FileNotFound as i32,
-				message: format!("File not found at path {file_path}"),
+				message: file_path,
 			},
 			ConfigError::ParseError {
 				source,
 				message,
 			} => SetConfigurationResponse {
 				status: ConfigurationStatus::ParseError as i32,
-				message: format!("The plugin's data from \"{source}\" could not be parsed correctly: {message}"),
+				message: format!("{source} could not be parsed correctly: {message}"),
 			},
 			ConfigError::EnvVarNotSet {
 				env_var_name,
-				field_name,
 				purpose,
 			} => SetConfigurationResponse {
 				status: ConfigurationStatus::EnvVarNotSet as i32,
-				message: format!("Could not find an environment variable with the name \"{env_var_name}\" (set by config field '{field_name}'). Purpose: {purpose}"),
+				message: format!("\"{env_var_name}\". Purpose: {purpose}"),
 			},
 			ConfigError::MissingProgram { program_name } => SetConfigurationResponse {
 				status: ConfigurationStatus::MissingProgram as i32,
-				message: format!("The plugin could not find or run a needed program: {program_name}"),
+				message: program_name,
 			},
 		}
 	}


### PR DESCRIPTION
Resolves #931

Add new variants to replace all existing uses of `Unspecified`, other than `serde_json` parse errors:
- `InternalError`
- `FileNotFound`
- `ParseError`
- `EnvVarNotSet`
- `MissingProgram`