### PR TITLE
feat: Allow plugins to return error information as query responses

### DIFF
--- a/hipcheck/src/engine/mod.rs
+++ b/hipcheck/src/engine/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 	},
 	policy::PolicyFile,
 	policy_exprs::Expr,
-	Result,
+	Error, Result,
 };
 use futures::future::{BoxFuture, FutureExt};
 use serde_json::Value;
@@ -110,6 +110,7 @@ pub fn async_query(
 				return Ok(v);
 			}
 			PluginResponse::AwaitingResult(a) => a,
+			PluginResponse::Error(e) => return Err(Error::msg(e)),
 		};
 		// Otherwise, the plugin needs more data to continue. Recursively query
 		// (with salsa memo-ization) to get the needed data, and resume our
@@ -143,6 +144,7 @@ pub fn async_query(
 					return Ok(v);
 				}
 				PluginResponse::AwaitingResult(a) => a,
+				PluginResponse::Error(e) => return Err(Error::msg(e)),
 			};
 		}
 	}

--- a/hipcheck/src/engine/salsa_cache.rs
+++ b/hipcheck/src/engine/salsa_cache.rs
@@ -4,7 +4,7 @@ use crate::{
 	engine::{HcEngine, RUNTIME},
 	hc_error,
 	plugin::{get_plugin_key, PluginResponse, QueryResult},
-	Result,
+	Error, Result,
 };
 
 trait CloneFromSalsaDb {
@@ -84,6 +84,7 @@ pub fn query_with_salsa(
 		}
 		PluginResponse::Completed(v) => return Ok(v),
 		PluginResponse::AwaitingResult(a) => a,
+		PluginResponse::Error(e) => return Err(Error::msg(e)),
 	};
 	// Otherwise, the plugin needs more data to continue. Recursively query
 	// (with salsa memo-ization) to get the needed data, and resume our
@@ -115,6 +116,7 @@ pub fn query_with_salsa(
 			}
 			PluginResponse::Completed(v) => return Ok(v),
 			PluginResponse::AwaitingResult(a) => a,
+			PluginResponse::Error(e) => return Err(Error::msg(e)),
 		};
 	}
 }

--- a/hipcheck/src/plugin/mod.rs
+++ b/hipcheck/src/plugin/mod.rs
@@ -118,6 +118,7 @@ impl ActivePlugin {
 			key: vec![key],
 			output: vec![],
 			concerns: vec![],
+			error: todo!(),
 		};
 
 		Ok(self.channel.query(query).await?.into())
@@ -137,6 +138,7 @@ impl ActivePlugin {
 			key: vec![],
 			output,
 			concerns: vec![],
+			error: todo!(),
 		};
 
 		log::trace!("Resuming query");

--- a/hipcheck/src/plugin/types.rs
+++ b/hipcheck/src/plugin/types.rs
@@ -506,11 +506,14 @@ pub struct QueryResult {
 	pub concerns: Vec<String>,
 }
 
+// Cal TODO remove unused
+#[allow(unused)]
 #[derive(Clone, Debug)]
 pub enum PluginResponse {
 	RemoteClosed,
 	AwaitingResult(AwaitingResult),
 	Completed(QueryResult),
+	Error(String),
 }
 
 impl From<Option<Query>> for PluginResponse {
@@ -529,6 +532,7 @@ impl From<Query> for PluginResponse {
 				value: value.output,
 				concerns: value.concerns,
 			};
+			// Cal TODO not all responses are complete, if some are errors
 			PluginResponse::Completed(result)
 		} else {
 			PluginResponse::AwaitingResult(value.into())

--- a/library/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
+++ b/library/hipcheck-common/proto/hipcheck/v1/hipcheck.proto
@@ -200,6 +200,10 @@ message Query {
     // Used to indicate whether or not a string field present in a `repeated string` field
     // was split between two messages
     bool split = 9;
+
+    // A plugin-generated error string.
+    // Shall be present if and only if state == QUERY_STATE_ERROR
+    optional string error = 10;
 }
 
 enum QueryState {
@@ -220,6 +224,9 @@ enum QueryState {
 
     // We are sending a query to a plugin and we are expecting to need to send more chunks
     QUERY_STATE_SUBMIT_IN_PROGRESS = 4;
+
+    // An error was encountered while processing.
+    QUERY_STATE_ERROR = 5;
 }
 
 /*===========================================================================

--- a/library/hipcheck-common/src/chunk.rs
+++ b/library/hipcheck-common/src/chunk.rs
@@ -63,6 +63,13 @@ pub fn chunk_with_size(msg: PluginQuery, max_est_size: usize) -> Result<Vec<Plug
 	let (in_progress_state, completion_state) = match msg.state() {
 		// if the message gets chunked, then it must either be a reply or submission that is in process
 		QueryState::Unspecified => return Err(anyhow!("msg in Unspecified query state")),
+		QueryState::Error => {
+			return Err(anyhow!(
+				// Cal TODO review whether this is the best approach
+				"msg is errored; error = '{}'",
+				msg.error.unwrap_or("".to_owned())
+			))
+		}
 		QueryState::SubmitInProgress | QueryState::SubmitComplete => {
 			(QueryState::SubmitInProgress, QueryState::SubmitComplete)
 		}
@@ -98,6 +105,9 @@ pub fn chunk_with_size(msg: PluginQuery, max_est_size: usize) -> Result<Vec<Plug
 			output: vec![],
 			concern: vec![],
 			split: false,
+			// Cal TODO is error always none here?
+			// if so, comment why
+			error: None,
 		};
 
 		for (source, sink) in [
@@ -530,6 +540,9 @@ mod test {
 					"< 10#2".to_owned(),
 				],
 				split: false,
+				// Cal TODO is error always none here?
+				// if so, comment why
+				error: None,
 			};
 			let res = match chunk_with_size(orig_query.clone(), 10) {
 				Ok(r) => r,

--- a/library/hipcheck-common/src/types.rs
+++ b/library/hipcheck-common/src/types.rs
@@ -18,6 +18,7 @@ pub struct Query {
 	pub key: Vec<serde_json::Value>,
 	pub output: Vec<serde_json::Value>,
 	pub concerns: Vec<String>,
+	pub error: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -101,6 +102,7 @@ impl TryFrom<PluginQuery> for Query {
 			key: keys,
 			output: outputs,
 			concerns: value.concern,
+			error: value.error,
 		})
 	}
 }
@@ -135,7 +137,7 @@ impl TryFrom<Query> for PluginQuery {
 			output: outputs,
 			concern: value.concerns,
 			split: false,
-			error: None, // TODO actually pass error
+			error: value.error,
 		})
 	}
 }

--- a/library/hipcheck-common/src/types.rs
+++ b/library/hipcheck-common/src/types.rs
@@ -32,6 +32,8 @@ impl TryFrom<QueryState> for QueryDirection {
 	fn try_from(value: QueryState) -> Result<Self, Self::Error> {
 		match value {
 			QueryState::Unspecified => Err(Error::UnspecifiedQueryState),
+			// Cal TODO use correct error type instead of UnspecifiedQueryState
+			QueryState::Error => Err(Error::UnspecifiedQueryState),
 			QueryState::SubmitInProgress => Err(Error::UnexpectedRequestInProgress),
 			QueryState::SubmitComplete => Ok(QueryDirection::Request),
 			QueryState::ReplyInProgress => Err(Error::UnexpectedReplyInProgress),
@@ -133,6 +135,7 @@ impl TryFrom<Query> for PluginQuery {
 			output: outputs,
 			concern: value.concerns,
 			split: false,
+			error: None, // TODO actually pass error
 		})
 	}
 }

--- a/sdk/rust/src/engine.rs
+++ b/sdk/rust/src/engine.rs
@@ -136,6 +136,7 @@ impl PluginEngine {
 				key: input,
 				output: vec![],
 				concerns: vec![],
+				error: todo!(),
 			};
 			self.send(query).await?;
 			let response = self.recv().await?;
@@ -231,6 +232,7 @@ impl PluginEngine {
 		Ok(())
 	}
 
+	// Cal TODO add error parameter
 	async fn send_session_err<P>(&mut self) -> crate::error::Result<()>
 	where
 		P: Plugin,
@@ -312,6 +314,7 @@ impl PluginEngine {
 			key: vec![],
 			output: vec![value],
 			concerns: self.take_concerns(),
+			error: todo!(),
 		};
 
 		self.send(query).await
@@ -330,6 +333,7 @@ impl PluginEngine {
 				}
 				other => {
 					tracing::error!("{}", other);
+					// Cal TODO pass error value
 					self.send_session_err::<P>().await
 				}
 			};

--- a/sdk/rust/src/engine.rs
+++ b/sdk/rust/src/engine.rs
@@ -245,6 +245,7 @@ impl PluginEngine {
 			output: vec![],
 			concern: self.take_concerns(),
 			split: false,
+			error: None, // Cal TODO send error string
 		};
 		self.tx
 			.send(Ok(InitiateQueryProtocolResponse { query: Some(query) }))


### PR DESCRIPTION
- Add `error` field to `Query` schema in protobuf
- Add `error: Option<String>` to `struct Query` in `hipcheck-common/src/types.rs`
- Add error variant to `QueryState` enum in protobuf
- Add `Error` case to `PluginResponse`

Remaining TODOs
- [ ] Create `PluginResponse::Error` when appropriate in its `impl From<Query>` block
- [ ] Make sure that `handle_session` passes error responses to `send_session_err`
- [ ] Update `send_session_err` to send error strings instead of just setting `QueryState` to `Unspecified`
- [ ] Test that the changes are effective
    - [ ] Change a plugin's use of `QueryState::Unspecified` to `QueryState::Error` and pass an error string
    - [ ] Confirm that Hipcheck prints the error
- [ ] Ensure all possible data paths for plugin errors eventually get printed in a useful way
- [ ] Update documentation
- [ ] Write RFD that explains changes