### PR TITLE
docs: editing documentation to include guidelines for pr submission

### DIFF
--- a/site/content/docs/contributing/pr-review.md
+++ b/site/content/docs/contributing/pr-review.md
@@ -1,13 +1,15 @@
 ---
-title: PR Review Checklist
+title: PR Submission and Review Checklist
 weight: 4
 ---
 
-# PR Review Checklist
+# PR Submission and Review Checklists
 
-This checklist should be followed both by PR submitters and reviewers to ensure
-that changes to Hipcheck's usage are properly versioned and do not result in
-stale documentation.
+These checklists should be followed by PR submitters and reviewers to ensure 
+that changes to Hipcheck's usage are properly versioned, do not result in
+stale documentation, and keep the working tree clean. 
+
+## PR Review
 
 1. If this PR has introduced organizational changes to the repository's
    directory structure (such as a refactor or adding a new crate), ensure that
@@ -26,3 +28,17 @@ stale documentation.
    the documentation have been updated accordingly.
 
 [semver]: https://semver.org/
+
+## PR Submission
+
+1. Ensure all tests pass (`cargo test --tests` from workspace root).
+
+2. (If the PR has previously been reviewed) Read comments on merge request, make changes accordingly, and resolve conversations on Github. 
+
+3. Run `cargo xtask ci` in the terminal and fix any errors.
+
+4. Commit changes.
+
+5. Squash all commits to a single commit using `git rebase` (https://git-scm.com/docs/git-rebase). Ensure that the remaining commit message follows the Conventional Commit standard (https://www.conventionalcommits.org/en/v1.0.0/).
+
+6. Ensure the remaining commit is signed-off on. Run `git commit --amend --no-edit -s` to sign the squashed commit if it is not.


### PR DESCRIPTION
I edited the docs to include guidelines for PR submission since there's so many steps involved. 