### PR TITLE
feat: Prints human output directly from Report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,8 @@ dependencies = [
  "logos",
  "maplit",
  "miette 7.4.0",
+ "minijinja",
+ "minijinja-contrib",
  "nom",
  "num-traits",
  "num_enum",
@@ -3072,6 +3074,26 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff7b8df5e85e30b87c2b0b3f58ba3a87b68e133738bf512a7713769326dbca9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac3e47a9006ed0500425a092c9f8b2e56d10f8aeec8ce870c5e8a7c6ef2d7c3"
+dependencies = [
+ "minijinja",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -78,6 +78,8 @@ log = "0.4.25"
 logos = "0.15.0"
 maplit = "1.0.2"
 miette = { version = "7.4.0", features = ["fancy"] }
+minijinja = "2.7.0"
+minijinja-contrib = { version ="2.7.0", features = ["datetime"] }
 nom = "7.1.3"
 num-traits = "0.2.19"
 num_enum = "0.7.3"


### PR DESCRIPTION
Resolves #909  

Replaces the old method of printing human readable output to the shell with a new one that parses the existing `Report` struct (which is what we serialize and print as the JSON output) using MiniJinja and prints a single report String.