### PR TITLE
chore: improve hc check --ref help

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -520,8 +520,8 @@ pub enum Commands {
 #[command(arg_required_else_help = true)]
 pub struct CheckArgs {
 	/// The ref (e.g. commit hash, branch, tag) of the target to analyze
-	#[clap(long = "ref")]
-	pub refspec: Option<String>,
+	#[clap(long = "ref", value_name = "REF")]
+	pub git_ref: Option<String>,
 
 	#[clap(subcommand)]
 	command: Option<CheckCommand>,
@@ -608,7 +608,7 @@ impl ToTargetSeed for CheckArgs {
 		let command = self.command()?;
 		let target = TargetSeed {
 			kind: command.to_target_seed_kind()?,
-			refspec: self.refspec.clone(),
+			refspec: self.git_ref.clone(),
 			specifier: command.get_specifier().to_owned(),
 		};
 		// Validate

--- a/site/content/docs/guide/cli/hc-check.md
+++ b/site/content/docs/guide/cli/hc-check.md
@@ -21,7 +21,7 @@ Arguments:
   <TARGET>  The target package, URL, commit, etc. for Hipcheck to analyze. If ambiguous, the -t flag must be set
 
 Options:
-      --ref <REFSPEC>         The ref (e.g. commit hash, branch, tag) of the target to analyze
+      --ref <REF>             The ref (e.g. commit hash, branch, tag) of the target to analyze
       --arch <ARCH>
   -t, --target <TARGET_TYPE>  [possible values: maven, npm, pypi, repo, request, sbom]
   -h, --help                  Print help (see more with '--help')


### PR DESCRIPTION
When updating the documentation for #1009, I found `--ref <REFSPEC>` to be confusing. We are looking for a [git ref/reference](https://git-scm.com/book/en/v2/Git-Internals-Git-References) NOT a [git refspec](https://git-scm.com/book/en/v2/Git-Internals-The-Refspec)

Here is the new help menu:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/ae9fc39a-3d1a-425b-a6ea-3d8dd1f8ac97" />
