### PR TITLE
chore: update hipcheck default plugin versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,18 +1,21 @@
 plugins {
-    plugin "mitre/activity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/affiliation" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/binary" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/churn" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
-    plugin "mitre/fuzz" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/review" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/activity" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/affiliation" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/binary" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/churn" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/fuzz" version="0.2.1" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/review" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
 }
 
 patch {
 	plugin "mitre/github" {
 		api-token-var "HC_GITHUB_TOKEN"
 	}
+	plugin "mitre/linguist" {
+        langs-file #rel("Langs.kdl")
+    }
 }
 
 analyze {
@@ -42,13 +45,10 @@ analyze {
             }
 
             analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
-				langs-file #rel("Langs.kdl")
 				entropy-threshold 10.0
 				commit-percentage 0.0
 	 		}
-            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" {
-				langs-file #rel("Langs.kdl")
-			}
+            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)"
         }
     }
 }

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -6,7 +6,7 @@ Automatically assess and score software packages for supply chain risk.
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"
-version = "3.10.0"
+version = "3.11.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://hipcheck.mitre.org"

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -49,13 +49,24 @@ pub fn config_to_policy(config: Config, path: &Path) -> Result<PolicyFile> {
 		analyze.push(attacks);
 	}
 
-	let patch = PolicyPatchList(vec![PolicyPatch::new(
-		PolicyPluginName::new("mitre/github")?,
-		PolicyConfig(HashMap::from_iter(vec![(
-			"api-token-var".to_owned(),
-			Value::String("HC_GITHUB_TOKEN".to_owned()),
-		)])),
-	)]);
+	let langs_path = pathbuf![&context.path, "Langs.kdl"];
+
+	let patch = PolicyPatchList(vec![
+		PolicyPatch::new(
+			PolicyPluginName::new("mitre/github")?,
+			PolicyConfig(HashMap::from_iter(vec![(
+				"api-token-var".to_owned(),
+				Value::String("HC_GITHUB_TOKEN".to_owned()),
+			)])),
+		),
+		PolicyPatch::new(
+			PolicyPluginName::new("mitre/linguist")?,
+			PolicyConfig(HashMap::from_iter(vec![(
+				"langs-file".to_owned(),
+				Value::String(langs_path.to_string_lossy().into_owned().replace("\\", "/")),
+			)])),
+		),
+	]);
 
 	Ok(PolicyFile {
 		plugins,
@@ -161,7 +172,7 @@ fn parse_activity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/activity").unwrap(),
-			PluginVersion::new("0.3.0".to_string()),
+			PluginVersion::new("0.4.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl").unwrap(),
 			)),
@@ -210,7 +221,7 @@ fn parse_binary(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/binary").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl").unwrap(),
 			)),
@@ -244,7 +255,7 @@ fn parse_fuzz(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/fuzz").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.2.1".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl").unwrap(),
 			)),
@@ -282,7 +293,7 @@ fn parse_identity(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/identity").unwrap(),
-			PluginVersion::new("0.3.0".to_string()),
+			PluginVersion::new("0.4.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl").unwrap(),
 			)),
@@ -320,7 +331,7 @@ fn parse_review(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/review").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl").unwrap(),
 			)),
@@ -364,7 +375,7 @@ fn parse_typo(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/typo").unwrap(),
-			PluginVersion::new("0.2.0".to_string()),
+			PluginVersion::new("0.3.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl").unwrap(),
 			)),
@@ -408,7 +419,7 @@ fn parse_affiliation(
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/affiliation").unwrap(),
-			PluginVersion::new("0.3.0".to_string()),
+			PluginVersion::new("0.4.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl").unwrap(),
 			)),
@@ -429,7 +440,7 @@ fn parse_affiliation(
 /// Updates the plugin and commit analysis lists with churn policies
 fn parse_churn(
 	plugins: &mut PolicyPluginList,
-	context: &Context,
+	_context: &Context,
 	commit: &mut PolicyCategory,
 	churn: &ChurnConfig,
 ) {
@@ -443,19 +454,11 @@ fn parse_churn(
 			"(lte (divz (count (filter (gt {}) $)) (count $)) {})",
 			value_threshold, percent_threshold,
 		);
-		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.kdl"];
-		config
-			.insert(
-				"langs-file".to_string(),
-				Value::String(langs_path.to_string_lossy().into_owned().replace("\\", "/")),
-			)
-			.unwrap();
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/churn").unwrap(),
-			PluginVersion::new("0.3.0".to_string()),
+			PluginVersion::new("0.4.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl").unwrap(),
 			)),
@@ -467,7 +470,7 @@ fn parse_churn(
 			PolicyPluginName::new("mitre/churn").unwrap(),
 			Some(expression),
 			Some(weight),
-			Some(config),
+			None,
 		));
 		commit.push(analysis);
 	}
@@ -476,7 +479,7 @@ fn parse_churn(
 /// Updates the plugin and commit analysis lists with entropy policies
 fn parse_entropy(
 	plugins: &mut PolicyPluginList,
-	context: &Context,
+	_context: &Context,
 	commit: &mut PolicyCategory,
 	entropy: &EntropyConfig,
 ) {
@@ -490,19 +493,11 @@ fn parse_entropy(
 			"(lte (divz (count (filter (gt {}) $)) (count $)) {})",
 			value_threshold, percent_threshold
 		);
-		let mut config = PolicyConfig::new();
-		let langs_path = pathbuf![&context.path, "Langs.kdl"];
-		config
-			.insert(
-				"langs-file".to_string(),
-				Value::String(langs_path.to_string_lossy().into_owned().replace("\\", "/")),
-			)
-			.unwrap();
 
 		// Add the plugin
 		let plugin = PolicyPlugin::new(
 			PolicyPluginName::new("mitre/entropy").unwrap(),
-			PluginVersion::new("0.3.0".to_string()),
+			PluginVersion::new("0.4.0".to_string()),
 			Some(ManifestLocation::Url(
 				Url::parse("https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl").unwrap(),
 			)),
@@ -514,7 +509,7 @@ fn parse_entropy(
 			PolicyPluginName::new("mitre/entropy").unwrap(),
 			Some(expression),
 			Some(weight),
-			Some(config),
+			None,
 		));
 		commit.push(analysis);
 	}

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -1,18 +1,21 @@
 plugins {
-    plugin "mitre/activity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/binary" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/fuzz" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/identity" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
-    plugin "mitre/review" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="0.2.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
-    plugin "mitre/affiliation" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/churn" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/activity" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/binary" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/fuzz" version="0.2.1" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/identity" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
+    plugin "mitre/review" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="0.3.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/affiliation" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/churn" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="0.4.0" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
 }
 patch {
 	plugin "mitre/github" {
 		api-token-var "HC_GITHUB_TOKEN"
 	}
+	plugin "mitre/linguist" {
+        langs-file "./config/Langs.kdl"
+    }
 }
 analyze {
     investigate policy="(gt 0.5 $)"
@@ -37,12 +40,8 @@ analyze {
                 orgs-file "./config/Orgs.kdl"
             }
 
-            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" weight=1 {
-				langs-file "./config/Langs.kdl"
-			}
-            analysis "mitre/entropy" policy="(lte (divz (count (filter (gt 10) $)) (count $)) 0)" weight=1 {
-				langs-file "./config/Langs.kdl"
-			}
+            analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)" weight=1
+            analysis "mitre/entropy" policy="(lte (divz (count (filter (gt 10) $)) (count $)) 0)" weight=1
         }
     }
 }


### PR DESCRIPTION
Updates Hipcheck to point to and use the new plugin versions. Linguist was introduced as a dependent plugin, and churn/entropy no longer need a `langs-file` config.