### PR TITLE
Make errored analyzes reports in the resulting json more "parallel" w…

### DIFF
--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -108,14 +108,16 @@ fn no_concerns(concerns: &[String]) -> bool {
 #[schemars(crate = "schemars")]
 pub struct ErroredAnalysis {
 	analysis: AnalysisIdent,
+	name: AnalysisIdent,
 	error: ErrorReport,
 }
 
 impl ErroredAnalysis {
 	/// Construct a new `ErroredAnalysis`.
-	pub fn new(analysis: AnalysisIdent, error: &Error) -> Self {
+	pub fn new(analysis: AnalysisIdent, name: AnalysisIdent, error: &Error) -> Self {
 		ErroredAnalysis {
 			analysis,
+			name,
 			error: ErrorReport::from(error),
 		}
 	}

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -65,7 +65,7 @@ pub fn build_report(
 				)?;
 			}
 			Err(error) => {
-				builder.add_errored_analysis(AnalysisIdent(name), error);
+				builder.add_errored_analysis(AnalysisIdent(name.clone()), AnalysisIdent(name), error);
 			}
 		}
 	}
@@ -146,8 +146,8 @@ impl<'target> ReportBuilder<'target> {
 	}
 
 	/// Add an errored analysis to the report.
-	pub fn add_errored_analysis(&mut self, analysis: AnalysisIdent, error: &Error) -> &mut Self {
-		self.errored.push(ErroredAnalysis::new(analysis, error));
+	pub fn add_errored_analysis(&mut self, analysis: AnalysisIdent, name: AnalysisIdent, error: &Error) -> &mut Self {
+		self.errored.push(ErroredAnalysis::new(analysis, name, error));
 		self
 	}
 


### PR DESCRIPTION
This PR Introduces and reuses an existing type, `AnalysisIdent`, from `src/report`, (rather than introducing a new type, e.g. `AnalysisIdentName` or `AnalysisPluginName`), to make `errored` analyzes reports in the resulting `json` more "parallel" with `passing` and `failing` analyzes. This would change the results for errored analyzes. 

from this:
```
  "errored": [
    {
      "analysis": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```
to this:
```
  "errored": [
    {
      "analysis": "mitre/typo",
      "name": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```
This is the first of four choices considered (perhaps there are more):

1) **Perceived** less impact
```
  "errored": [
    {
      "analysis": "mitre/typo",
      "name": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```
2) **More** chance of impact (not sure how/where `errored` are used in the overall context of `hipcheck` which would "jam" the string Analysis into this errored report structure.
```
  "errored": [
    {
      "analysis": "Analysis",
      "name": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```
3) **more accurate** would be to introduce "kind" as per the hints seen regarding type `"TYPE"` or `"KIND"` of plugin being either `__Kind__: "analysis" or "data"` shown in the plugin architecture vision. This would be the same `json` result, but the code would be refactored to comprehend this type (e.g., `struct Analysis` could become `struct AnalysisKind` or `struct AnalysisType`)
```
  "errored": [
    {
      "analysis": "Analysis",
      "name": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```
4) **more complete** - but does not address the "parallel" issue (completely) and has redundant data (but is "code cleaner")
```
  "errored": [
    {
      "analysis": {
        "analysis": "Analysis",
        "name": "mitre/typo",
        "passed": false,
        "policy_expr": "(lte (count (filter (eq #t) $)) 0)",
        "final_value": null,
        "message": "Expected the number of  to be less than or equal to 0 but it was no value was returned by the query"
      },
      "name": "mitre/typo",
      "error": {
        "msg": "unknown error; query is in an unspecified state"
      }
    }
  ],
```