### PR TITLE
feat: added first iteration of `cargo xtask benchmark`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "clap",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "jiff",
+ "jiff 0.1.16",
  "serde",
  "serde_json",
  "tokio",
@@ -206,7 +206,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -710,6 +710,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cyclonedx-bom"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +762,7 @@ checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -765,7 +786,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -776,7 +797,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -818,7 +839,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -874,7 +895,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1142,7 +1163,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1250,7 +1271,7 @@ dependencies = [
  "gix",
  "hipcheck-sdk",
  "hipcheck-workspace-hack",
- "jiff",
+ "jiff 0.1.16",
  "lru",
  "schemars",
  "serde",
@@ -1459,7 +1480,7 @@ checksum = "c57c477b645ee248b173bb1176b52dd528872f12c50375801a58aaf5ae91113f"
 dependencies = [
  "bstr",
  "itoa",
- "jiff",
+ "jiff 0.1.16",
  "thiserror 2.0.12",
 ]
 
@@ -2175,7 +2196,7 @@ dependencies = [
  "indextree",
  "indicatif",
  "itertools 0.13.0",
- "jiff",
+ "jiff 0.1.16",
  "log",
  "logos",
  "miette 7.4.0",
@@ -2250,7 +2271,7 @@ dependencies = [
  "hipcheck-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2263,7 +2284,7 @@ dependencies = [
  "hipcheck-sdk-macros",
  "hipcheck-workspace-hack",
  "indexmap 2.7.1",
- "jiff",
+ "jiff 0.1.16",
  "lazy_static",
  "schemars",
  "serde",
@@ -2286,7 +2307,7 @@ dependencies = [
  "hipcheck-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tracing",
 ]
 
@@ -2315,7 +2336,7 @@ dependencies = [
  "idna",
  "indexmap 2.7.1",
  "itertools 0.13.0",
- "jiff",
+ "jiff 0.1.16",
  "libc",
  "libz-sys",
  "linux-raw-sys",
@@ -2336,7 +2357,7 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tokio",
  "tokio-stream",
  "tracing-core",
@@ -2610,7 +2631,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2706,7 +2727,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.26.3",
- "syn 2.0.96",
+ "syn 2.0.100",
  "thiserror 1.0.69",
 ]
 
@@ -2781,16 +2802,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-tzdb"
-version = "0.1.1"
+name = "jiff"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
 ]
@@ -3002,7 +3047,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.8.5",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3086,7 +3131,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3144,7 +3189,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3155,7 +3200,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3570,7 +3615,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3593,9 +3638,18 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3616,7 +3670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3638,7 +3692,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3687,7 +3741,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tempfile",
 ]
 
@@ -3701,7 +3755,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4084,7 +4138,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -4130,7 +4184,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4194,7 +4248,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4205,7 +4259,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4238,7 +4292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4268,7 +4322,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4370,7 +4424,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4486,7 +4540,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4499,7 +4553,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4542,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4565,7 +4619,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4588,7 +4642,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4645,7 +4699,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4684,7 +4738,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4695,7 +4749,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4789,7 +4843,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4890,7 +4944,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4958,7 +5012,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5040,7 +5094,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.96",
+ "syn 2.0.100",
  "thiserror 2.0.12",
  "unicode-ident",
 ]
@@ -5058,7 +5112,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.96",
+ "syn 2.0.100",
  "typify-impl",
 ]
 
@@ -5307,7 +5361,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -5329,7 +5383,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5454,7 +5508,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5465,7 +5519,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5726,10 +5780,12 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "convert_case",
+ "csv",
  "env_logger",
  "glob",
  "hipcheck-workspace-hack",
  "itertools 0.14.0",
+ "jiff 0.2.5",
  "kdl 4.7.1",
  "log",
  "pathbuf",
@@ -5776,7 +5832,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5806,7 +5862,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5817,7 +5873,7 @@ checksum = "76331675d372f91bf8d17e13afbd5fe639200b73d01f0fc748bb059f9cca2db7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5837,7 +5893,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5858,7 +5914,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5880,7 +5936,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/config/benchmark-targets.kdl
+++ b/config/benchmark-targets.kdl
@@ -1,0 +1,10 @@
+targets {
+    // NOTE: the parser of this file expects the following order repo url=<> ref=<> type=<>
+    // git repository with about 700 commits
+    repo url="https://github.com/mitre/hipcheck" ref="hipcheck-v3.11.0" type="repo"
+    // popular Python repo with approximately 3000 commits
+    repo url="jinja2" ref="3.1.6" type="pypi"
+    // popular NPM package with approximately 6000 commits as of v5.0.0
+    repo url="express" ref="v5.0.0" type="npm"
+}
+

--- a/library/hipcheck-workspace-hack/Cargo.toml
+++ b/library/hipcheck-workspace-hack/Cargo.toml
@@ -97,7 +97,7 @@ semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["alloc", "derive", "rc"] }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "union", "write"] }
-syn = { version = "2.0.96", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn = { version = "2.0.100", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 tokio = { version = "1.44.1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tracing-core = { version = "0.1.32" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -44,3 +44,5 @@ rustls = { version = "0.23.10", default-features = false, features = [
 rustls-platform-verifier = "0.5.0"
 itertools = "0.14.0"
 hipcheck-workspace-hack = { version = "0.1", path = "../library/hipcheck-workspace-hack" }
+csv = "1.3.1"
+jiff = { version = "0.2.5", default-features = false, features = ["alloc", "serde", "std"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ use clap::{
 };
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use std::{fmt::Display, process::ExitCode};
+use task::benchmark::BenchmarkArgs;
 
 fn main() -> ExitCode {
 	let args = Args::parse();
@@ -35,6 +36,7 @@ fn main() -> ExitCode {
 			SiteCommand::Serve(args) => task::site::serve::run(args),
 		},
 		Commands::Manifest => task::manifest::run(),
+		Commands::Benchmark(args) => task::benchmark::run(args),
 	};
 
 	match result {
@@ -98,6 +100,8 @@ enum Commands {
 	Rfd(RfdArgs),
 	/// Work with the Hipcheck website.
 	Site(SiteArgs),
+	/// Run benchmark suite (currently x86_linux only)
+	Benchmark(BenchmarkArgs),
 }
 
 #[derive(Debug, clap::Args)]
@@ -139,7 +143,7 @@ impl Display for BuildProfile {
 }
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
-enum BuildPkg {
+pub enum BuildPkg {
 	/// Rebuild the whole workspace.
 	#[default]
 	All,

--- a/xtask/src/task/benchmark/linux/config.rs
+++ b/xtask/src/task/benchmark/linux/config.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::{fmt::Display, fs::File, io::Read, path::Path, str::FromStr};
+
+use anyhow::anyhow;
+use kdl::KdlDocument;
+use serde::{Deserialize, Serialize};
+
+use crate::task::manifest::ParseKdlNode;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BenchmarkTargetType {
+	/// plain git repository
+	Repo,
+	/// Python package repository
+	PyPI,
+	/// Java package repository
+	Maven,
+	/// NodeJS package repository
+	#[allow(clippy::upper_case_acronyms)]
+	NPM,
+}
+
+impl Display for BenchmarkTargetType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			BenchmarkTargetType::Repo => write!(f, "repo"),
+			BenchmarkTargetType::PyPI => write!(f, "pypi"),
+			BenchmarkTargetType::Maven => write!(f, "maven"),
+			BenchmarkTargetType::NPM => write!(f, "npm"),
+		}
+	}
+}
+
+impl FromStr for BenchmarkTargetType {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s.to_lowercase().trim() {
+			"repo" => Ok(Self::Repo),
+			"pypi" => Ok(Self::PyPI),
+			"maven" => Ok(Self::Maven),
+			"npm" => Ok(Self::NPM),
+			_ => Err(anyhow!("{} is not a valid BenchmarkTargetType", s)),
+		}
+	}
+}
+
+pub struct BenchmarkTargets(pub Vec<BenchmarkTarget>);
+
+impl BenchmarkTargets {
+	pub fn from_file(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+		let mut contents = String::new();
+		File::open(path)?.read_to_string(&mut contents)?;
+		let targets = Self::from_str(&contents)?;
+		Ok(targets)
+	}
+}
+
+impl FromStr for BenchmarkTargets {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let document =
+			KdlDocument::from_str(s).map_err(|e| anyhow!("Error parsing as KDL: {}", e))?;
+
+		let mut targets = vec![];
+		for node in document
+			.nodes()
+			.first()
+			.ok_or(anyhow!("missing 'targets' keyword"))?
+			.children()
+			.ok_or(anyhow!("no children found for 'targets'"))?
+			.nodes()
+		{
+			let target = BenchmarkTarget::parse_node(node)
+				.ok_or(anyhow!("Error parsing node as BenchmarkTarget"))?;
+			targets.push(target);
+		}
+		Ok(Self(targets))
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct BenchmarkTarget {
+	target_type: BenchmarkTargetType,
+	url: String,
+	reference: String,
+}
+
+impl BenchmarkTarget {
+	pub fn target_type(&self) -> BenchmarkTargetType {
+		self.target_type
+	}
+
+	pub fn url(&self) -> &str {
+		&self.url
+	}
+
+	pub fn reference(&self) -> &str {
+		&self.reference
+	}
+}
+
+impl ParseKdlNode for BenchmarkTarget {
+	fn kdl_key() -> &'static str {
+		"repo"
+	}
+
+	fn parse_node(node: &kdl::KdlNode) -> Option<Self> {
+		if node.name().to_string().as_str() != Self::kdl_key() {
+			return None;
+		}
+		let url = node.entries().first()?.value().as_string()?.to_string();
+		let reference = node.entries().get(1)?.value().as_string()?.to_string();
+		let target_type =
+			BenchmarkTargetType::from_str(node.entries().get(2)?.value().as_string()?).ok()?;
+		let benchmark_target = Self {
+			target_type,
+			url,
+			reference,
+		};
+		Some(benchmark_target)
+	}
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod test {
+	use std::str::FromStr;
+
+	use super::BenchmarkTargets;
+
+	#[test]
+	fn ensure_target_kdl_is_valid() {
+		let contents = include_str!("../../../../../config/benchmark-targets.kdl");
+		BenchmarkTargets::from_str(contents).unwrap();
+	}
+}

--- a/xtask/src/task/benchmark/linux/mod.rs
+++ b/xtask/src/task/benchmark/linux/mod.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::{
+	fs::File,
+	io::Read,
+	num::NonZeroUsize,
+	path::Path,
+	process::{Command, Stdio},
+	str::FromStr,
+};
+
+use anyhow::{anyhow, Context, Result};
+use config::{BenchmarkTarget, BenchmarkTargets};
+use results::{
+	AvgCpuCycles, AvgMaxRssKb, AvgTotalInstructions, AvgWallTimeResult, BenchmarkResult,
+	BenchmarkStats, FromBenchmarkResult,
+};
+use which::which;
+
+use crate::workspace::root;
+use crate::{BuildPkg, BuildProfile};
+
+use crate::BenchmarkArgs;
+
+mod config;
+mod results;
+
+/// binaries required to run the benchmarks
+///
+/// - `perf` is used to record cpu statistics (cycles, instructions)
+/// - `/usr/bin/time` is used to record max RAM usage via maximum RSS and wall time
+const REQUIRED_BINARIES: [&str; 2] = ["perf", "/usr/bin/time"];
+
+fn check_preconditions() -> Result<()> {
+	for binary in REQUIRED_BINARIES {
+		which(binary).context(format!("could not find '{}'", binary))?;
+	}
+	// verify /proc/sys/kernel/perf_event_paranoid is set to a level that will allow tracing of
+	// perf events
+	let mut contents = String::new();
+	File::open("/proc/sys/kernel/perf_event_paranoid")?.read_to_string(&mut contents)?;
+	let perf_event_level = i32::from_str(contents.trim())?;
+	if perf_event_level > 2 {
+		return Err(anyhow!("/proc/sys/kernel/perf_event_paranoid greater than 2; 'sudo sysctl -w kernel.perf_event_paranoid=2' to fix"));
+	}
+	Ok(())
+}
+
+pub fn run(args: BenchmarkArgs) -> Result<()> {
+	check_preconditions()?;
+	let targets = BenchmarkTargets::from_file(args.config.as_path())?;
+	// build release versions of everything
+	crate::task::build::run(crate::BuildArgs {
+		profile: BuildProfile::Release,
+		pkg: vec![BuildPkg::All],
+		timings: false,
+	})?;
+	run_benchmark_suite(targets, args.runs, &args.output_dir)
+}
+
+/// Use existing `xshell::Shell` to run `buf lint`
+fn run_benchmark_suite(
+	targets: BenchmarkTargets,
+	runs_per_target: NonZeroUsize,
+	output_dir: &Path,
+) -> Result<()> {
+	let total_benchmarks = targets.0.len();
+	let mut results = Vec::with_capacity(targets.0.len());
+	for (idx, target) in targets.0.into_iter().enumerate() {
+		eprintln!("Starting Benchmark [{} of {}]", idx + 1, total_benchmarks);
+		let result = benchmark_target(target, runs_per_target)?;
+		eprintln!(
+			"Benchmark Result [{} of {}]: {:?}",
+			idx + 1,
+			total_benchmarks,
+			result
+		);
+		results.push(result);
+	}
+
+	std::fs::create_dir_all(output_dir)?;
+
+	// write each of the metrics to a file
+	results
+		.iter()
+		.try_for_each(|res| AvgCpuCycles::from_benchmark_result(res).write_to_file(output_dir))?;
+	results.iter().try_for_each(|res| {
+		AvgTotalInstructions::from_benchmark_result(res).write_to_file(output_dir)
+	})?;
+	results.iter().try_for_each(|res| {
+		AvgWallTimeResult::from_benchmark_result(res).write_to_file(output_dir)
+	})?;
+	results
+		.iter()
+		.try_for_each(|res| AvgMaxRssKb::from_benchmark_result(res).write_to_file(output_dir))?;
+
+	eprintln!("Wrote results to {:?}", output_dir);
+	Ok(())
+}
+
+// Run `runs` number of benchmarks for a target repo and gather the results
+fn benchmark_target(
+	target: BenchmarkTarget,
+	runs: NonZeroUsize,
+) -> anyhow::Result<BenchmarkResult> {
+	let mut results = Vec::with_capacity(runs.into());
+	for run in 1..(usize::from(runs)) + 1 {
+		eprintln!(
+			"Beginning run {run} of {runs} for {} reference: {}",
+			target.url(),
+			target.reference()
+		);
+		let result = benchmark_single_target(target.clone())?;
+		results.push(result);
+	}
+	let mut stats = results
+		.iter()
+		.fold(BenchmarkStats::default(), |mut total, indiv| {
+			total.cpu_cycles += indiv.cpu_cycles;
+			total.instructions += indiv.instructions;
+			total.max_rss += indiv.max_rss;
+			total.wall_time += indiv.wall_time;
+			total
+		});
+	stats.instructions /= results.len() as u64;
+	stats.cpu_cycles /= results.len() as u64;
+	stats.max_rss /= results.len() as u64;
+	stats.wall_time /= results.len() as f32;
+	let result = BenchmarkResult::new(target.clone(), stats);
+	Ok(result)
+}
+
+// NOTE: this function intentionally takes a mandatory reference to ensure benchmarks are able
+// to be compared
+fn benchmark_single_target(target: BenchmarkTarget) -> Result<BenchmarkStats> {
+	let target_type = target.target_type().to_string();
+	let args = vec![
+		"-v",
+		"perf",
+		"stat",
+		"--summary",
+		"./target/release/hc",
+		"check",
+		"--policy",
+		"./config/local.release.Hipcheck.kdl",
+		"--target",
+		target_type.as_str(),
+		"--ref",
+		target.reference(),
+		target.url(),
+	];
+	let process = Command::new("/usr/bin/time")
+		.current_dir(root()?)
+		.args(args)
+		// the output needed for parsing benchmark results is output to stderr
+		.stdout(Stdio::null())
+		.stderr(Stdio::piped())
+		.spawn()?;
+
+	// just capture the result, do nothing with it inside active counters to avoid inclusion in
+	// measurment
+	let result = process.wait_with_output();
+
+	let output = match result {
+		Ok(output) => {
+			if !output.status.success() {
+				return Err(anyhow!("hc check did not exit successfully"));
+			}
+			output
+		}
+		Err(e) => return Err(anyhow!("hc errored out: {e}")),
+	};
+
+	BenchmarkStats::parse_benchmark_result_stderr(&String::from_utf8_lossy(&output.stderr))
+}

--- a/xtask/src/task/benchmark/linux/results.rs
+++ b/xtask/src/task/benchmark/linux/results.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Seek;
+use std::path::Path;
+
+use anyhow::anyhow;
+use jiff::{Unit, Zoned};
+use serde::Serialize;
+
+use super::config::{BenchmarkTarget, BenchmarkTargetType};
+
+pub trait FromBenchmarkResult {
+	const OUTPUT_FILE: &'static str;
+	fn from_benchmark_result(result: &BenchmarkResult) -> Self;
+	fn write_to_file(&self, output_dir: &Path) -> anyhow::Result<()>;
+}
+
+macro_rules! SingleBenchmarkResult {
+	($struct_name:ident, $benchmark_result_field_name: ident, $result_type:ty, $output_file: expr) => {
+		#[derive(serde::Serialize, Debug)]
+		pub struct $struct_name {
+			/// repo type being analyzed, passed as `-t` to `hc check`
+			target_type: BenchmarkTargetType,
+			/// target passed to `hc check`
+			target: String,
+			/// reference identifier for the target, passed as `--ref` to `hc check`
+			reference: String,
+			/// time of the benchmark was created
+			record_time: Zoned,
+			/// metric being recorded in this struct
+			$benchmark_result_field_name: $result_type,
+		}
+
+		impl FromBenchmarkResult for $struct_name {
+			const OUTPUT_FILE: &'static str = $output_file;
+
+			fn from_benchmark_result(result: &BenchmarkResult) -> Self {
+				Self {
+					target_type: result.target_type,
+					target: result.target.clone(),
+					reference: result.reference.clone(),
+					record_time: result.record_time.clone(),
+					$benchmark_result_field_name: result.$benchmark_result_field_name,
+				}
+			}
+
+			fn write_to_file(&self, output_dir: &Path) -> anyhow::Result<()> {
+				let mut file = std::fs::OpenOptions::new()
+					.read(true)
+					.append(true)
+					.create(true)
+					.open(output_dir.join(Self::OUTPUT_FILE))?;
+
+				let mut reader = csv::ReaderBuilder::new().from_reader(&file);
+				if reader.records().count() == 0 {
+					file.seek(std::io::SeekFrom::Start(0))?;
+					let mut header_writer = csv::WriterBuilder::new().from_writer(&file);
+					let headers = csv::StringRecord::from(vec![
+						"target_type",
+						"target",
+						"reference",
+						"record_time",
+						stringify!($benchmark_result_field_name),
+					]);
+					header_writer.write_record(&headers)?;
+					header_writer.flush()?;
+				}
+				let mut writer = csv::WriterBuilder::new()
+					.has_headers(false)
+					.from_writer(file);
+				writer.serialize(&self)?;
+				writer.flush()?;
+				Ok(())
+			}
+		}
+	};
+}
+
+// create wrappers for each of the metrics being tracked to make it easier to write
+// each metric to its own file
+SingleBenchmarkResult!(
+	AvgWallTimeResult,
+	avg_wall_time,
+	f32,
+	"average_wall_time.csv"
+);
+SingleBenchmarkResult!(
+	AvgMaxRssKb,
+	avg_max_rss_in_kb,
+	u64,
+	"average_max_rss_in_kb.csv"
+);
+SingleBenchmarkResult!(
+	AvgTotalInstructions,
+	avg_total_instructions,
+	u64,
+	"average_total_instructions.csv"
+);
+SingleBenchmarkResult!(AvgCpuCycles, avg_cpu_cycles, u64, "average_cpu_cycles.csv");
+
+#[derive(Debug)]
+pub struct BenchmarkResult {
+	/// repo type being analyzed, passed as `-t` to `hc check`
+	target_type: BenchmarkTargetType,
+	/// target passed to `hc check`
+	target: String,
+	/// reference identifier for the target, passed as `--ref` to `hc check`
+	reference: String,
+	/// time of the benchmark was created
+	record_time: Zoned,
+	/// average wall time across all runs
+	avg_wall_time: f32,
+	/// average max RSS across all runs
+	avg_max_rss_in_kb: u64,
+	/// average total instructions across all runs
+	avg_total_instructions: u64,
+	/// average total number of cpu cycles across all runs
+	avg_cpu_cycles: u64,
+}
+
+impl BenchmarkResult {
+	pub fn new(target: BenchmarkTarget, stats: BenchmarkStats) -> Self {
+		Self {
+			target_type: target.target_type(),
+			target: target.url().to_string(),
+			reference: target.reference().to_string(),
+			record_time: Zoned::now().round(Unit::Second).unwrap(),
+			avg_wall_time: stats.wall_time,
+			avg_total_instructions: stats.instructions,
+			avg_cpu_cycles: stats.cpu_cycles,
+			avg_max_rss_in_kb: stats.max_rss,
+		}
+	}
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct BenchmarkStats {
+	/// how long the test took
+	pub wall_time: f32,
+	/// number of instructions executed during benchmark run
+	pub instructions: u64,
+	/// number of CPU cycles used during benchmark run
+	pub cpu_cycles: u64,
+	/// peak memory usage during benchmark run (in KB)
+	pub max_rss: u64,
+}
+
+impl BenchmarkStats {
+	pub fn parse_benchmark_result_stderr(stderr: &str) -> anyhow::Result<Self> {
+		let result = BenchmarkStatsParser::new()
+			.parse_wall_time(stderr)
+			.ok_or(anyhow!("Unable to parse wall time"))?
+			.parse_instructions(stderr)
+			.ok_or(anyhow!("Unable to parse number of instructions"))?
+			.parse_cpu_cycles(stderr)
+			.ok_or(anyhow!("Unable to parse CPU cycles"))?
+			.parse_max_rss(stderr)
+			.ok_or(anyhow!("Unable to parse max RSS"))?
+			.build()
+			.ok_or(anyhow!("Unable to determine overall result"))?;
+		Ok(result)
+	}
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+/// structure for parsing stderr from benchmark results and capturing statistics
+pub struct BenchmarkStatsParser {
+	wall_time: Option<f32>,
+	instructions: Option<u64>,
+	cpu_cycles: Option<u64>,
+	max_rss: Option<u64>,
+}
+
+impl BenchmarkStatsParser {
+	fn new() -> Self {
+		Self::default()
+	}
+
+	fn parse_wall_time(mut self, stderr: &str) -> Option<Self> {
+		let amount_of_time = stderr
+			.lines()
+			.find(|line| line.contains("seconds time elapsed"))?
+			.split_whitespace()
+			.next()?;
+		self.wall_time = Some(amount_of_time.parse().ok()?);
+		Some(self)
+	}
+
+	fn parse_instructions(mut self, stderr: &str) -> Option<Self> {
+		let instructions = stderr
+			.lines()
+			.find(|line| line.contains("instructions") && line.contains("insn per cycle"))?
+			.split_whitespace()
+			.next()?;
+		self.instructions = Some(instructions.parse().ok()?);
+		Some(self)
+	}
+
+	fn parse_cpu_cycles(mut self, stderr: &str) -> Option<Self> {
+		let cycles = stderr
+			.lines()
+			.find(|line| line.contains("cycles") && line.contains("GHz"))?
+			.split_whitespace()
+			.next()?;
+		self.cpu_cycles = Some(cycles.parse().ok()?);
+		Some(self)
+	}
+
+	fn parse_max_rss(mut self, stderr: &str) -> Option<Self> {
+		let max_rss = stderr
+			.lines()
+			.find(|line| line.contains("Maximum resident set size (kbytes)"))?
+			.split_whitespace()
+			.last()?;
+		self.max_rss = Some(max_rss.parse().ok()?);
+		Some(self)
+	}
+
+	fn build(self) -> Option<BenchmarkStats> {
+		Some(BenchmarkStats {
+			wall_time: self.wall_time?,
+			instructions: self.instructions?,
+			cpu_cycles: self.cpu_cycles?,
+			max_rss: self.max_rss?,
+		})
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	const TEST_OUTPUT: &str = r#"Performance counter stats for './target/release/hc check --policy ./config/local.release.Hipcheck.kdl https://github.com/mitre/hipcheck':
+
+           6919.11 msec task-clock                       #    0.586 CPUs utilized
+             36030      context-switches                 #    5.207 K/sec
+               338      cpu-migrations                   #   48.850 /sec
+            323800      page-faults                      #   46.798 K/sec
+       27295917202      cycles                           #    3.945 GHz
+       37840778595      instructions                     #    1.39  insn per cycle
+        7383582407      branches                         #    1.067 G/sec
+         258357252      branch-misses                    #    3.50% of all branches
+
+      11.339844280 seconds time elapsed
+
+       0.985113000 seconds user
+       0.406738000 seconds sys
+
+
+        Command being timed: "perf stat --summary ./target/release/hc check --policy ./config/local.release.Hipcheck.kdl https://github.com/mitre/hipcheck"
+        User time (seconds): 0.98
+        System time (seconds): 0.41
+        Percent of CPU this job got: 11%
+        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:11.82
+        Average shared text size (kbytes): 0
+        Average unshared data size (kbytes): 0
+        Average stack size (kbytes): 0
+        Average total size (kbytes): 0
+        Maximum resident set size (kbytes): 246904
+        Average resident set size (kbytes): 0
+        Major (requiring I/O) page faults: 0
+        Minor (reclaiming a frame) page faults: 134964
+        Voluntary context switches: 13760
+        Involuntary context switches: 18
+        Swaps: 0
+        File system inputs: 656
+        File system outputs: 220192
+        Socket messages sent: 0
+        Socket messages received: 0
+        Signals delivered: 0
+        Page size (bytes): 4096
+        Exit status: 0"#;
+
+	#[test]
+	fn test_parse_wall_time() {
+		let builder = BenchmarkStatsParser::new()
+			.parse_wall_time(TEST_OUTPUT)
+			.unwrap();
+		assert_eq!(builder.wall_time, Some(11.339_845));
+	}
+
+	#[test]
+	fn test_parse_instructions() {
+		let builder = BenchmarkStatsParser::new()
+			.parse_instructions(TEST_OUTPUT)
+			.unwrap();
+		assert_eq!(builder.instructions, Some(37840778595));
+	}
+
+	#[test]
+	fn test_parse_cpu_cycles() {
+		let builder = BenchmarkStatsParser::new()
+			.parse_cpu_cycles(TEST_OUTPUT)
+			.unwrap();
+		assert_eq!(builder.cpu_cycles, Some(27295917202));
+	}
+
+	#[test]
+	fn test_parse_max_rss() {
+		let builder = BenchmarkStatsParser::new()
+			.parse_max_rss(TEST_OUTPUT)
+			.unwrap();
+		assert_eq!(builder.max_rss, Some(246904));
+	}
+}

--- a/xtask/src/task/benchmark/mod.rs
+++ b/xtask/src/task/benchmark/mod.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{num::NonZeroUsize, path::PathBuf};
+
+#[cfg(not(target_os = "linux"))]
+mod non_linux {
+	use super::BenchmarkArgs;
+	use anyhow::Result;
+
+	pub fn run(_args: BenchmarkArgs) -> Result<()> {
+		panic!("benchmark is currently only available on Linux")
+	}
+}
+
+#[cfg(not(target_os = "linux"))]
+pub use non_linux::run;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::run;
+
+#[derive(Debug, clap::Args)]
+pub struct BenchmarkArgs {
+	/// number of runs to perform for each benchmark target
+	#[arg(long = "runs", short = 'r', default_value_t = NonZeroUsize::new(3).unwrap())]
+	runs: NonZeroUsize,
+	/// path to file contain configuration for running benchmarks
+	#[arg(long = "config", short = 'c')]
+	config: PathBuf,
+	/// path to directory to write results should be written, results will be appended to a CSV
+	/// file per metric
+	#[arg(long = "output", short = 'o')]
+	output_dir: PathBuf,
+}

--- a/xtask/src/task/manifest/mod.rs
+++ b/xtask/src/task/manifest/mod.rs
@@ -11,6 +11,9 @@ use download_manifest::DownloadManifestEntry;
 use anyhow::Result;
 use std::collections::HashSet;
 
+#[allow(unused)]
+pub use kdl::ParseKdlNode;
+
 pub fn run() -> Result<()> {
 	let api_token = std::env::var("HC_GITHUB_TOKEN")?;
 	let releases = remote::get_hipcheck_plugin_releases(&api_token)?;

--- a/xtask/src/task/mod.rs
+++ b/xtask/src/task/mod.rs
@@ -2,6 +2,7 @@
 
 //! Commands supported by 'xtask'
 
+pub mod benchmark;
 pub mod buf;
 pub mod build;
 pub mod changelog;


### PR DESCRIPTION
This PR contains a first pass at implementing `cargo xtask benchmark`

I added a config file to the repository `./config/benchmark-targets.kdl` that contains three different repositories for benchmarking. I am very open to changing these repositories, but they serve as an example of how configuring benchmark gathering works! Each benchmark target currently requires a `ref` in order to make it easier to draw conclusions from benchmark run, as the targets should be constant across benchmark runs!

## Current Process

1. Ensure prerequisites are installed and `/proc/sys/kernel/perf_event_paranoid` (contains 2 or less)
2. Read config file and parse it to determine all benchmark targets
3. Build the release version of all binaries in the repo
4. Run `-r/--runs` number of benchmark runs for each benchmark targets and save off results
5. Serialize results to user-defined CSV file upon completion

## Data Points Captured 

```rust
#[derive(Serialize, Debug)]
pub struct BenchmarkResult {
	/// repo type being analyzed, passed as `-t` to `hc check`
	target_type: BenchmarkTargetType,
	/// target passed to `hc check`
	target: String,
	/// reference identifier for the target, passed as `--ref` to `hc check`
	reference: String,
	/// average wall time across all runs
	avg_wall_time: f32,
	/// average max RSS across all runs
	avg_max_rss_in_kb: u64,
	/// average total instructions across all runs
	avg_total_instructions: u64,
	/// average total number of cpu cycles across all runs
	avg_cpu_cycles: u64,
}
```

## Example Terminal Output

![image](https://github.com/user-attachments/assets/4ec1ef48-7e28-4a52-a512-f57dfea6d062)

## Example CSV

![image](https://github.com/user-attachments/assets/54622586-0451-4d65-8435-21263db2106e)

This is still accurate, except the target_types are all lowercase now!

## Final Notes

`cargo xtask benchmark` currently only works on Linux

