### PR TITLE
feat: investigate-if-fail in report

### DIFF
--- a/hipcheck/src/policy/policy_file.rs
+++ b/hipcheck/src/policy/policy_file.rs
@@ -592,9 +592,21 @@ impl PolicyPluginName {
 	}
 }
 
+impl From<PolicyPluginName> for String {
+	fn from(value: PolicyPluginName) -> Self {
+		format!("{}/{}", value.publisher.0, value.name.0)
+	}
+}
+
+impl From<&PolicyPluginName> for String {
+	fn from(value: &PolicyPluginName) -> Self {
+		value.clone().into()
+	}
+}
+
 impl Display for PolicyPluginName {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}/{}", self.publisher.0, self.name.0)
+		write!(f, "{}", String::from(self))
 	}
 }
 

--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -315,6 +315,7 @@ pub struct Percent {
 #[schemars(crate = "schemars")]
 pub struct Recommendation {
 	pub kind: RecommendationKind,
+	pub reason: Option<InvestigateReason>,
 	risk_score: RiskScore,
 	risk_policy: RiskPolicy,
 }
@@ -323,9 +324,14 @@ impl Recommendation {
 	/// Make a recommendation.
 	pub fn is(risk_score: RiskScore, risk_policy: RiskPolicy) -> Result<Recommendation> {
 		let kind = RecommendationKind::is(risk_score, risk_policy.clone())?;
+		let reason = match kind {
+			RecommendationKind::Pass => None,
+			RecommendationKind::Investigate => Some(InvestigateReason::Policy),
+		};
 
 		Ok(Recommendation {
 			kind,
+			reason,
 			risk_score,
 			risk_policy,
 		})
@@ -338,6 +344,14 @@ impl Recommendation {
 pub enum RecommendationKind {
 	Pass,
 	Investigate,
+}
+
+/// Describe why the the recommendation is to investigate
+#[derive(Debug, Serialize, JsonSchema, Clone)]
+#[schemars(crate = "schemars")]
+pub enum InvestigateReason {
+	Policy,
+	FailedAnalyses(Vec<String>),
 }
 
 impl RecommendationKind {

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -198,7 +198,18 @@ impl<'sess> ReportBuilder<'sess> {
 				};
 				if self.investigate_if_failed.contains(&policy_plugin_name) {
 					rec.kind = RecommendationKind::Investigate;
-					break;
+					// If no investigate reason, add one
+					match &mut rec.reason {
+						Some(InvestigateReason::Policy) => (),
+						None => {
+							rec.reason = Some(InvestigateReason::FailedAnalyses(vec![
+								policy_plugin_name.into(),
+							]))
+						}
+						Some(InvestigateReason::FailedAnalyses(x)) => {
+							x.push(policy_plugin_name.into())
+						}
+					}
 				}
 			}
 

--- a/hipcheck/src/shell/mod.rs
+++ b/hipcheck/src/shell/mod.rs
@@ -79,7 +79,8 @@ const TEMPLATE: &str = r#"
 {% if recommendation.kind == "Pass" -%}
 {{ title("Pass") }} risk rated as {{ recommendation.risk_score }}, policy was {{ recommendation.risk_policy }}
 {% elif recommendation.kind == "Investigate" -%}
-{{ title("Investigate") }} risk rated as {{ recommendation.risk_score }}, policy was {{ recommendation.risk_policy }}
+{{ title("Investigate") }} {% if recommendation.reason is string and recommendation.reason == "Policy" -%} recommendation.risk rated as {{ recommendation.risk_score }}, policy was {{ recommendation.risk_policy }} {%- elif recommendation.reason.FailedAnalyses is sequence -%} the following investigate-if-fail plugins failed: {% for f in recommendation.reason.FailedAnalyses %}{{f}} {% endfor %}
+{%- endif %}
 {%- endif %}"#;
 
 /// Type interface to the global shell used to produce output in the user's terminal.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -256,6 +256,7 @@ pub trait Plugin: Send + Sync + 'static {
 pub fn init_tracing_logger(log_level: LogLevel) {
 	tracing_subscriber::fmt()
 		.json()
+		.with_writer(std::io::stderr)
 		.with_env_filter(log_level.to_string())
 		.init();
 }

--- a/site/content/docs/rfds/0013-plugin-config-hash.md
+++ b/site/content/docs/rfds/0013-plugin-config-hash.md
@@ -6,7 +6,8 @@ extra:
   rfd: 13
   primary_author: Julian Lanson
   primary_author_link: https://github.com/j-lanson
-  status: Proposed
+  status: Accepted
+  pr: 1032
 ---
 
 # Plugin Configuration Hashing


### PR DESCRIPTION
Resolves #1058 .

Adds an additional field `reason` to `Recommendation` to identify why something is marked for investigation. When an "investigate-if-fail" policy is the cause of the overall "investigate" determination on a target, this now will display why in the output report, both in JSON and pretty-print form. Example below:

<img width="522" alt="Screenshot 2025-03-28 092556" src="https://github.com/user-attachments/assets/d8948e00-62a0-4624-b247-ea78f771aafc" />

As an additional commit, fixed an issue with the SDK logger to make it print to stderr instead of stdout.