### PR TITLE
feat: Refactor Session for support of multiple target runs

### DIFF
--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -37,7 +37,7 @@ pub struct Report {
 	pub repo_name: Arc<String>,
 
 	/// Optional owner/maintainer of the repo
-	pub repo_owner: Option<Arc<String>>,
+	pub repo_owner: Arc<Option<String>>,
 
 	/// The HEAD commit hash of the repository during analysis.
 	pub repo_head: Arc<String>,

--- a/hipcheck/src/score.rs
+++ b/hipcheck/src/score.rs
@@ -9,6 +9,7 @@ use crate::{
 	policy_exprs::{std_exec, Expr},
 	session::Session,
 	shell::spinner_phase::SpinnerPhase,
+	target::Target,
 };
 use indextree::{Arena, NodeId};
 #[cfg(test)]
@@ -186,7 +187,11 @@ pub struct ScoreTreeNode {
 	pub weight: f64,
 }
 
-pub fn score_results(_phase: &SpinnerPhase, session: &Session) -> Result<ScoringResults> {
+pub fn score_results(
+	_phase: &SpinnerPhase,
+	session: &Session,
+	target: &Target,
+) -> Result<ScoringResults> {
 	// Scoring should be performed by the construction of a "score tree" where scores are the
 	// nodes and weights are the edges. The leaves are the analyses themselves, which either
 	// pass (a score of 0) or fail (a score of 1). These are then combined with the other
@@ -201,7 +206,7 @@ pub fn score_results(_phase: &SpinnerPhase, session: &Session) -> Result<Scoring
 
 	// RFD4 analysis style - get all "leaf" analyses and call through plugin architecture
 	let plugin_score_tree = {
-		let target_json = serde_json::to_value(session.target())?;
+		let target_json = serde_json::to_value(target)?;
 
 		for analysis in analysis_tree.get_analyses() {
 			let policy = analysis.1.ok_or(hc_error!(

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -26,6 +26,35 @@ pub struct Target {
 	pub package: Option<Package>,
 }
 
+impl Target {
+	/// git ref of the HEAD commit being analyzed
+	pub fn head(&self) -> String {
+		self.local.git_ref.clone()
+	}
+
+	/// gets the owner if there is a known Github remote repository
+	pub fn owner(&self) -> Option<String> {
+		// Gets the owner if there is a known GitHub remote repository
+		let KnownRemote::GitHub { owner, repo: _ } =
+			&self.remote.as_ref()?.known_remote.as_ref()?;
+		Some(owner.clone())
+	}
+
+	/// name of the repository being analyzed
+	pub fn name(&self) -> String {
+		// In the future may want to augment Target/LocalGitRepo with a
+		// "name" field. For now, treat the dir name of the repo as the name
+		self.local
+			.path
+			.as_path()
+			.file_name()
+			.unwrap()
+			.to_str()
+			.unwrap()
+			.to_owned()
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct VcsUrl {
 	pub remote: RemoteGitRepo,
@@ -160,6 +189,16 @@ pub enum TargetSeedKind {
 pub enum TargetSeed {
 	Single(SingleTargetSeed),
 	Multi(MultiTargetSeed),
+}
+
+impl TargetSeed {
+	/// Return whether the target seed is for multiple targets or not
+	pub fn is_multi_target(&self) -> bool {
+		match self {
+			Self::Single(_) => false,
+			Self::Multi(_) => true,
+		}
+	}
 }
 
 impl Display for SingleTargetSeedKind {

--- a/sdk/schema/hipcheck_target_schema.json
+++ b/sdk/schema/hipcheck_target_schema.json
@@ -7,22 +7,15 @@
     "specifier"
   ],
   "properties": {
+    "specifier": {
+      "description": "The original specifier provided by the user.",
+      "type": "string"
+    },
     "local": {
       "description": "The path to the local repository.",
       "allOf": [
         {
           "$ref": "#/definitions/LocalGitRepo"
-        }
-      ]
-    },
-    "package": {
-      "description": "The package associated with the target, if any.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Package"
-        },
-        {
-          "type": "null"
         }
       ]
     },
@@ -37,12 +30,58 @@
         }
       ]
     },
-    "specifier": {
-      "description": "The original specifier provided by the user.",
-      "type": "string"
+    "package": {
+      "description": "The package associated with the target, if any.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Package"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
+    "LocalGitRepo": {
+      "type": "object",
+      "required": [
+        "git_ref",
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "description": "The path to the repo.",
+          "type": "string"
+        },
+        "git_ref": {
+          "description": "The Git ref we're referring to.",
+          "type": "string"
+        }
+      }
+    },
+    "RemoteGitRepo": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "known_remote": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/KnownRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
     "KnownRemote": {
       "oneOf": [
         {
@@ -71,23 +110,6 @@
         }
       ]
     },
-    "LocalGitRepo": {
-      "type": "object",
-      "required": [
-        "git_ref",
-        "path"
-      ],
-      "properties": {
-        "git_ref": {
-          "description": "The Git ref we're referring to.",
-          "type": "string"
-        },
-        "path": {
-          "description": "The path to the repo.",
-          "type": "string"
-        }
-      }
-    },
     "Package": {
       "type": "object",
       "required": [
@@ -97,6 +119,19 @@
         "version"
       ],
       "properties": {
+        "purl": {
+          "description": "A package url for the package.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "description": "The package name",
+          "type": "string"
+        },
+        "version": {
+          "description": "The package version",
+          "type": "string"
+        },
         "host": {
           "description": "What host the package is from.",
           "allOf": [
@@ -104,19 +139,6 @@
               "$ref": "#/definitions/PackageHost"
             }
           ]
-        },
-        "name": {
-          "description": "The package name",
-          "type": "string"
-        },
-        "purl": {
-          "description": "A package url for the package.",
-          "type": "string",
-          "format": "uri"
-        },
-        "version": {
-          "description": "The package version",
-          "type": "string"
         }
       }
     },
@@ -126,28 +148,6 @@
         "Npm",
         "PyPI"
       ]
-    },
-    "RemoteGitRepo": {
-      "type": "object",
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "known_remote": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/KnownRemote"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Resolves #1068 . Refactors `Session` and supporting code for future implementation of running Hipcheck against multiple targets.

 `Session` no longer contains a `Target` but instead has a `run()` function that takes a `Target` as an argument. When running against multiple `Target`s, we will initialize a base session with policy and configuration information, then clone that `Session` for each `Target` we want to call `session.run()`.

The current code for looping through `Target`s and `Report`s is only a placeholder that allows for unchanged runs against single targets but will be changed in future PRs.