### PR TITLE
chore: use mold as linker for x86_64-unknown-linux-gnu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ xtask = "run --package xtask --bin xtask --quiet --"
 
 [build]
 incremental = true
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,6 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": {
-    "openssl": "sudo apt-get install libssl-dev protobuf-compiler"
+    "openssl": "sudo apt-get install libssl-dev protobuf-compiler mold"
   }
 }

--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Install the protobuf compiler
       - if: runner.os == 'Linux' && steps.filter.outputs.code == 'true'
-        run: sudo apt-get install -y protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler mold
       - if: runner.os == 'macOS' && steps.filter.outputs.code == 'true'
         run: brew install protobuf
       - if: runner.os == 'Windows' && steps.filter.outputs.code == 'true'


### PR DESCRIPTION
Using mold as a linker on x86-linux lead to the following gains on my system:
- ~10% faster debug builds
- ~5% faster release builds

## `cargo build --workspace`
### Benchmark Command:
```bash
cd /tmp && hyperfine --runs 2 \
 --prepare 'cd ~/workspace/hipcheck/main && cargo clean' \
 'cd ~/workspace/hipcheck/main && RUSTC_WRAPPER="" cargo build --workspace' \
 --prepare 'cd ~/workspace/hipcheck/patrickjcasey/use-mold-linux && cargo clean' \
 'cd ~/workspace/hipcheck/patrickjcasey/use-mold-linux  &&  RUSTC_WRAPPER="" cargo build --workspace'
```

### Results
![image](https://github.com/user-attachments/assets/33e8a50c-8fa4-4e80-a515-233d206fb7e4)

## `cargo build --workspace --release`
### Benchmark Command:
```bash
cd /tmp && hyperfine --runs 2 \
 --prepare 'cd ~/workspace/hipcheck/main && cargo clean' \
 'cd ~/workspace/hipcheck/main && RUSTC_WRAPPER="" cargo build --workspace --release' \
 --prepare 'cd ~/workspace/hipcheck/patrickjcasey/use-mold-linux && cargo clean' \
 'cd ~/workspace/hipcheck/patrickjcasey/use-mold-linux  &&  RUSTC_WRAPPER="" cargo build --workspace --release'
```

###  Results
![image](https://github.com/user-attachments/assets/10855324-e2fb-4a43-9f9c-2a7753d93f50)
