### PR TITLE
feat: update and sync runners (ubuntu-22.04, macos-14)

### DIFF
--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -29,13 +29,13 @@ jobs:
   test:
     strategy:
       matrix:
-        # NOTE: this list of runners is manually synced with the set used by
-        # `dist` and should be kept up to date.  we've purposefully chosen to
-        # use two different versions of macOS here to achieve ARM and x86
-        # support (macos-14 is ARM, macos-13 is x86), since alternative runners
-        # with matching versions aren't all on the free plan for GitHub
-        # Actions.
-        os: [ubuntu-20.04, windows-2019, macos-14, macos-13]
+        # NOTE: MUST be synced manually with runners in 'dist-workspace.toml'
+        #
+        # We've purposefully chosen to use two different versions of macOS here
+        # to achieve ARM and x86 support (macos-14 is ARM, macos-13 is x86),
+        # since alternative runners with matching versions aren't all on the
+        # free plan for GitHub Actions.
+        os: [ubuntu-22.04, windows-2019, macos-14, macos-13]
     name: "Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,3 +26,17 @@ targets = [
 install-updater = true
 # Only build the artifacts we need, instead of the whole workspace
 precise-builds = true
+
+# NOTE: MUST be synced manually with runners in `.github/workflows/hipcheck.yml`
+[dist.github-custom-runners]
+# Ensure Apple Silicon macOS builds run natively rather than cross-compiling
+# from x86. Also makes sure our Apple Silicon macOS release builds match the
+# runner used for regular CI testing.
+aarch64-apple-darwin = "macos-14"
+# Update our Ubuntu release runs away from Ubuntu 20.04, which is now being
+# sunset by GitHub. They only track the last two LTS Ubuntu releases for free
+# runners, and with 24.04 out they're sunsetting 20.04. We're *just* moving to
+# 22.04, since releases compiled against 22.04's glibc should be forwards-
+# compatible with 24.04, but if we built on 24.04 the glibc *would not* be
+# backwards-compatible.
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
This commit does two things:

- Updates our Ubuntu runner (used for x86 Linux builds) to `ubuntu-22.04` instead of `ubuntu-20.04`. GitHub is in the process of sunsetting their `ubuntu-20.04` image. For now, dist hasn't changed the default runner for `x86_64-unknown-linux-gnu`, so we're overriding it here.
- Syncs the runner used for Apple Silicon macOS builds across dist and regular CI testing to always use `macos-14`. Previously, dist would use `macos-13`, which is x86 macOS, and cross compile to ARM. This didn't match what we did in our own regular CI testing. Now they match, which should hopefully reduce the chance of surprise errors at release time in the future.

Closes #924