### PR TITLE
fix: Binary plugin now correctly matches file extension strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "binary"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "content_inspector",

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/binary/plugin.kdl
+++ b/plugins/binary/plugin.kdl
@@ -1,6 +1,6 @@
 publisher "mitre"
 name "binary"
-version "0.3.1"
+version "0.3.2"
 license "Apache-2.0"
 
 entrypoint {

--- a/plugins/binary/src/binary_detector.rs
+++ b/plugins/binary/src/binary_detector.rs
@@ -43,7 +43,7 @@ impl BinaryFileDetector {
 	pub fn is_likely_binary_file<P: AsRef<Path>>(&self, file_name: P) -> bool {
 		fn inner(binary_file_detector: &BinaryFileDetector, file_name: &Path) -> bool {
 			let extension = match file_name.extension() {
-				Some(e) => format!(".{}", e.to_string_lossy()),
+				Some(e) => format!("{}", e.to_string_lossy()),
 				None => return true,
 			};
 			for ext in &binary_file_detector.extensions {


### PR DESCRIPTION
Resolve issue #997  Removes the extraneous "." from the file extension string we extract from likely binary files in the binary plugin. The "." caused those file extension strings to fail to match with the known binary file extension strings we get from the default `Binary.kdl`.