### PR TITLE
Switch Plugins to use Tracing crate Logging and Forward Plugin Logging to Hipcheck core stderr/stdout 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,10 @@ dependencies = [
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
  "jiff",
- "log",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -57,7 +57,6 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "miette 7.4.0",
  "pathbuf",
  "schemars",
@@ -65,6 +64,7 @@ dependencies = [
  "serde_json",
  "strum 0.27.1",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -346,6 +346,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "walkdir",
 ]
 
@@ -487,11 +488,11 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1256,12 +1257,12 @@ dependencies = [
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
  "jiff",
- "log",
  "lru",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1288,13 +1289,13 @@ dependencies = [
  "graphql_client",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "rustls",
  "rustls-native-certs",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "ureq",
  "url",
 ]
@@ -2219,9 +2220,11 @@ name = "hipcheck-common"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hipcheck-workspace-hack",
  "pathbuf",
  "prost",
+ "serde",
  "serde_json",
  "thiserror 2.0.11",
  "tonic",
@@ -2258,7 +2261,6 @@ dependencies = [
  "indexmap 2.7.1",
  "jiff",
  "lazy_static",
- "log",
  "schemars",
  "serde",
  "serde_json",
@@ -2266,6 +2268,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
+ "tracing-subscriber",
  "typify-macro",
  "url",
 ]
@@ -2276,10 +2280,10 @@ version = "0.1.2"
 dependencies = [
  "convert_case",
  "hipcheck-workspace-hack",
- "log",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+ "tracing",
 ]
 
 [[package]]
@@ -2292,8 +2296,6 @@ dependencies = [
  "bytes",
  "cc",
  "chrono",
- "clap",
- "clap_builder",
  "dashmap",
  "digest",
  "either",
@@ -2335,6 +2337,7 @@ dependencies = [
  "syn 2.0.96",
  "tokio",
  "tokio-stream",
+ "tracing-core",
  "unicode-normalization",
  "url",
  "windows-sys 0.52.0",
@@ -2621,11 +2624,11 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2910,12 +2913,12 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "miette 7.4.0",
  "pathbuf",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3216,7 +3219,6 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "pathbuf",
  "regex",
  "schemars",
@@ -3224,6 +3226,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "which",
 ]
 
@@ -3882,11 +3885,11 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -4278,6 +4281,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -4719,6 +4731,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -4913,6 +4926,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,12 +4945,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4988,13 +5014,13 @@ dependencies = [
  "hipcheck-kdl",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "log",
  "maplit",
  "miette 7.4.0",
  "pathbuf",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -110,6 +110,7 @@ tokio = { version = "1.44.0", features = [
     "rt-multi-thread",
     "sync",
     "time",
+    "process"
 ] }
 tokio-stream = "0.1.17"
 toml = "0.8.20"

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -22,13 +22,12 @@ use std::{
 	ops::Not as _,
 	path::PathBuf,
 	pin::Pin,
-	process::Child,
 	result::Result as StdResult,
 };
+use tokio::process::Child;
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Channel, Code, Status};
-
 pub type HcPluginClient = PluginServiceClient<Channel>;
 
 #[derive(Clone, Debug)]
@@ -345,13 +344,6 @@ impl PluginContext {
 			tx,
 			rx: Mutex::new(MultiplexedQueryReceiver::new(rx)),
 		})
-	}
-}
-impl Drop for PluginContext {
-	fn drop(&mut self) {
-		if let Err(e) = self.proc.kill() {
-			println!("Failed to kill child: {e}");
-		}
 	}
 }
 

--- a/library/hipcheck-common/Cargo.toml
+++ b/library/hipcheck-common/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.96"
+clap = { version = "4.5.27", features = ["cargo", "derive", "string"] }
 prost = "0.13.5"
+serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.139"
 thiserror = "2.0.11"
 tonic = "0.12.3"

--- a/library/hipcheck-common/src/types.rs
+++ b/library/hipcheck-common/src/types.rs
@@ -4,7 +4,9 @@ use crate::{
 	error::Error,
 	proto::{Query as PluginQuery, QueryState},
 };
+use serde::Deserialize;
 use serde_json::Value;
+use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug)]
 pub struct Query {
@@ -132,5 +134,42 @@ impl TryFrom<Query> for PluginQuery {
 			concern: value.concerns,
 			split: false,
 		})
+	}
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone, clap::ValueEnum)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+	Off,
+	Error,
+	Warn,
+	Info,
+	Debug,
+	Trace,
+}
+impl LogLevel {
+	pub fn level_from_str(s: &str) -> Result<LogLevel, String> {
+		match s.trim().to_lowercase().as_str() {
+			"off" => Ok(LogLevel::Off),
+			"error" => Ok(LogLevel::Error),
+			"warn" => Ok(LogLevel::Warn),
+			"info" => Ok(LogLevel::Info),
+			"debug" => Ok(LogLevel::Debug),
+			"trace" => Ok(LogLevel::Trace),
+			_ => Err(format!("Invalid log level: {}", s.trim())),
+		}
+	}
+}
+
+impl Display for LogLevel {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match &self {
+			LogLevel::Off => write!(f, "off"),
+			LogLevel::Error => write!(f, "error"),
+			LogLevel::Warn => write!(f, "warn"),
+			LogLevel::Info => write!(f, "info"),
+			LogLevel::Debug => write!(f, "debug"),
+			LogLevel::Trace => write!(f, "trace"),
+		}
 	}
 }

--- a/library/hipcheck-sdk-macros/Cargo.toml
+++ b/library/hipcheck-sdk-macros/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.7.1"
-log = "0.4.25"
+tracing = "0.1"
 proc-macro2 = "1.0.94"
 quote = "1.0.38"
 syn = { version = "2.0.96", features = ["full", "printing"] }

--- a/library/hipcheck-sdk-macros/src/lib.rs
+++ b/library/hipcheck-sdk-macros/src/lib.rs
@@ -268,7 +268,7 @@ pub fn queries(_item: TokenStream) -> TokenStream {
 		};
 		agg.extend(out);
 	}
-	log::info!(
+	tracing::debug!(
 		"Auto-generating Plugin::queries() with {} detected queries",
 		q_lock.len()
 	);

--- a/library/hipcheck-workspace-hack/Cargo.toml
+++ b/library/hipcheck-workspace-hack/Cargo.toml
@@ -19,8 +19,6 @@ ahash = { version = "0.8.11" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.6.1" }
 chrono = { version = "0.4.39", features = ["serde"] }
-clap = { version = "4.5.27", features = ["cargo", "derive", "string"] }
-clap_builder = { version = "4.5.27", default-features = false, features = ["cargo", "color", "help", "std", "string", "suggestions", "usage"] }
 dashmap = { version = "6.1.0", default-features = false, features = ["inline", "raw-api", "rayon"] }
 digest = { version = "0.10.7", features = ["mac", "std"] }
 either = { version = "1.15.0", features = ["use_std"] }
@@ -55,8 +53,9 @@ semver = { version = "1.0.25", features = ["serde"] }
 serde = { version = "1.0.219", features = ["alloc", "derive", "rc"] }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "union", "write"] }
-tokio = { version = "1.44.0", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.44.0", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1.17", features = ["net"] }
+tracing-core = { version = "0.1.32" }
 unicode-normalization = { version = "0.1.24" }
 url = { version = "2.5.4", features = ["serde"] }
 winnow = { version = "0.6.22", features = ["simd", "unstable-recover"] }
@@ -68,8 +67,6 @@ byteorder = { version = "1.5.0" }
 bytes = { version = "1.6.1" }
 cc = { version = "1.2.16", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.39", features = ["serde"] }
-clap = { version = "4.5.27", features = ["cargo", "derive", "string"] }
-clap_builder = { version = "4.5.27", default-features = false, features = ["cargo", "color", "help", "std", "string", "suggestions", "usage"] }
 dashmap = { version = "6.1.0", default-features = false, features = ["inline", "raw-api", "rayon"] }
 digest = { version = "0.10.7", features = ["mac", "std"] }
 either = { version = "1.15.0", features = ["use_std"] }
@@ -105,8 +102,9 @@ serde = { version = "1.0.219", features = ["alloc", "derive", "rc"] }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "union", "write"] }
 syn = { version = "2.0.96", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-tokio = { version = "1.44.0", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.44.0", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1.17", features = ["net"] }
+tracing-core = { version = "0.1.32" }
 unicode-normalization = { version = "0.1.24" }
 url = { version = "2.5.4", features = ["serde"] }
 winnow = { version = "0.6.22", features = ["simd", "unstable-recover"] }

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -12,7 +12,7 @@ hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
 jiff = { version = "0.1.16", features = ["serde"] }
-log = "0.4.25"
+tracing = "0.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.139"
 tokio = { version = "1.44.0", features = ["rt"] }

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -13,7 +13,7 @@ hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 schemars = { version = "0.8.22", features = ["url"] }

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -13,6 +13,7 @@ hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
+tracing = "0.1"
 miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 serde = "1.0.219"

--- a/plugins/binary/src/main.rs
+++ b/plugins/binary/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use hipcheck_sdk::{
 	prelude::*,
 	types::{LocalGitRepo, Target},
+	LogLevel,
 };
 use pathbuf::pathbuf;
 use serde::Deserialize;
@@ -140,6 +141,9 @@ struct Args {
 	#[arg(long)]
 	port: u16,
 
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
+
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
 }
@@ -147,7 +151,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(BinaryPlugin::default())
+	PluginServer::register(BinaryPlugin::default(), args.log_level)
 		.listen_local(args.port)
 		.await
 }

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 schemars = "0.8.22"
 serde = "1.0.219"
 serde_json = "1.0.139"

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -7,7 +7,7 @@ mod types;
 use crate::{metric::*, types::*};
 
 use clap::Parser;
-use hipcheck_sdk::{prelude::*, types::Target};
+use hipcheck_sdk::{prelude::*, types::Target, LogLevel};
 use serde::Deserialize;
 
 use std::{collections::HashSet, path::PathBuf, result::Result as StdResult, sync::OnceLock};
@@ -210,6 +210,9 @@ struct Args {
 	#[arg(long)]
 	port: u16,
 
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
+
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
 }
@@ -217,7 +220,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(EntropyPlugin::default())
+	PluginServer::register(EntropyPlugin::default(), args.log_level)
 		.listen_local(args.port)
 		.await
 }

--- a/plugins/fuzz/src/main.rs
+++ b/plugins/fuzz/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hipcheck_sdk::{prelude::*, types::Target};
+use hipcheck_sdk::{prelude::*, types::Target, LogLevel};
 use serde_json::Value;
 use std::result::Result as StdResult;
 
@@ -19,6 +19,9 @@ async fn fuzz(engine: &mut PluginEngine, key: Target) -> Result<Value> {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
 
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
@@ -49,7 +52,7 @@ impl Plugin for FuzzAnalysisPlugin {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(FuzzAnalysisPlugin {})
+	PluginServer::register(FuzzAnalysisPlugin {}, args.log_level)
 		.listen_local(args.port)
 		.await
 }

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -19,7 +19,7 @@ gix = { version = "0.70.0", default-features = false, features = [
     "zlib-stock",
 ] }
 jiff = { version = "0.1.16", features = ["serde"] }
-log = "0.4.25"
+tracing = "0.1"
 schemars = { version = "0.8.22", features = ["url"] }
 serde_json = "1.0.139"
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/plugins/github/Cargo.toml
+++ b/plugins/github/Cargo.toml
@@ -13,7 +13,7 @@ graphql_client = "0.14.0"
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 # Exactly matching the version of rustls used by ureq
 # Get rid of default features since we don't use the AWS backed crypto
 # provider (we use ring) and it breaks stuff on windows.

--- a/plugins/identity/Cargo.toml
+++ b/plugins/identity/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 schemars = "0.8.22"
 serde = "1.0.219"
 serde_json = "1.0.139"

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -12,7 +12,7 @@ hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/plugins/linguist/src/linguist.rs
+++ b/plugins/linguist/src/linguist.rs
@@ -106,7 +106,7 @@ impl LanguageFile {
 			}
 		}
 
-		log::trace!("linguist known code extensions [exts='{:#?}']", result);
+		tracing::trace!("linguist known code extensions [exts='{:#?}']", result);
 
 		result
 	}

--- a/plugins/linguist/src/main.rs
+++ b/plugins/linguist/src/main.rs
@@ -7,7 +7,7 @@ mod linguist;
 mod util;
 
 use clap::Parser;
-use hipcheck_sdk::prelude::*;
+use hipcheck_sdk::{prelude::*, LogLevel};
 use linguist::SourceFileDetector;
 use serde::Deserialize;
 use std::{path::PathBuf, result::Result as StdResult, sync::OnceLock};
@@ -75,6 +75,9 @@ struct Args {
 	#[arg(long)]
 	port: u16,
 
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
+
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
 }
@@ -82,7 +85,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(LinguistPlugin {})
+	PluginServer::register(LinguistPlugin {}, args.log_level)
 		.listen_local(args.port)
 		.await
 }

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 pathbuf = "1.0.0"
 regex = "1.11.1"
 schemars = { version = "0.8.22", features = ["url"] }

--- a/plugins/npm/src/npm.rs
+++ b/plugins/npm/src/npm.rs
@@ -72,7 +72,7 @@ pub fn get_npm_version() -> Result<String> {
 }
 
 fn generate_package_lock_file(package_dir: &Path, version: String) -> Result<()> {
-	log::debug!("generating lock file [path={}]", package_dir.display());
+	tracing::debug!("generating lock file [path={}]", package_dir.display());
 
 	NpmCommand::for_package(
 		package_dir,
@@ -157,7 +157,7 @@ impl NpmCommand {
 	{
 		check_version(&version)?;
 
-		log::debug!("minimum version in use [min='npm', version='{}']", &version);
+		tracing::debug!("minimum version in use [min='npm', version='{}']", &version);
 
 		NpmCommand::internal(Some(pkg_path), Out::Null, args)
 	}
@@ -213,7 +213,7 @@ impl NpmCommand {
 		if output.status.success() {
 			return Ok(output_text);
 		}
-		log::debug!("npm output_text [output_text='{}']", output_text);
+		tracing::debug!("npm output_text [output_text='{}']", output_text);
 
 		match String::from_utf8(output.stderr) {
 			Ok(msg) if msg.is_empty().not() => {

--- a/plugins/npm/src/util/command.rs
+++ b/plugins/npm/src/util/command.rs
@@ -44,7 +44,7 @@ fn parse_version(version: &str) -> Result<Version> {
 		.ok_or_else(|| anyhow!("failed to find a npm version"))?
 		.as_str();
 
-	log::debug!("{} version detected [version='npm']", version);
+	tracing::debug!("{} version detected [version='npm']", version);
 
 	Ok(Version::parse(version)?)
 }
@@ -55,18 +55,18 @@ where
 	I: IntoIterator<Item = S> + Copy,
 	S: AsRef<OsStr>,
 {
-	log::debug!("logging npm CLI args");
+	tracing::debug!("logging npm CLI args");
 
 	// https://doc.rust-lang.org/std/env/fn.args.html
 	for arg in env::args() {
-		log::debug!("npm CLI environment arg [arg='{}']", arg);
+		tracing::debug!("npm CLI environment arg [arg='{}']", arg);
 	}
 
-	log::debug!("npm CLI executable location [path='{}']", command_path);
+	tracing::debug!("npm CLI executable location [path='{}']", command_path);
 
 	log_each_arg(args);
 
-	log::debug!("done logging npm CLI args");
+	tracing::debug!("done logging npm CLI args");
 }
 
 pub fn log_each_arg<I, S>(args: I)
@@ -80,6 +80,6 @@ where
 			.to_str()
 			.unwrap_or("argument for command could not be logged.");
 
-		log::debug!("npm CLI argument [name='{}', value='{}']", index, arg_val);
+		tracing::debug!("npm CLI argument [name='{}', value='{}']", index, arg_val);
 	}
 }

--- a/plugins/review/Cargo.toml
+++ b/plugins/review/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.27", features = ["derive"] }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 schemars = { version = "0.8.22", features = ["url"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.139"

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -13,7 +13,7 @@ hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
 hipcheck-sdk = { version = "0.4.0", path = "../../sdk/rust", features = [
     "macros",
 ] }
-log = "0.4.25"
+tracing = "0.1"
 maplit = "1.0.2"
 miette = { version = "7.4.0", features = ["fancy"] }
 pathbuf = "1.0.0"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -23,14 +23,17 @@ schemars = { version = "0.8.22", features = ["url"] }
 hipcheck-sdk-macros = { path = "../../library/hipcheck-sdk-macros", version = "0.1.2", optional = true }
 typify-macro = "0.2.0"
 url = { version = "2.5.4", features = ["serde"] }
-log = "0.4.25"
+tracing = { version= "0.1", optional = true }
+tracing-subscriber = { version="0.3", features=["env-filter", "json"], optional = true }
 hipcheck-common = { version = "0.3.0", path = "../../library/hipcheck-common" }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [features]
+default = ["log_forwarding"]
 macros = ["dep:hipcheck-sdk-macros"]
 mock_engine = []
 print-timings = []
+log_forwarding = ["tracing", "tracing-subscriber"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/test-plugins/dummy_rand_data/src/main.rs
+++ b/tests/test-plugins/dummy_rand_data/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hipcheck_sdk::prelude::*;
+use hipcheck_sdk::{prelude::*, LogLevel};
 #[cfg(test)]
 use std::result::Result as StdResult;
 
@@ -71,6 +71,9 @@ struct Args {
 	#[arg(long)]
 	port: u16,
 
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
+
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
 }
@@ -78,7 +81,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(RandDataPlugin)
+	PluginServer::register(RandDataPlugin, args.log_level)
 		.listen_local(args.port)
 		.await
 }

--- a/tests/test-plugins/dummy_sha256/src/main.rs
+++ b/tests/test-plugins/dummy_sha256/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hipcheck_sdk::prelude::*;
+use hipcheck_sdk::{prelude::*, LogLevel};
 use sha2::{Digest, Sha256};
 
 #[query(default)]
@@ -40,6 +40,9 @@ struct Args {
 	#[arg(long)]
 	port: u16,
 
+	#[arg(long, default_value_t=LogLevel::Error)]
+	log_level: LogLevel,
+
 	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
 	unknown_args: Vec<String>,
 }
@@ -47,7 +50,7 @@ struct Args {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
 	let args = Args::try_parse().unwrap();
-	PluginServer::register(Sha256Plugin)
+	PluginServer::register(Sha256Plugin, args.log_level)
 		.listen_local(args.port)
 		.await
 }


### PR DESCRIPTION
Resolves #381 and #933.
This PR switches the Hipcheck plugins to use the tracing crate for logging instead of the logging crate (as will be done on Hipcheck core).
It also forwards the logging output of plugins to the stderr/stdout output of Hipcheck core.
It does this through:
- Creating a feature in hipcheck_sdk to initialize a tracing_subscriber
- Calling the init_logger() feature from each plugin
- When plugins are launched as a child process: pipe their output to a tokio task in manager.rs that deserializes the json logs, parses them, and re-emits them to Hipcheck core output.


It also adds docs in the sdk on how to use the init_logger() feature.