### PR TITLE
fix: Improves english message when missing default explanation

### DIFF
--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -42,7 +42,7 @@ pub fn build_report(session: &Session, scoring: &ScoringResults) -> Result<Repor
 				// This is the "explanation" pulled from the new gRPC call.
 				let message = session
 					.default_query_explanation(analysis.publisher.clone(), analysis.plugin.clone())?
-					.unwrap_or("no query explanation provided".to_owned());
+					.unwrap_or("output".to_owned());
 
 				builder.add_analysis(
 					Analysis::plugin(

--- a/library/hipcheck-workspace-hack/Cargo.toml
+++ b/library/hipcheck-workspace-hack/Cargo.toml
@@ -65,7 +65,7 @@ zeroize = { version = "1.8.1", features = ["zeroize_derive"] }
 ahash = { version = "0.8.11" }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.6.1" }
-cc = { version = "1.1.15", default-features = false, features = ["parallel"] }
+cc = { version = "1.2.16", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.27", features = ["cargo", "derive", "string"] }
 clap_builder = { version = "4.5.27", default-features = false, features = ["cargo", "color", "help", "std", "string", "suggestions", "usage"] }


### PR DESCRIPTION
Resolves Issue #994 Changes the explanation for a plugin with no default explanation from "no query explanation provided" to "output" to improve readability.