### PR TITLE
feat: Add async target analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +602,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1019,6 +1062,27 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2173,6 +2237,8 @@ name = "hipcheck"
 version = "3.12.0"
 dependencies = [
  "anyhow",
+ "async-channel",
+ "async-stream",
  "base64 0.22.1",
  "blake3",
  "chrono",
@@ -3511,6 +3577,12 @@ dependencies = [
  "fnv",
  "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -32,6 +32,8 @@ benchmarking = []
 
 [dependencies]
 
+async-channel = "2.3.1"
+async-stream = "0.3.6"
 base64 = "0.22.1"
 blake3 = "1.8.1"
 cyclonedx-bom = "0.8.0"

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -159,7 +159,7 @@ struct DeprecatedArgs {
 	quiet: Option<bool>,
 
 	/// Use JSON output format.
-	#[arg(short = 'j', long = "json", hide = true, global = true)]
+	#[arg(long = "json", hide = true, global = true)]
 	json: Option<bool>,
 
 	/// Print the home directory for Hipcheck.
@@ -529,6 +529,10 @@ pub struct CheckArgs {
 	/// The ref (e.g. commit hash, branch, tag) of the target to analyze
 	#[clap(long = "ref", value_name = "REF")]
 	pub git_ref: Option<String>,
+
+	/// The number of parallel jobs to run at once against a multi-target run of Hipcheck (default 5)
+	#[clap(short = 'j', long = "jobs")]
+	pub num_jobs: Option<usize>,
 
 	#[clap(subcommand)]
 	command: Option<CheckCommand>,
@@ -1350,6 +1354,8 @@ pub enum Format {
 	/// Human-readable format.
 	#[default]
 	Human,
+	/// Summary format, suitable for multi-target runs with minimal information printed for each target
+	Summary,
 }
 
 impl Format {

--- a/hipcheck/src/engine/mod.rs
+++ b/hipcheck/src/engine/mod.rs
@@ -194,7 +194,7 @@ impl HcEngineImpl {
 	// analysis plugin to kick off the execution
 }
 
-pub fn start_plugins(
+pub async fn start_plugins(
 	policy_file: &PolicyFile,
 	plugin_cache: &HcPluginCache,
 	executor: PluginExecutor,
@@ -244,7 +244,6 @@ pub fn start_plugins(
 		plugins.push(plugin_with_config);
 	}
 
-	let runtime = RUNTIME.handle();
-	let core = runtime.block_on(HcPluginCore::new(executor, plugins))?;
+	let core = HcPluginCore::new(executor, plugins).await?;
 	Ok(Arc::new(core))
 }

--- a/site/content/docs/getting-started/install.md
+++ b/site/content/docs/getting-started/install.md
@@ -149,7 +149,7 @@ Hipcheck image, you might run:
 
 ```sh
 $ export HC_GITHUB_TOKEN=<TOKEN_VALUE>
-$ docker run -e HC_GITHUG_TOKEN=$HC_GITHUB_TOKEN mitre/hipcheck:latest check https://github.com/mitre/hipcheck
+$ docker run -e HC_GITHUB_TOKEN=$HC_GITHUB_TOKEN mitre/hipcheck:latest check https://github.com/mitre/hipcheck
 ```
 
 ### Using the `Containerfile`


### PR DESCRIPTION
Resolves #1092 

Adds async code to analyze targets and print reports in parallel.

Adds `-j`/`--jobs` flag to `hc check` to allow users to set the number of parallel jobs.

Adds `summary` option to `-f`/`--format` flag that prints a one-line summary for each `Report`