### PR TITLE
chore: CI workflows always run, jobs do filtering

### DIFF
--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -13,26 +13,8 @@ name: Hipcheck
 on:
   push:
     branches: [main]
-    paths:
-      - "config/**"
-      - "hipcheck/**"
-      - "plugins/**"
-      - "xtask/**"
-      - "sdk/rust/**"
-      - "hipcheck-common/**"
-      - "hipcheck-macros/**"
-      - "hipcheck-sdk-macros/**"
   pull_request:
     branches: [main]
-    paths:
-      - "config/**"
-      - "hipcheck/**"
-      - "plugins/**"
-      - "xtask/**"
-      - "sdk/rust/**"
-      - "hipcheck-common/**"
-      - "hipcheck-macros/**"
-      - "hipcheck-sdk-macros/**"
   merge_group:
     types: [checks_requested]
 
@@ -44,7 +26,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # job to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - "config/**"
+            - "hipcheck/**"
+            - "plugins/**"
+            - "xtask/**"
+            - "sdk/rust/**"
+            - "hipcheck-common/**"
+            - "hipcheck-macros/**"
+            - "hipcheck-sdk-macros/**"
+            - 'backend/**'
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     strategy:
       matrix:
         # NOTE: this list of runners is manually synced with the set used by

--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -26,34 +26,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # job to run change detection
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          code:
-            - "config/**"
-            - "hipcheck/**"
-            - "plugins/**"
-            - "xtask/**"
-            - "sdk/rust/**"
-            - "hipcheck-common/**"
-            - "hipcheck-macros/**"
-            - "hipcheck-sdk-macros/**"
-            - 'backend/**'
   test:
-    needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' }}
     strategy:
       matrix:
         # NOTE: this list of runners is manually synced with the set used by
@@ -72,51 +45,75 @@ jobs:
     steps:
       # Get the repo, get Rust, get `cargo-nextest`, setup caching.
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - "config/**"
+              - "hipcheck/**"
+              - "plugins/**"
+              - "xtask/**"
+              - "sdk/rust/**"
+              - "hipcheck-common/**"
+              - "hipcheck-macros/**"
+              - "hipcheck-sdk-macros/**"
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.filter.outputs.code == 'true'
       - uses: taiki-e/install-action@nextest
+        if: steps.filter.outputs.code == 'true'
       - uses: swatinem/rust-cache@v2
+        if: steps.filter.outputs.code == 'true'
         with:
           key: ${{ matrix.os }}
 
       # Install the protobuf compiler
-      - if: runner.os == 'Linux'
+      - if: runner.os == 'Linux' && steps.filter.outputs.code == 'true'
         run: sudo apt-get install -y protobuf-compiler
-      - if: runner.os == 'macOS'
+      - if: runner.os == 'macOS' && steps.filter.outputs.code == 'true'
         run: brew install protobuf
-      - if: runner.os == 'Windows'
+      - if: runner.os == 'Windows' && steps.filter.outputs.code == 'true'
         run: choco install protoc
 
       # Print dependency info (useful for debugging)
       - name: Dependency Tree
+        if: steps.filter.outputs.code == 'true'
         run: cargo tree
 
       # Try building every crate in the workspace, without debug symbols to
       # hopefully reduce build times
       - name: Build
+        if: steps.filter.outputs.code == 'true'
         run: cargo build --verbose --workspace
 
       # Test the code.
       - name: Test
+        if: steps.filter.outputs.code == 'true'
         run: cargo nextest r --verbose --workspace
 
       # Run the linter.
       - name: Lint
+        if: steps.filter.outputs.code == 'true'
         run: cargo clippy --verbose --workspace
 
       # Run our own checks for licensing and other info.
       - name: Check
+        if: steps.filter.outputs.code == 'true'
         run: cargo xtask check
 
       # Run a few variants of Hipcheck
       - name: Run with Policy
+        if: steps.filter.outputs.code == 'true'
         env:
           HC_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./target/debug/hc --policy ./config/Hipcheck.kdl check https://github.com/mitre/hipcheck
       - name: Run with Local Policy
+        if: steps.filter.outputs.code == 'true'
         env:
           HC_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./target/debug/hc --policy ./config/local.Hipcheck.kdl check https://github.com/mitre/hipcheck
       - name: Run with Config
+        if: steps.filter.outputs.code == 'true'
         env:
           HC_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./target/debug/hc --config ./config check https://github.com/mitre/hipcheck

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -13,11 +13,30 @@ permissions:
   contents: read
 
 jobs:
+  # job to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          site:
+            - "site/**"
   #==========================================================================
   # Build the Hipcheck site with Zola and the Tailwindcss CLI
   #--------------------------------------------------------------------------
   website-test:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.site == 'true' }}
 
     env:
       TAILWIND_VERSION: 3.4.4

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -4,8 +4,6 @@ name: Website Test
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "site/**"
   merge_group:
     types: [checks_requested]
 
@@ -13,30 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  # job to run change detection
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      site: ${{ steps.filter.outputs.site }}
-    steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          site:
-            - "site/**"
   #==========================================================================
   # Build the Hipcheck site with Zola and the Tailwindcss CLI
   #--------------------------------------------------------------------------
   website-test:
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.site == 'true' }}
 
     env:
       TAILWIND_VERSION: 3.4.4
@@ -46,14 +25,24 @@ jobs:
       - name: Checkout Hipcheck Repository
         uses: actions/checkout@v4
 
+      # Check if any site changes and skip future steps if not
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            site:
+              - "site/**"
+
       # Install the latest version of Zola.
       - name: Install Zola
+        if: steps.filter.outputs.site == 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: zola@0.19.1
 
       # Install the latest version of the Tailwind CLI.
       - name: Install Tailwind CLI
+        if: steps.filter.outputs.site == 'true'
         run: |
           curl --proto '=https' --tlsv1.2 -sSLO https://github.com/tailwindlabs/tailwindcss/releases/download/v${TAILWIND_VERSION}/tailwindcss-linux-x64
           chmod +x tailwindcss-linux-x64
@@ -64,12 +53,14 @@ jobs:
 
       # Install the latest major version of Deno.
       - name: Install Deno
+        if: steps.filter.outputs.site == 'true'
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
       # Build the actual site with Zola and Tailwind.
       - name: Build Hipcheck Website
+        if: steps.filter.outputs.site == 'true'
         run: |
           cd site
           zola build


### PR DESCRIPTION
Resolves #957 .

Merge queues trigger jobs based on the "required jobs" section of a branch's merge protections. Unfortunately, merge queues cannot detect when a workflow is "skipped", and so expects all of the required jobs to return success. Our current workflows decide at the top-level whether to run based on the modified files in the PR, so sometimes these jobs considered "required" by the merge queue do not fire, causing a deadlock. This PR moves the filtering into a job of the workflow, so now the workflow always "runs", but the relevant job will not unless any files in the given paths are modified.