### PR TITLE
chore: replace once_cell::Lazy with std::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,7 +2196,6 @@ dependencies = [
  "minijinja-contrib",
  "nom",
  "num-traits",
- "once_cell",
  "ordered-float 5.0.0",
  "packageurl",
  "pathbuf",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -72,7 +72,6 @@ minijinja = "2.7.0"
 minijinja-contrib = { version = "2.7.0", features = ["datetime"] }
 nom = "7.1.3"
 num-traits = "0.2.19"
-once_cell = "1.20.3"
 ordered-float = { version = "5.0.0", features = ["serde"] }
 packageurl = "0.4.1"
 pathbuf = "1.0.0"

--- a/hipcheck/src/util/command.rs
+++ b/hipcheck/src/util/command.rs
@@ -4,7 +4,6 @@ use crate::{
 	error::{Context as _, Result},
 	hc_error,
 };
-use once_cell::sync::Lazy;
 use regex::Regex;
 use semver::Version;
 use std::{
@@ -15,13 +14,14 @@ use std::{
 	fmt,
 	fmt::{Display, Formatter},
 	iter::IntoIterator,
+	sync::LazyLock,
 };
 
 use DependentProgram::*;
 
 type VersionMap = HashMap<DependentProgram, Version>;
 
-static MIN_VERSIONS: Lazy<VersionMap> = Lazy::new(|| {
+static MIN_VERSIONS: LazyLock<VersionMap> = LazyLock::new(|| {
 	fn insert_version(hm: &mut VersionMap, program: DependentProgram) {
 		// SAFETY: The versions in `min_version_str` are known to be valid.
 		hm.insert(program, Version::parse(program.min_version_str()).unwrap());


### PR DESCRIPTION
Instead of merging #1051 , this removes the outdated `once_cell` crate in favor of the std library.