### PR TITLE
Infers ref from git VCS URLs

### DIFF
--- a/hipcheck/src/config.rs
+++ b/hipcheck/src/config.rs
@@ -713,7 +713,7 @@ pub fn unresolved_analysis_tree_from_policy(policy: &PolicyFile) -> Result<Analy
 	let mut tree = AnalysisTree::new(&policy.analyze.root.name);
 	let root = tree.root;
 	add_category(&mut tree, root, &policy.analyze.root)?;
-	
+
 	Ok(tree)
 }
 

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> ExitCode {
 	}
 
 	match config.subcommand() {
-		Some(FullCommands::Check(args)) => return cmd_check(&args, &config),
+		Some(FullCommands::Check(mut args)) => return cmd_check(&mut args, &config),
 		Some(FullCommands::Schema(args)) => cmd_schema(&args),
 		Some(FullCommands::Setup) => return cmd_setup(&config),
 		Some(FullCommands::Ready(args)) => return cmd_ready(&args, &config),
@@ -116,7 +116,7 @@ fn main() -> ExitCode {
 }
 
 /// Run the `check` command.
-fn cmd_check(args: &CheckArgs, config: &CliConfig) -> ExitCode {
+fn cmd_check(args: &mut CheckArgs, config: &CliConfig) -> ExitCode {
 	// Before we do any analysis, set the user-provided arch
 	if let Some(arch) = &args.arch {
 		if let Err(e) = try_set_arch(arch) {

--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -519,7 +519,7 @@ impl PolicyAnalyze {
 	pub fn pop(&mut self) -> Option<PolicyCategory> {
 		match self.root.children.pop() {
 			Some(PolicyCategoryChild::Category(c)) => Some(c),
-			_ => None
+			_ => None,
 		}
 	}
 

--- a/hipcheck/src/session/mod.rs
+++ b/hipcheck/src/session/mod.rs
@@ -509,9 +509,9 @@ fn load_target(seed: &TargetSeed, home: &Path) -> Result<Target> {
 	match seed {
 		TargetSeed::Single(single_target_seed) => {
 			let phase_desc = match single_target_seed.kind {
-				SingleTargetSeedKind::LocalRepo(_) | SingleTargetSeedKind::RemoteRepo(_) => {
-					"resolving git repository target"
-				}
+				SingleTargetSeedKind::LocalRepo(_)
+				| SingleTargetSeedKind::RemoteRepo(_)
+				| SingleTargetSeedKind::VcsUrl(_) => "resolving git repository target",
 				SingleTargetSeedKind::Package(_) => "resolving package target",
 				SingleTargetSeedKind::Sbom(_) => "parsing SBOM document",
 				SingleTargetSeedKind::MavenPackage(_) => "resolving maven package target",

--- a/hipcheck/src/target/mod.rs
+++ b/hipcheck/src/target/mod.rs
@@ -35,17 +35,17 @@ impl ToTargetSeedKind for MultiTargetSeedKind {
 }
 
 pub trait ToTargetSeed {
-	fn to_target_seed(&self) -> Result<TargetSeed, Error>;
+	fn to_target_seed(&mut self) -> Result<TargetSeed, Error>;
 }
 
 impl ToTargetSeed for SingleTargetSeed {
-	fn to_target_seed(&self) -> Result<TargetSeed, Error> {
+	fn to_target_seed(&mut self) -> Result<TargetSeed, Error> {
 		Ok(TargetSeed::Single(self.clone()))
 	}
 }
 
 impl ToTargetSeed for MultiTargetSeed {
-	fn to_target_seed(&self) -> Result<TargetSeed, Error> {
+	fn to_target_seed(&mut self) -> Result<TargetSeed, Error> {
 		Ok(TargetSeed::Multi(self.clone()))
 	}
 }
@@ -72,29 +72,12 @@ impl TargetType {
 			parse_purl(&purl)
 		// Otherwise check if it is a Git VCS URL
 		} else if tgt.starts_with("git+") {
-			// Remove Git prefix
+			// Remove Git prefix and check of the URL is correctly formatted
 			let tgt_trimmed = tgt.replace("git+", "");
-			// If the URL is not correctly formatted, we cannot identify the target type
-			if let Ok(vcs_url) = Url::parse(&tgt_trimmed) {
-				match vcs_url.scheme() {
-					// If the URL is for a file, trim the file scheme idenfifier and return the presumptive file path
-					// If the path is not valid, we will handle that error later
-					"file" => {
-						let filepath = vcs_url.path().to_string();
-						Some((Repo, filepath))
-					}
-					// If the scheme is anything other than a file (e.g. https, ssh) clean up and return the repo URL
-					_ => {
-						// Remove any git ref information that trails the end of the URL
-						let mut url =
-							tgt_trimmed.split(".git").collect::<Vec<&str>>()[0].to_string();
-						// Restore ".git" to the end of the URL, since we did not intend to remove that part
-						url.push_str(".git");
-						Some((Repo, url))
-					}
-				}
-			} else {
-				None
+			// If the URL is not correctly formatted, we cannot identify the target type; otherwise we will parse the VCS URL information later
+			match Url::parse(&tgt_trimmed) {
+				Ok(_) => Some((Repo, tgt.to_string())),
+				Err(_) => None,
 			}
 		// Otherwise, check if it is a GitHub repo URL
 		} else if tgt.starts_with("https://github.com/") {

--- a/hipcheck/src/target/resolve.rs
+++ b/hipcheck/src/target/resolve.rs
@@ -154,6 +154,10 @@ impl TargetResolver {
 				resolver.remote = Some(repo.clone());
 				repo.resolve(&mut resolver)
 			}
+			VcsUrl(vcs) => {
+				resolver.remote = Some(vcs.remote.clone());
+				vcs.remote.resolve(&mut resolver)
+			}
 			LocalRepo(local) => {
 				resolver.local = Some(local.clone());
 				local.resolve(&mut resolver)

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -27,6 +27,12 @@ pub struct Target {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+pub struct VcsUrl {
+	pub remote: RemoteGitRepo,
+	pub git_ref: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct RemoteGitRepo {
 	pub url: Url,
 	pub known_remote: Option<KnownRemote>,
@@ -118,6 +124,7 @@ impl Display for SbomStandard {
 pub enum SingleTargetSeedKind {
 	LocalRepo(LocalGitRepo),
 	RemoteRepo(RemoteGitRepo),
+	VcsUrl(VcsUrl),
 	Package(Package),
 	MavenPackage(MavenPackage),
 	Sbom(Sbom),
@@ -165,6 +172,12 @@ impl Display for SingleTargetSeedKind {
 					write!(f, "GitHub repo {}/{} from {}", owner, repo, remote.url)
 				}
 				_ => write!(f, "remote repo at {}", remote.url.as_str()),
+			},
+			VcsUrl(vcs) => match &vcs.remote.known_remote {
+				Some(KnownRemote::GitHub { owner, repo }) => {
+					write!(f, "GitHub repo {}/{} from {}", owner, repo, vcs.remote.url)
+				}
+				_ => write!(f, "remote repo at {}", vcs.remote.url.as_str()),
 			},
 			Package(package) => {
 				let ver_str = if package.has_version() {


### PR DESCRIPTION
Resolves #1034 Now if a remote git VCS URL is provided with ref information, we set the `TargetSeed.refspec` to that ref instead of simply discarding it.

If a ref is also provided by the user with the `--ref` flag that does not match the VCS URL ref, Hipcheck will error out.

Edit: Also resolves #1057 