### PR TITLE
chore: update versions of libraries and plugins ahead of 3.11 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "affiliation"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -339,7 +339,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "binary"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "content_inspector",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "churn"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -1253,7 +1253,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "github"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "log",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "console",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -2576,7 +2576,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "linguist"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "npm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "typo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/hipcheck-common/Cargo.toml
+++ b/hipcheck-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-common"
 description = "Common functionality for the Hipcheck gRPC protocol"
 repository = "https://github.com/mitre/hipcheck"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/hipcheck-sdk-macros/Cargo.toml
+++ b/hipcheck-sdk-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-sdk-macros"
 description = "Helper macros for the `hipcheck-sdk` crate."
 repository = "https://github.com/mitre/hipcheck"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -144,7 +144,7 @@ xz2 = "0.1.7"
 zip = "2.2.2"
 zip-extensions = "0.8.1"
 zstd = "0.13.2"
-hipcheck-common = { version = "0.2.0", path = "../hipcheck-common", features = [
+hipcheck-common = { version = "0.3.0", path = "../hipcheck-common", features = [
     "rfd9-compat",
 ] }
 serde_with = "3.12.0"

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "activity"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 jiff = { version = "0.1.16", features = ["serde"] }
@@ -19,6 +19,6 @@ serde_json = "1.0.134"
 tokio = { version = "1.43.0", features = ["rt"] }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/activity/plugin.kdl
+++ b/plugins/activity/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "activity"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affiliation"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../hipcheck-kdl" }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -23,7 +23,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["rt"] }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "affiliation"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 clap = { version = "4.5.27", features = ["derive"] }
 content_inspector = "0.2.4"
 hipcheck-kdl = { version = "0.1.0", path = "../../hipcheck-kdl" }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -24,6 +24,6 @@ toml = "0.8.20"
 walkdir = "2.5.0"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/binary/plugin.kdl
+++ b/plugins/binary/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "binary"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "churn"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -18,7 +18,7 @@ serde_json = "1.0.134"
 tokio = { version = "1.43.0", features = ["rt"] }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }
 pathbuf = "1.0.0"

--- a/plugins/churn/plugin.kdl
+++ b/plugins/churn/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "churn"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,6 +11,6 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
-  plugin "mitre/linguist" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
+  plugin "mitre/git" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/linguist" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
 }

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entropy"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -11,7 +11,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 dashmap = { version = "6.1.0", features = ["inline", "rayon"] }
 finl_unicode = { version = "1.3.0", features = ["grapheme_clusters"] }
 futures = "0.3.31"
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 ordered-float = { version = "4.6.0", features = ["serde"] }
@@ -24,7 +24,7 @@ tokio = { version = "1.43.0", features = ["rt"] }
 unicode-normalization = "0.1.24"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/entropy/plugin.kdl
+++ b/plugins/entropy/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "entropy"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,6 +11,6 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
-  plugin "mitre/linguist" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
+  plugin "mitre/git" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/linguist" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
 }

--- a/plugins/fuzz/Cargo.toml
+++ b/plugins/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 serde = { version = "1.0.217", features = ["derive"] }
@@ -16,7 +16,7 @@ serde_json = "1.0.134"
 tokio = { version = "1.43.0", features = ["rt"] }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/fuzz/plugin.kdl
+++ b/plugins/fuzz/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "fuzz"
-version "0.2.0"
+version "0.2.1"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 lru = "0.13.0"

--- a/plugins/git/plugin.kdl
+++ b/plugins/git/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "git"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/github/Cargo.toml
+++ b/plugins/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 graphql_client = "0.14.0"
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"

--- a/plugins/github/plugin.kdl
+++ b/plugins/github/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "github"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/identity/Cargo.toml
+++ b/plugins/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -19,6 +19,6 @@ tokio = { version = "1.43.0", features = ["rt"] }
 toml = "0.8.20"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/identity/plugin.kdl
+++ b/plugins/identity/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "identity"
-version "0.3.0"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-    plugin "mitre/git" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+    plugin "mitre/git" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linguist"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../hipcheck-kdl" }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -22,7 +22,7 @@ tokio = { version = "1.43.0", features = ["rt"] }
 toml = "0.8.20"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/linguist/plugin.kdl
+++ b/plugins/linguist/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "linguist"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npm"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"

--- a/plugins/npm/plugin.kdl
+++ b/plugins/npm/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "npm"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/review/Cargo.toml
+++ b/plugins/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -20,6 +20,6 @@ tokio = { version = "1.43.0", features = ["rt"] }
 url = "2.5.4"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/review/plugin.kdl
+++ b/plugins/review/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "review"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/github" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typo"
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.95"
 clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../hipcheck-kdl" }
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 log = "0.4.25"
@@ -24,6 +24,6 @@ toml = "0.8.20"
 url = "2.5.4"
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.3.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/typo/plugin.kdl
+++ b/plugins/typo/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "typo"
-version "0.2.0"
+version "0.3.0"
 license "Apache-2.0"
 
 entrypoint {
@@ -11,5 +11,5 @@ entrypoint {
 }
 
 dependencies {
-  plugin "mitre/npm" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
+  plugin "mitre/npm" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -4,7 +4,7 @@ description = "SDK for writing Hipcheck plugins in Rust"
 homepage = "https://hipcheck.mitre.org"
 repository = "https://github.com/mitre/hipcheck"
 license = "Apache-2.0"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
@@ -21,11 +21,11 @@ tokio = { version = "1.43.0", features = ["rt"] }
 tokio-stream = "0.1.17"
 tonic = "0.12.3"
 schemars = { version = "0.8.21", features = ["url"] }
-hipcheck-sdk-macros = { path = "../../hipcheck-sdk-macros", version = "0.1.0", optional = true }
+hipcheck-sdk-macros = { path = "../../hipcheck-sdk-macros", version = "0.1.2", optional = true }
 typify-macro = "0.2.0"
 url = { version = "2.5.4", features = ["serde"] }
 log = "0.4.25"
-hipcheck-common = { version = "0.2.0", path = "../../hipcheck-common" }
+hipcheck-common = { version = "0.3.0", path = "../../hipcheck-common" }
 console = "0.15.10"
 
 [features]


### PR DESCRIPTION
HIPCHECK_COMMON		=> 0.3.0 (minor, new gRPC enum variants, non breaking)
HIPCHECK_SDK_MACROS	=> 0.1.2 (patch, deps change)
HIPCHECK_SDK		        => 0.4.0 (minor, exposure of new non-breaking variants from hipcheck-common)

GIT			=> 0.4.0 (minor, new config errors)
GITHUB		=> 0.3.0 (minor, new config errors)
ACTIVITY		=> 0.4.0 (minor, new config errors)
AFFILIATION	=> 0.4.0 (minor, new config errors)
BINARY		=> 0.3.0 (minor, new config errors)
CHURN		=> 0.4.0 (minor, new config errors)
ENTROPY		=> 0.4.0 (minor, new config errors)
FUZZ		=> 0.2.1 (patch, deps change)
IDENTITY		=> 0.4.0 (minor, new config errors)
LINGUIST		=> 0.3.0 (minor, new config errors)
REVIEW		=> 0.3.0 (minor, new config errors)
NPM		=> 0.3.0 (minor, new config errors)
TYPO		=> 0.3.0 (minor, new config errors)