### PR TITLE
fix: allow analysis-only policies

### DIFF
--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -710,13 +710,10 @@ fn add_category(
 
 // Lowest-level function to turn a PolicyFile into an AnalysisTree
 pub fn unresolved_analysis_tree_from_policy(policy: &PolicyFile) -> Result<AnalysisTree> {
-	let mut tree = AnalysisTree::new("risk");
+	let mut tree = AnalysisTree::new(&policy.analyze.root.name);
 	let root = tree.root;
-
-	for c in policy.analyze.categories.iter() {
-		add_category(&mut tree, root, c)?;
-	}
-
+	add_category(&mut tree, root, &policy.analyze.root)?;
+	
 	Ok(tree)
 }
 


### PR DESCRIPTION
Closes #1000 

Tested with this `local.Hipcheck.kdl` policy file and all related files within `./config`

```
plugins {
    plugin "mitre/activity" version="0.0.0" manifest="plugins/activity/local-plugin.kdl"
    plugin "mitre/affiliation" version="0.0.0" manifest="plugins/affiliation/local-plugin.kdl"
    plugin "mitre/binary" version="0.0.0" manifest="plugins/binary/local-plugin.kdl"
    plugin "mitre/churn" version="0.0.0" manifest="plugins/churn/local-plugin.kdl"
    plugin "mitre/entropy" version="0.0.0" manifest="plugins/entropy/local-plugin.kdl"
    plugin "mitre/fuzz" version="0.0.0" manifest="plugins/fuzz/local-plugin.kdl"
    plugin "mitre/review" version="0.0.0" manifest="plugins/review/local-plugin.kdl"
    plugin "mitre/typo" version="0.0.0" manifest="plugins/typo/local-plugin.kdl"
}

patch {
    plugin "mitre/github" {
        api-token-var "HC_GITHUB_TOKEN"
    }

    plugin "mitre/linguist" {
        langs-file #rel("Langs.kdl")
    }
}

analyze {
    investigate policy="(gt 0.5 $)"
    investigate-if-fail "mitre/typo" "mitre/binary"


    analysis "mitre/activity" policy="(lte $ P52w)" weight=3
    analysis "mitre/binary" {
        binary-file #rel("Binary.kdl")
        binary-file-threshold 0
    }
    analysis "mitre/fuzz" policy="(eq #t $)"
    analysis "mitre/review" policy="(lte (divz (count (filter (eq #f) $)) (count $)) 0.05)"


    analysis "mitre/typo" {
        typo-file #rel("Typos.kdl")
        count-threshold 0
    }

    analysis "mitre/affiliation" {
        orgs-file #rel("Orgs.kdl")
        count-threshold 0
    }

    analysis "mitre/entropy" policy="(eq 0 (count (filter (gt 8.0) $)))" {
        entropy-threshold 10.0
        commit-percentage 0.0
    }
    analysis "mitre/churn" policy="(lte (divz (count (filter (gt 3) $)) (count $)) 0.02)"

}
```