### PR TITLE
feat: Add `--arch` flag to `hc ready`, as used by `hc check`

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -460,7 +460,7 @@ pub enum FullCommands {
 	Check(CheckArgs),
 	Schema(SchemaArgs),
 	Setup,
-	Ready,
+	Ready(ReadyArgs),
 	Update(UpdateArgs),
 	CacheTarget(CacheTargetArgs),
 	CachePlugin(CachePluginArgs),
@@ -476,7 +476,7 @@ impl From<&Commands> for FullCommands {
 			Commands::Check(args) => FullCommands::Check(args.clone()),
 			Commands::Schema(args) => FullCommands::Schema(args.clone()),
 			Commands::Setup => FullCommands::Setup,
-			Commands::Ready => FullCommands::Ready,
+			Commands::Ready(args) => FullCommands::Ready(args.clone()),
 			Commands::Scoring => FullCommands::Scoring,
 			Commands::Update(args) => FullCommands::Update(args.clone()),
 			Commands::Cache(args) => match &args.subcmd {
@@ -502,7 +502,7 @@ pub enum Commands {
 	/// Initialize Hipcheck config file and script file locations.
 	Setup,
 	/// Check if Hipcheck is ready to run.
-	Ready,
+	Ready(ReadyArgs),
 	/// Print the tree used to weight analyses during scoring.
 	Scoring,
 	/// Run Hipcheck self-updater, if installed
@@ -822,6 +822,12 @@ pub enum SchemaCommand {
 	Pypi,
 	/// Print the JSON schema for running Hipcheck against a source repository
 	Repo,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct ReadyArgs {
+	#[arg(long = "arch", value_parser = Arch::from_str)]
+	pub arch: Option<Arch>,
 }
 
 #[derive(Debug, Clone, clap::Args)]


### PR DESCRIPTION
Relates to #674

This allows users to override the detected architecture when `hc ready` starts plugins.

Also, `hc ready` will now return `ExitCode::FAILURE` when any of its checks fail.

Feedback requested:
- [x] Which Clap options should be set on `ReadyArgs`? I tentatively copied `subcommand_negates_reqs = true` and `arg_required_else_help = true` from `CheckArgs`, but even after reading the documentation, I'm not sure why `CheckArgs` needs these or how they interact with other parts of the CLI.