### PR TITLE
fix: plugins accept and parse unknown trailing args

### DIFF
--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -92,6 +92,9 @@ impl Plugin for ActivityPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -324,6 +324,9 @@ impl Plugin for AffiliationPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/binary/src/main.rs
+++ b/plugins/binary/src/main.rs
@@ -139,6 +139,9 @@ impl Plugin for BinaryPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -301,6 +301,9 @@ impl Plugin for ChurnPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -209,6 +209,9 @@ impl Plugin for EntropyPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/fuzz/src/main.rs
+++ b/plugins/fuzz/src/main.rs
@@ -19,6 +19,9 @@ async fn fuzz(engine: &mut PluginEngine, key: Target) -> Result<Value> {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/plugins/git/src/main.rs
+++ b/plugins/git/src/main.rs
@@ -355,6 +355,9 @@ impl Plugin for GitPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/github/src/main.rs
+++ b/plugins/github/src/main.rs
@@ -112,6 +112,9 @@ async fn has_fuzz(_engine: &mut PluginEngine, key: RemoteGitRepo) -> Result<bool
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/plugins/identity/src/main.rs
+++ b/plugins/identity/src/main.rs
@@ -148,6 +148,9 @@ impl Plugin for IdentityPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/linguist/src/main.rs
+++ b/plugins/linguist/src/main.rs
@@ -74,6 +74,9 @@ impl Plugin for LinguistPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/npm/src/main.rs
+++ b/plugins/npm/src/main.rs
@@ -124,6 +124,9 @@ impl Plugin for DependenciesPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/review/src/main.rs
+++ b/plugins/review/src/main.rs
@@ -111,6 +111,9 @@ impl Plugin for ReviewPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -156,6 +156,9 @@ impl Plugin for TypoPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/test-plugins/dummy_rand_data/src/main.rs
+++ b/test-plugins/dummy_rand_data/src/main.rs
@@ -70,6 +70,9 @@ impl Plugin for RandDataPlugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/test-plugins/dummy_sha256/src/main.rs
+++ b/test-plugins/dummy_sha256/src/main.rs
@@ -39,6 +39,9 @@ impl Plugin for Sha256Plugin {
 struct Args {
 	#[arg(long)]
 	port: u16,
+
+	#[arg(trailing_var_arg(true), allow_hyphen_values(true), hide = true)]
+	unknown_args: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]


### PR DESCRIPTION
Plugins can now accept unknown trailing arguments without failure. 
Allows for greater robustness when arguments get added.