### PR TITLE
refactor: TargetSeedKind refactor to support single and mulit targets

### DIFF
--- a/hipcheck/src/target/mod.rs
+++ b/hipcheck/src/target/mod.rs
@@ -6,13 +6,13 @@ pub mod purl;
 pub mod resolve;
 pub mod spdx;
 pub mod types;
-use purl::parse_purl;
 pub use types::*;
 
 use crate::error::Error;
 
 use clap::ValueEnum;
 use packageurl::PackageUrl;
+use purl::parse_purl;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -22,8 +22,32 @@ pub trait ToTargetSeedKind {
 	fn to_target_seed_kind(&self) -> Result<TargetSeedKind, Error>;
 }
 
+impl ToTargetSeedKind for SingleTargetSeedKind {
+	fn to_target_seed_kind(&self) -> Result<TargetSeedKind, crate::error::Error> {
+		Ok(TargetSeedKind::Single(self.clone()))
+	}
+}
+
+impl ToTargetSeedKind for MultiTargetSeedKind {
+	fn to_target_seed_kind(&self) -> Result<TargetSeedKind, crate::error::Error> {
+		Ok(TargetSeedKind::Multi(self.clone()))
+	}
+}
+
 pub trait ToTargetSeed {
 	fn to_target_seed(&self) -> Result<TargetSeed, Error>;
+}
+
+impl ToTargetSeed for SingleTargetSeed {
+	fn to_target_seed(&self) -> Result<TargetSeed, Error> {
+		Ok(TargetSeed::Single(self.clone()))
+	}
+}
+
+impl ToTargetSeed for MultiTargetSeed {
+	fn to_target_seed(&self) -> Result<TargetSeed, Error> {
+		Ok(TargetSeed::Multi(self.clone()))
+	}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum, Serialize)]

--- a/hipcheck/src/target/pm.rs
+++ b/hipcheck/src/target/pm.rs
@@ -545,7 +545,7 @@ fn is_none_or_empty(s: Option<&str>) -> bool {
 mod tests {
 	use crate::{
 		cli::{CheckNpmArgs, CheckPypiArgs},
-		target::{TargetSeedKind, ToTargetSeedKind},
+		target::{SingleTargetSeedKind, TargetSeedKind, ToTargetSeedKind},
 	};
 
 	// Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -563,7 +563,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -591,7 +591,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -619,7 +619,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -647,7 +647,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -675,7 +675,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -703,7 +703,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -732,7 +732,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -764,7 +764,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -792,7 +792,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -820,7 +820,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -848,7 +848,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -876,7 +876,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -904,7 +904,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {
@@ -932,7 +932,7 @@ mod tests {
 		}
 		.to_target_seed_kind()
 		.unwrap();
-		if let TargetSeedKind::Package(package) = target_seed {
+		if let TargetSeedKind::Single(SingleTargetSeedKind::Package(package)) = target_seed {
 			assert_eq!(
 				package,
 				Package {

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -115,7 +115,7 @@ impl Display for SbomStandard {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TargetSeedKind {
+pub enum SingleTargetSeedKind {
 	LocalRepo(LocalGitRepo),
 	RemoteRepo(RemoteGitRepo),
 	Package(Package),
@@ -124,15 +124,40 @@ pub enum TargetSeedKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TargetSeed {
-	pub kind: TargetSeedKind,
+pub struct SingleTargetSeed {
+	pub kind: SingleTargetSeedKind,
 	pub refspec: Option<String>,
 	pub specifier: String,
 }
 
-impl Display for TargetSeedKind {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MultiTargetSeedKind {
+	// CargoToml(PathBuf),
+	// GoMod(PathBuf),
+	// PackageJson(PathBuf),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultiTargetSeed {
+	pub kind: MultiTargetSeedKind,
+	pub specifier: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TargetSeedKind {
+	Single(SingleTargetSeedKind),
+	Multi(MultiTargetSeedKind),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TargetSeed {
+	Single(SingleTargetSeed),
+	Multi(MultiTargetSeed),
+}
+
+impl Display for SingleTargetSeedKind {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		use TargetSeedKind::*;
+		use SingleTargetSeedKind::*;
 		match self {
 			LocalRepo(repo) => write!(f, "local repo at {}", repo.path.display()),
 			RemoteRepo(remote) => match &remote.known_remote {
@@ -158,8 +183,12 @@ impl Display for TargetSeedKind {
 		}
 	}
 }
+
 impl Display for TargetSeed {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		self.kind.fmt(f)
+		match self {
+			TargetSeed::Single(x) => x.kind.fmt(f),
+			TargetSeed::Multi(_x) => unimplemented!(),
+		}
 	}
 }


### PR DESCRIPTION
First pass at implementing the minimal amount of changes to support this function signature

```rust
impl TargetSeed {
    pub fn get_targets(config: TargetResolverConfig) -> impl Iterator<Item = Target> {
    ...
```