### PR TITLE
chore: remove unused deps from workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
  "walkdir",
 ]
 
@@ -485,7 +484,6 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "log",
- "pathbuf",
  "schemars",
  "serde",
  "serde_json",
@@ -891,18 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "duct"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
-dependencies = [
- "libc",
- "once_cell",
- "os_pipe",
- "shared_child",
-]
-
-[[package]]
 name = "dummy_rand_data"
 version = "0.1.0"
 dependencies = [
@@ -965,8 +951,6 @@ dependencies = [
  "finl_unicode",
  "futures",
  "hipcheck-sdk",
- "ordered-float",
- "pathbuf",
  "rayon",
  "schemars",
  "serde",
@@ -1058,12 +1042,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1264,11 +1242,9 @@ dependencies = [
  "lru",
  "once_cell",
  "schemars",
- "semver",
  "serde",
  "serde_json",
  "tokio",
- "which",
 ]
 
 [[package]]
@@ -2159,44 +2135,35 @@ dependencies = [
  "chrono",
  "clap",
  "console",
- "content_inspector",
  "cyclonedx-bom",
  "dashmap",
  "dialoguer",
  "dirs",
  "dotenv",
- "duct",
  "env_logger",
- "finl_unicode",
  "flate2",
  "fs_extra",
  "futures",
  "git2",
- "graphql_client",
  "hipcheck-common",
  "hipcheck-kdl",
  "hipcheck-macros",
  "http",
- "indexmap 2.7.1",
  "indextree",
  "indicatif",
  "itertools",
  "jiff",
  "log",
  "logos",
- "maplit",
  "miette 7.4.0",
  "minijinja",
  "minijinja-contrib",
  "nom",
  "num-traits",
- "num_enum",
  "once_cell",
  "ordered-float",
  "packageurl",
- "paste",
  "pathbuf",
- "petgraph 0.7.1",
  "prost",
  "rand 0.9.0",
  "rayon",
@@ -2216,15 +2183,12 @@ dependencies = [
  "tabled",
  "tar",
  "tempfile",
- "term_size",
  "test-log",
  "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "toml",
  "tonic",
- "tonic-build",
- "unicode-normalization",
  "ureq",
  "url",
  "walkdir",
@@ -2232,7 +2196,6 @@ dependencies = [
  "xml-rs",
  "xz2",
  "zip",
- "zip-extensions",
  "zstd",
 ]
 
@@ -2271,7 +2234,6 @@ name = "hipcheck-sdk"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "console",
  "futures",
  "hipcheck-common",
  "hipcheck-sdk-macros",
@@ -2295,7 +2257,6 @@ dependencies = [
 name = "hipcheck-sdk-macros"
 version = "0.1.2"
 dependencies = [
- "anyhow",
  "convert_case",
  "log",
  "proc-macro2",
@@ -2585,7 +2546,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -2867,7 +2827,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -3255,27 +3214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,16 +3280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,12 +3336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathbuf"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,20 +3363,8 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset 0.4.2",
+ "fixedbitset",
  "indexmap 2.7.1",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset 0.5.7",
- "indexmap 2.7.1",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3524,15 +3434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit 0.21.1",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,7 +3496,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -4197,16 +4098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4484,16 +4375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,7 +4582,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.24",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4711,17 +4592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.7.1",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -4937,7 +4807,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
  "url",
 ]
 
@@ -5333,15 +5202,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
@@ -5605,15 +5465,6 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
-]
-
-[[package]]
-name = "zip-extensions"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386508a00aae1d8218b9252a41f59bba739ccee3f8e420bb90bcb1c30d960d4a"
-dependencies = [
- "zip",
 ]
 
 [[package]]

--- a/hipcheck-sdk-macros/Cargo.toml
+++ b/hipcheck-sdk-macros/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-anyhow = "1.0.96"
 convert_case = "0.7.1"
 log = "0.4.25"
 proc-macro2 = "1.0.93"

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -35,7 +35,6 @@ benchmarking = []
 async-stream = "0.3.6"
 base64 = "0.22.1"
 blake3 = "1.5.5"
-content_inspector = "0.2.4"
 cyclonedx-bom = "0.8.0"
 dotenv = "0.15.0"
 chrono = { version = "0.4.39", features = ["alloc", "serde"] }
@@ -44,11 +43,7 @@ console = { version = "0.15.10", features = ["windows-console-colors"] }
 dashmap = { version = "6.1.0", features = ["rayon", "inline"] }
 dialoguer = "0.11.0"
 dirs = "6.0.0"
-duct = "0.13.5"
 env_logger = { version = "0.11.6" }
-finl_unicode = { version = "1.3.0", default-features = false, features = [
-    "grapheme_clusters",
-] }
 flate2 = "1.0.35"
 fs_extra = "1.3.0"
 futures = "0.3.31"
@@ -59,7 +54,6 @@ git2 = { version = "0.20.0", features = [
     "vendored-libgit2",
     "vendored-openssl",
 ] }
-graphql_client = "0.14.0"
 # Include with both a `path` and `version` reference.
 # Local builds will use the `path` dependency, which may be a newer
 # version than the one published to Crates.io.
@@ -69,26 +63,21 @@ graphql_client = "0.14.0"
 hipcheck-kdl = { version = "0.1.0", path = "../hipcheck-kdl" }
 hipcheck-macros = { path = "../hipcheck-macros", version = "0.3.1" }
 http = "1.2.0"
-indexmap = "2.7.1"
 indextree = "4.7.3"
 indicatif = { version = "0.17.11", features = ["rayon"] }
 itertools = "0.13.0"
 jiff = "0.1.16"
 log = "0.4.25"
 logos = "0.15.0"
-maplit = "1.0.2"
 miette = { version = "7.4.0", features = ["fancy"] }
 minijinja = "2.7.0"
 minijinja-contrib = { version ="2.7.0", features = ["datetime"] }
 nom = "7.1.3"
 num-traits = "0.2.19"
-num_enum = "0.7.3"
 once_cell = "1.20.3"
 ordered-float = { version = "4.6.0", features = ["serde"] }
 packageurl = "0.4.1"
-paste = "1.0.7"
 pathbuf = "1.0.0"
-petgraph = { version = "0.7.1", features = ["serde-1"] }
 prost = "0.13.4"
 rand = "0.9.0"
 rayon = "1.10.0"
@@ -120,7 +109,6 @@ spdx-rs = "0.5.0"
 tabled = "0.18.0"
 tar = "0.4.43"
 tempfile = "3.17.0"
-term_size = "0.3.2"
 tokio = { version = "1.43.0", features = [
     "rt",
     "rt-multi-thread",
@@ -131,7 +119,6 @@ tokio-stream = "0.1.17"
 toml = "0.8.20"
 tonic = "0.12.3"
 thiserror = "2.0.11"
-unicode-normalization = "0.1.24"
 ureq = { version = "2.12.1", default-features = false, features = [
     "json",
     "tls",
@@ -142,7 +129,6 @@ which = { version = "7.0.2", default-features = false }
 xml-rs = "0.8.25"
 xz2 = "0.1.7"
 zip = "2.2.2"
-zip-extensions = "0.8.1"
 zstd = "0.13.2"
 hipcheck-common = { version = "0.3.0", path = "../hipcheck-common", features = [
     "rfd9-compat",
@@ -156,7 +142,6 @@ pathbuf = "1.0.0"
 schemars = { version = "0.8.21", features = ["chrono", "url"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.139"
-tonic-build = "0.12.3"
 url = { version = "2.5.4", features = ["serde"] }
 which = { version = "7.0.2", default-features = false }
 

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -20,7 +20,6 @@ schemars = "0.8.21"
 serde = "1.0.217"
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt"] }
-toml = "0.8.20"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -21,4 +21,3 @@ tokio = { version = "1.43.0", features = ["rt"] }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }
-pathbuf = "1.0.0"

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -14,8 +14,6 @@ futures = "0.3.31"
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-ordered-float = { version = "4.6.0", features = ["serde"] }
-pathbuf = "1.0.0"
 rayon = "1.10.0"
 schemars = "0.8.21"
 serde = "1.0.217"

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -22,8 +22,6 @@ jiff = { version = "0.1.16", features = ["serde"] }
 log = "0.4.25"
 once_cell = "1.20.3"
 schemars = { version = "0.8.21", features = ["url"] }
-semver = "1.0.25"
 serde_json = "1.0.139"
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 tokio = { version = "1.43.0", features = ["rt"] }
-which = { version = "7.0.2", default-features = false }

--- a/plugins/identity/Cargo.toml
+++ b/plugins/identity/Cargo.toml
@@ -16,7 +16,6 @@ schemars = "0.8.21"
 serde = "1.0.217"
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt"] }
-toml = "0.8.20"
 
 [dev-dependencies]
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -19,7 +19,6 @@ pathbuf = "1.0.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt"] }
-toml = "0.8.20"
 
 [dev-dependencies]
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -20,7 +20,6 @@ pathbuf = "1.0.0"
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 serde_json = "1.0.139"
 tokio = { version = "1.43.0", features = ["rt"] }
-toml = "0.8.20"
 url = "2.5.4"
 
 [dev-dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -26,7 +26,6 @@ typify-macro = "0.2.0"
 url = { version = "2.5.4", features = ["serde"] }
 log = "0.4.25"
 hipcheck-common = { version = "0.3.0", path = "../../hipcheck-common" }
-console = "0.15.10"
 
 [features]
 macros = ["dep:hipcheck-sdk-macros"]


### PR DESCRIPTION
Used `cargo-udeps` tool to identify and remove unused crates from Cargo.toml files.