### PR TITLE
chore: Update tagline on site index

### DIFF
--- a/site/templates/bases/base.tera.html
+++ b/site/templates/bases/base.tera.html
@@ -18,8 +18,8 @@
                     {{ bc::breadcrumbs(current=current) }}
                 {% endblock %}
             </div>
-            <div class="lg:max-w-7xl lg:mx-auto mt-8 lg:mt-24 lg:mb-8 px-4 md:px-8 lg:px-16">
-                <div class="lg:grid lg:grid-cols-12 lg:gap-16">            
+            <div class="lg:max-w-7xl lg:mx-auto mt-8 lg:mt-32 lg:mb-32 px-4 md:px-8 lg:px-8">
+                <div class="lg:grid lg:grid-cols-12 lg:gap-16">
                     <div class="lg:col-span-7">
                         <div class="
                             lg:w-full lg:max-w-none

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -15,11 +15,9 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% block content %}
-  
+
     <span class="mt-4 text-4xl lg:text-5xl relative z-20 font-medium !leading-tight">
-        <span class="bg-gradient-to-r from-blue-600 via-cyan-600 to-green-600 text-transparent bg-clip-text italic font-black">Maximally<span class="inline lg:hidden"> </span><span class="hidden lg:inline">&nbsp;</span>configurable</span>
-        analysis of open source software for
-        <span class="bg-gradient-to-r from-red-500 via-orange-500 to-yellow-500 text-transparent bg-clip-text italic font-black">long&nbsp;term&nbsp;risk</span>
+        Identify <span class="bg-gradient-to-r from-red-500 via-orange-500 to-yellow-500 text-transparent bg-clip-text font-black">risky&nbsp;practices</span> and <span class="bg-gradient-to-r from-red-500 via-orange-500 to-yellow-500 text-transparent bg-clip-text font-black">possible attacks</span> in your software dependencies.
     </span>
 
     <ul class="list-none ps-0 mt-12 text-lg">


### PR DESCRIPTION
This updates the tagline used on the site homepage to more clearly explain what Hipcheck does, and thereby imply why it's useful. This matches language that seemed to resonate with folks when I was discussing Hipcheck at the SoCal Linux Expo.