### PR TITLE
chore: move plugin query trace log to engine.rs from plugins

### DIFF
--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -28,7 +28,6 @@ async fn activity(engine: &mut PluginEngine, target: Target) -> Result<String> {
 	let today = Timestamp::now();
 
 	// Get the date of the most recent commit.
-	tracing::trace!("querying mitre/git/last_commit_date");
 	let value = engine
 		.query("mitre/git/last_commit_date", repo)
 		.await

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -229,7 +229,6 @@ async fn affiliation(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>
 	let repo = key.local;
 
 	// query the git plugin for a summary of all git contributors in the repo
-	tracing::trace!("querying mitre/git/contributor_summary");
 	let contributors_value = engine.query("mitre/git/contributor_summary", repo).await?;
 	let contributors: Vec<CommitContributorView> = serde_json::from_value(contributors_value)
 		.map_err(|e| {

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -99,7 +99,6 @@ async fn commit_churns(
 		.collect::<StdResult<Vec<Value>, serde_json::Error>>()
 		.map_err(|_| Error::UnspecifiedQueryState)?;
 
-	tracing::trace!("querying mitre/linguist/is_likely_source_file");
 	let res = engine.batch_query("mitre/linguist", psf_val_vec).await?;
 	let psf_bools: Vec<bool> = serde_json::from_value(serde_json::Value::Array(res))
 		.map_err(|_| Error::UnspecifiedQueryState)?;
@@ -233,7 +232,6 @@ async fn commit_churns(
 async fn churn(engine: &mut PluginEngine, value: Target) -> Result<Vec<f64>> {
 	tracing::info!("running churn query");
 	let local = value.local;
-	tracing::trace!("querying mitre/git/commit_diffs");
 	let val_commits = engine.query("mitre/git/commit_diffs", local).await?;
 	let commits: Vec<CommitDiff> =
 		serde_json::from_value(val_commits).map_err(Error::InvalidJsonInQueryOutput)?;

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -93,7 +93,6 @@ async fn commit_entropies(
 		.collect::<StdResult<Vec<Value>, serde_json::Error>>()
 		.map_err(|_| Error::UnspecifiedQueryState)?;
 
-	tracing::trace!("querying mitre/linguist/is_likely_source_file");
 	let res = engine.batch_query("mitre/linguist", psf_val_vec).await?;
 	let psf_bools: Vec<bool> = serde_json::from_value(serde_json::Value::Array(res))
 		.map_err(|_| Error::UnspecifiedQueryState)?;
@@ -143,7 +142,6 @@ async fn commit_entropies(
 async fn entropy(engine: &mut PluginEngine, value: Target) -> Result<Vec<f64>> {
 	tracing::info!("running entropy query");
 	let local = value.local;
-	tracing::trace!("querying mitre/git/commit_diffs");
 	let val_commits = engine.query("mitre/git/commit_diffs", local).await?;
 	let commits: Vec<CommitDiff> =
 		serde_json::from_value(val_commits).map_err(Error::InvalidJsonInQueryOutput)?;

--- a/plugins/fuzz/src/main.rs
+++ b/plugins/fuzz/src/main.rs
@@ -10,7 +10,6 @@ use std::result::Result as StdResult;
 async fn fuzz(engine: &mut PluginEngine, key: Target) -> Result<Value> {
 	tracing::info!("running fuzz query");
 	if let Some(remote) = &key.remote {
-		tracing::trace!("querying mitre/github/has_fuzz");
 		let fuzz = engine.query("mitre/github", remote.clone()).await;
 		tracing::info!("completed fuzz query");
 		fuzz

--- a/plugins/identity/src/main.rs
+++ b/plugins/identity/src/main.rs
@@ -64,7 +64,6 @@ impl Display for Commit {
 #[query]
 async fn commit_identity(engine: &mut PluginEngine, key: DetailedGitRepo) -> Result<bool> {
 	tracing::info!("running commit_identity query");
-	tracing::trace!("querying mitre/git/contributors_for_commit");
 	let value = engine
 		.query("mitre/git/contributors_for_commit", key)
 		.await
@@ -83,7 +82,6 @@ async fn identity(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>> {
 	tracing::info!("running identity query");
 	// Get the commits for the source.
 	let repo = key.local;
-	tracing::trace!("querying mitre/git/commits");
 	let value = engine
 		.query("mitre/git/commits", repo.clone())
 		.await

--- a/plugins/review/src/main.rs
+++ b/plugins/review/src/main.rs
@@ -46,7 +46,6 @@ async fn review(engine: &mut PluginEngine, value: Target) -> Result<Vec<bool>> {
 	};
 
 	// Get a list of all pull requests to the repo, with their corresponding number of reviews
-	tracing::trace!("querying mitre/github/pr_reviews");
 	let value = engine
 		.query("mitre/github/pr_reviews", known_remote)
 		.await

--- a/plugins/typo/src/main.rs
+++ b/plugins/typo/src/main.rs
@@ -74,7 +74,6 @@ async fn typo(engine: &mut PluginEngine, value: Target) -> Result<Vec<bool>> {
 		.ok_or_else(|| anyhow!("could not find typo file"))?;
 
 	// Get the repo's dependencies
-	tracing::trace!("querying mitre/npm/dependencies");
 	let value = engine
 		.query("mitre/npm/dependencies", value.local)
 		.await

--- a/sdk/rust/src/engine.rs
+++ b/sdk/rust/src/engine.rs
@@ -156,6 +156,7 @@ impl PluginEngine {
 		V: Serialize,
 	{
 		let query_target: QueryTarget = target.try_into().map_err(|e| e.into())?;
+		tracing::trace!("querying {}", query_target.to_string());
 		let input: JsonValue = serde_json::to_value(input).map_err(Error::InvalidJsonInQueryKey)?;
 		// since there input had one value, there will only be one response
 		let mut response = self.query_inner(query_target, vec![input]).await?;
@@ -172,6 +173,7 @@ impl PluginEngine {
 		V: Serialize,
 	{
 		let target: QueryTarget = target.try_into().map_err(|e| e.into())?;
+		tracing::trace!("querying {}", target.to_string());
 		let mut input = Vec::with_capacity(keys.len());
 		for key in keys {
 			let jsonified_key = serde_json::to_value(key).map_err(Error::InvalidJsonInQueryKey)?;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -124,6 +124,14 @@ impl FromStr for QueryTarget {
 		}
 	}
 }
+impl std::fmt::Display for QueryTarget {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match &self.query {
+			Some(query) => write!(f, "{}/{}/{}", self.publisher, self.plugin, query),
+			None => write!(f, "{}/{}", self.publisher, self.plugin),
+		}
+	}
+}
 
 impl TryInto<QueryTarget> for &str {
 	type Error = Error;


### PR DESCRIPTION
Resolves #1064 
Moves trace level logs occurring in plugins to the shared functions in the query engine that they call.