### PR TITLE
chore: Update default message for identity plugin

### DIFF
--- a/plugins/identity/src/main.rs
+++ b/plugins/identity/src/main.rs
@@ -137,8 +137,7 @@ impl Plugin for IdentityPlugin {
 
 	fn explain_default_query(&self) -> Result<Option<String>> {
 		Ok(Some(
-			"Returns whether each commit in the repo was commited and authored by the same person"
-				.to_owned(),
+			"commits in the repo authored and commited by the same person".to_owned(),
 		))
 	}
 


### PR DESCRIPTION
Resolves #935 . Changes the default query text for the identity plugin to be compatible with the English language messaging.