### PR TITLE
feat: parse package-lock.json npm dependencies to SingleTargetSeeds

### DIFF
--- a/hipcheck/src/target/resolve.rs
+++ b/hipcheck/src/target/resolve.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::{
 	cyclone_dx::{extract_cyclonedx_download_url, BomTarget},
+	multi::resolve_package_lock_json,
 	pm::{detect_and_extract, extract_repo_for_maven},
 	spdx::extract_spdx_download_url,
 };
@@ -250,7 +251,8 @@ impl ResolveRepo for RemoteGitRepo {
 		// Clone remote repo if not exists
 		if path.exists().not() {
 			t.update_status("cloning");
-			git::clone(&self.url, &path).context("failed to clone remote repository")?;
+			git::clone(&self.url, &path)
+				.map_err(|e| hc_error!("failed to clone remote repository {}", e))?;
 		} else {
 			t.update_status("pulling");
 		}
@@ -421,6 +423,7 @@ impl MultiTargetSeed {
 	pub async fn get_target_seeds(&self) -> Result<Vec<SingleTargetSeed>> {
 		match &self.kind {
 			MultiTargetSeedKind::GoMod(path) => resolve_go_mod(path).await,
+			MultiTargetSeedKind::PackageLockJson(path) => resolve_package_lock_json(path).await,
 		}
 	}
 }

--- a/hipcheck/src/target/tests/package-lock.json
+++ b/hipcheck/src/target/tests/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "fake-app",
+  "version": "0.2.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {  
+  },
+  "dependencies": {
+    "@bugsounet/node-lpcm16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bugsounet/node-lpcm16/-/node-lpcm16-1.0.2.tgz",
+      "integrity": "sha512-PZ3EUZ7C2V1hYNSsHQLW+vy/xKbKeeBwbL4mVYNdaxRjf3ByYF/Udu8qQX9zpRTBD2D3VYq5dtEMS0aD2g6IEQ==",
+      "requires": {
+        "child_process": "^1.0.2"
+      }
+    },
+    "child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    }
+  }
+}

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -171,7 +171,7 @@ pub struct SingleTargetSeed {
 pub enum MultiTargetSeedKind {
 	// CargoToml(PathBuf),
 	GoMod(PathBuf),
-	// PackageJson(PathBuf),
+	PackageLockJson(PathBuf),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Related to #1071 .
Parses package-lock.json to SingleTargetSeeds. Called by `get_targets()` method of `TargetSeed`, currently just tested via a unit-test and a sample `package-lock.json` added in a test data folder. Will be used after CLI support for package-lock.json input is added.