### PR TITLE
feat: python sdk unit testing capabilities

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "logging>=0.4.9.6",
     "pydantic>=2.10.6",
     "pytest>=8.3.5",
+    "pytest-asyncio>=0.26.0",
     "sphinx>=8.1.3",
     "wheel>=0.45.1",
 ]

--- a/sdk/python/src/hipcheck_sdk/__init__.py
+++ b/sdk/python/src/hipcheck_sdk/__init__.py
@@ -2,7 +2,7 @@
 
 from hipcheck_sdk.options import *
 
-from hipcheck_sdk.engine import PluginEngine
+from hipcheck_sdk.engine import PluginEngine, MockResponses
 from hipcheck_sdk.server import Plugin, PluginServer
 from hipcheck_sdk.query import query, Endpoint
 from hipcheck_sdk.cli import get_parser_for, run_server_for

--- a/sdk/python/src/hipcheck_sdk/options.py
+++ b/sdk/python/src/hipcheck_sdk/options.py
@@ -13,7 +13,6 @@ class SdkOptions:
     """
 
     rfd9_compat: bool = True
-    mock_engine: bool = False
 
 
 _options = SdkOptions()

--- a/sdk/python/src/hipcheck_sdk/server.py
+++ b/sdk/python/src/hipcheck_sdk/server.py
@@ -225,14 +225,17 @@ class PluginServer(gen.PluginServiceServicer):
         """
         self.plugin = plugin
 
-    def register(plugin: Plugin, log_level="error"):
+    def register(plugin: Plugin, log_level="error", init_logger=True):
         """
         Set the server to use `plugin` as its implementation
 
         :param Plugin plugin: The plugin instance with which to run
+        :param str log_level: A string indicating the minimum logging level to emit
+        :param bool init_logger: If True, init the standard plugin logger that emits a custom JSON format over stderr to Hipcheck core.
         """
         plugin_server = PluginServer(plugin)
-        plugin_server.init_logger(log_level)
+        if init_logger:
+            plugin_server.init_logger(log_level)
         return plugin_server
 
     def init_logger(self, log_level_str=str):

--- a/sdk/python/src/hipcheck_sdk/server.py
+++ b/sdk/python/src/hipcheck_sdk/server.py
@@ -243,9 +243,9 @@ class PluginServer(gen.PluginServiceServicer):
         """
         # set output format
         log_format = (
-            "{\"target\": \""
+            '{"target": "'
             + self.plugin.name
-            + "\", \"level\": \"%(levelname)s\", \"fields\": { \"message\": \"%(message)s\" } }"
+            + '", "level": "%(levelname)s", "fields": { "message": "%(message)s" } }'
         )
         logging.basicConfig(format=log_format, level=logging.ERROR)
 

--- a/sdk/python/tests/context.py
+++ b/sdk/python/tests/context.py
@@ -6,14 +6,6 @@ from hipcheck_sdk import *
 
 
 @fixture
-def options_enable_mock_responses():
-    opts_before = get_options()
-    set_option("mock_engine", True)
-    yield
-    set_options(opts_before)
-
-
-@fixture
 def options_disable_rfd9_compat():
     opts_before = get_options()
     set_option("rfd9_compat", False)

--- a/sdk/python/tests/example-plugin/local-plugin.kdl
+++ b/sdk/python/tests/example-plugin/local-plugin.kdl
@@ -4,8 +4,8 @@ version "0.0.0"
 license "Apache-2.0"
 
 entrypoint {
-  on arch="aarch64-apple-darwin" "uv run --project sdk/python sdk/python/tests/example-plugin/main.py"
-  on arch="x86_64-apple-darwin" "uv run --project sdk/python sdk/python/tests/example-plugin/main.py"
-  on arch="x86_64-unknown-linux-gnu" "uv run --project sdk/python sdk/python/tests/example-plugin/main.py"
-  on arch="x86_64-pc-windows-msvc" "uv run --project sdk/python sdk/python/tests/example-plugin/main.py"
+  on arch="aarch64-apple-darwin" "uv run --project sdk/python sdk/python/tests/example-plugin/test_main.py"
+  on arch="x86_64-apple-darwin" "uv run --project sdk/python sdk/python/tests/example-plugin/test_main.py"
+  on arch="x86_64-unknown-linux-gnu" "uv run --project sdk/python sdk/python/tests/example-plugin/test_main.py"
+  on arch="x86_64-pc-windows-msvc" "uv run --project sdk/python sdk/python/tests/example-plugin/test_main.py"
 }

--- a/sdk/python/tests/example-plugin/test_main.py
+++ b/sdk/python/tests/example-plugin/test_main.py
@@ -4,11 +4,20 @@ import asyncio
 import argparse
 import os
 import logging
+import pytest
 
 from typing import Optional
 
 from hipcheck_sdk.error import *
-from hipcheck_sdk import PluginEngine, Plugin, query, run_server_for, Target
+from hipcheck_sdk import (
+    PluginEngine,
+    Plugin,
+    query,
+    run_server_for,
+    Target,
+    LocalGitRepo,
+    MockResponses,
+)
 
 DETECTOR = None
 
@@ -77,3 +86,40 @@ class ExamplePlugin(Plugin):
 
 if __name__ == "__main__":
     run_server_for(ExamplePlugin())
+
+
+@pytest.mark.asyncio
+async def test_endpoint():
+    t = Target(
+        local=LocalGitRepo(git_ref="", path="this/is/a/file/path"),
+        specifier="this/is/a/file/path",
+    )
+
+    t2 = Target(
+        local=LocalGitRepo(git_ref="", path="this/is/a/file/path"),
+        specifier="this/is/a/file/path",
+    )
+
+    # Ensure that our matching logic in `mock_engine` handling will work
+    assert t == t2
+
+    mock_responses: MockResponses = [
+        (("dummy/sha256/sha256", [1]), [0xBE]),
+        (("dummy/sha256/sha256", t), None),
+    ]
+    engine = PluginEngine.mock(mock_responses)
+
+    res = await dummy_rand_data(engine, 8)
+    assert res == 0xBE
+
+    # Demonstrate that an empty `mock()` call will still use an empty list
+    # If not we would get a networking related error
+    engine = PluginEngine.mock()
+    try:
+        res = await dummy_rand_data(engine, 8)
+        assert False
+    except UnknownPluginQuery:
+        pass
+
+    res = await take_target(engine, t)
+    assert res == 19

--- a/sdk/python/tests/test_mock_responses.py
+++ b/sdk/python/tests/test_mock_responses.py
@@ -6,12 +6,10 @@ import asyncio
 from hipcheck_sdk import *
 from hipcheck_sdk.error import UnknownPluginQuery
 
-from context import *
 
-
-def test_mock_responses(options_enable_mock_responses):
+def test_mock_responses():
     expected = 2
-    engine = PluginEngine.mock({("mitre/example/nondefault", 1): expected})
+    engine = PluginEngine.mock([(("mitre/example/nondefault", 1), expected)])
     try:
         res = asyncio.run(engine.query("mitre/example", 1))
         assert false
@@ -27,7 +25,11 @@ def test_mock_responses(options_enable_mock_responses):
     assert res == expected
 
     engine = PluginEngine.mock(
-        {("mitre/example", 1): 1, ("mitre/example", 2): 2, ("mitre/example", 3): 3}
+        [
+            (("mitre/example", 1), 1),
+            (("mitre/example", 2), 2),
+            (("mitre/example", 3), 3),
+        ]
     )
 
     async def run(engine):

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -390,6 +390,7 @@ dependencies = [
     { name = "logging" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "wheel" },
@@ -405,6 +406,7 @@ requires-dist = [
     { name = "logging", specifier = ">=0.4.9.6" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "wheel", specifier = ">=0.45.1" },
 ]
@@ -702,6 +704,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Removed the `mock_engine` SDK option, the `PluginEngine` now just checks if `mock_responses is not None` to decide whether to do mocked response.
- Added example query endpoint unit test to `main.py`, renamed `test_main.py` to make it easy for `pytest` to find
- Refactored `mock_responses` from a dict to a `list[tuple]`, because types we envision to be common query keys (object, dict, list) are not hashable by default. Now PluginEngine uses `find_response` function to get the right output object or return None.
- added default-True `init_logger` parameter to `PluginServer.register()` so people can init their own logger if they wish.
- Added section to Python SDK docs on website explaining how to write unit tests for query endpoint funcs