### PR TITLE
docs: Document that hc ready starts plugins (implemented in #908)

### DIFF
--- a/site/content/docs/getting-started/first-run.md
+++ b/site/content/docs/getting-started/first-run.md
@@ -3,6 +3,14 @@ title: "Quickstart: Your First Analysis"
 weight: 3
 ---
 
+# Configuration Test: Run `hc ready`
+
+Before running an analysis, you may find it useful to check that Hipcheck has
+everything it needs to run and the plugins are configured correctly. You can do
+this by running [`hc ready`](@/docs/guide/cli/hc-ready.md). This is an optional
+step that performs a subset of the work that `hc check` would do to prepare for
+analysis, and exits without loading a target.
+
 # Quickstart: Your First Analysis
 
 With Hipcheck installed, let's use it to analyze something! To do that, we'll

--- a/site/content/docs/guide/cli/hc-ready.md
+++ b/site/content/docs/guide/cli/hc-ready.md
@@ -11,6 +11,16 @@ This is intended to help the user debug issues with a Hipcheck installation,
 including problems like missing configuration files, inaccessible config,
 data, or cache paths, missing authentication tokens, and more.
 
+`hc ready` starts all the plugins specified in the
+[policy file](@/docs/guide/config/policy-file.md) and confirms that initial
+configuration is successful. If `hc ready` doesn't report any problems with
+plugins, that means they are installed, runnable by Hipcheck, and are able to
+load their configuration without issues.
+
+Since `hc ready` does not involve the analysis subsystem like
+[`hc check`](@/docs/guide/cli/hc-check.md) does, it will not expose plugin
+issues that would only occur while analyzing a target.
+
 `hc ready` has no special flags currently, and only accepts the
 [General Flags](@/docs/guide/cli/general-flags.md) that _all_ Hipcheck
 commands accept.

--- a/site/content/docs/guide/config/policy-file.md
+++ b/site/content/docs/guide/config/policy-file.md
@@ -14,6 +14,9 @@ each analysis when calculating a final score. In this way, Hipcheck provides
 users extensive flexibility in both defining risk and the set of measurements
 used to evaluate it.
 
+While editing the policy file, it may be useful to check it by running
+[`hc ready --policy <POLICY_FILE_PATH>`](@/docs/guide/cli/hc-ready.md).
+
 Let's now look at an example policy file to examine its parts more closely:
 
 ```

--- a/site/content/docs/guide/debugging/starting.md
+++ b/site/content/docs/guide/debugging/starting.md
@@ -12,6 +12,12 @@ currently configured, including Hipcheck's own version, the versions of tools
 Hipcheck may need to run its analyses, the configuration of paths Hipcheck will
 use during execution, and the presence of API tokens Hipcheck may need.
 
+It also starts the plugins specified in the
+[policy file](@/docs/guide/config/policy-file.md) and confirms that all of them
+started and received configuration successfully. This is likely to catch
+configuration errors, though it will not expose issues that would only arise
+during analysis with [`hc check`](@/docs/guide/cli/hc-check.md).
+
 This is a very useful starting point when debugging Hipcheck. While Hipcheck
 can only automatically check basic information like whether configured paths
 are present and accessible, you should also review whether the paths `hc ready`
@@ -23,5 +29,5 @@ information on its specific CLI.
 ## Checking API Tokens
 
 Similarly, for any API tokens, it's good to make sure those tokens are valid
-to use, and have tha appropriate permissions required to access the
+to use, and have the appropriate permissions required to access the
 repositories or packages you are trying to analyze.


### PR DESCRIPTION
Relates to #674

- Add links to `hc ready` docs where users might find it useful.
- Fix a minor typo in docs. "tha" -> "the"