### PR TITLE
chore: Bump versions to prep for 3.14.0 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "affiliation"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "binary"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "content_inspector",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "churn"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "dashmap",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -1328,7 +1328,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "github"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2234,7 +2234,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-common"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-macros"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "hipcheck-workspace-hack",
  "proc-macro2",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "console",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "convert_case",
  "hipcheck-workspace-hack",
@@ -2712,7 +2712,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "linguist"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "hipcheck-kdl",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "npm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "typo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -6,7 +6,7 @@ Automatically assess and score software packages for supply chain risk.
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"
-version = "3.13.0"
+version = "3.14.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://hipcheck.mitre.org"
@@ -61,7 +61,7 @@ git2 = { version = "0.20.1", features = [
 #
 # See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
 hipcheck-kdl = { version = "0.1.0", path = "../library/hipcheck-kdl" }
-hipcheck-macros = { path = "../library/hipcheck-macros", version = "0.3.4" }
+hipcheck-macros = { path = "../library/hipcheck-macros", version = "0.3.5" }
 http = "1.3.1"
 indextree = "4.7.3"
 indicatif = { version = "0.17.11", features = ["rayon"] }
@@ -108,7 +108,14 @@ strum_macros = "0.27.1"
 tabled = "0.18.0"
 tar = "0.4.44"
 tempfile = "3.19.1"
-tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread", "sync", "time", "process", "fs"] }
+tokio = { version = "1.44.2", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "process",
+    "fs",
+] }
 tokio-stream = "0.1.17"
 toml = "0.8.20"
 tonic = "0.13.0"
@@ -124,7 +131,7 @@ xml-rs = "0.8.26"
 xz2 = "0.1.7"
 zip = "2.3.0"
 zstd = "0.13.3"
-hipcheck-common = { version = "0.4.1", path = "../library/hipcheck-common", features = [
+hipcheck-common = { version = "0.4.2", path = "../library/hipcheck-common", features = [
     "rfd9-compat",
 ] }
 serde_with = "3.12.0"

--- a/library/hipcheck-common/Cargo.toml
+++ b/library/hipcheck-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-common"
 description = "Common functionality for the Hipcheck gRPC protocol"
 repository = "https://github.com/mitre/hipcheck"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/library/hipcheck-macros/Cargo.toml
+++ b/library/hipcheck-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-macros"
 description = "Helper macros for the `hipcheck` crate."
 repository = "https://github.com/mitre/hipcheck"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/library/hipcheck-sdk-macros/Cargo.toml
+++ b/library/hipcheck-sdk-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-sdk-macros"
 description = "Helper macros for the `hipcheck-sdk` crate."
 repository = "https://github.com/mitre/hipcheck"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "activity"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 jiff = { version = "0.1.16", features = ["serde"] }
@@ -19,6 +19,6 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affiliation"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -24,7 +24,7 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 clap = { version = "4.5.32", features = ["derive"] }
 content_inspector = "0.2.4"
 hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -23,6 +23,6 @@ walkdir = "2.5.0"
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "churn"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -19,6 +19,6 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entropy"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 clap = { version = "4.5.32", features = ["derive"] }
 dashmap = { version = "6.1.0", features = ["inline", "rayon"] }
 finl_unicode = { version = "1.3.0", features = ["grapheme_clusters"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 rayon = "1.10.0"
@@ -23,7 +23,7 @@ unicode-normalization = "0.1.24"
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/fuzz/Cargo.toml
+++ b/plugins/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz"
-version = "0.3.1"
+version = "0.3.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 serde_json = "1.0.139"
@@ -17,7 +17,7 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 lru = "0.14.0"

--- a/plugins/github/Cargo.toml
+++ b/plugins/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 graphql_client = "0.14.0"
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"

--- a/plugins/identity/Cargo.toml
+++ b/plugins/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity"
-version = "0.5.1"
+version = "0.5.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -19,6 +19,6 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linguist"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -21,7 +21,7 @@ tokio = { version = "1.44.2", features = ["rt"] }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
     "mock_engine",
 ] }

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npm"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"

--- a/plugins/review/Cargo.toml
+++ b/plugins/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -21,6 +21,6 @@ url = "2.5.4"
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typo"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/mitre/hipcheck"
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 hipcheck-kdl = { version = "0.1.0", path = "../../library/hipcheck-kdl" }
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "macros",
 ] }
 tracing = "0.1"
@@ -24,6 +24,6 @@ url = "2.5.4"
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 
 [dev-dependencies]
-hipcheck-sdk = { version = "0.6.0", path = "../../sdk/rust", features = [
+hipcheck-sdk = { version = "0.6.1", path = "../../sdk/rust", features = [
     "mock_engine",
 ] }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -4,7 +4,7 @@ description = "SDK for writing Hipcheck plugins in Rust"
 homepage = "https://hipcheck.mitre.org"
 repository = "https://github.com/mitre/hipcheck"
 license = "Apache-2.0"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]
@@ -20,12 +20,15 @@ tokio = { version = "1.44.2", features = ["rt"] }
 tokio-stream = "0.1.17"
 tonic = "0.13.0"
 schemars = { version = "0.8.22", features = ["url"] }
-hipcheck-sdk-macros = { path = "../../library/hipcheck-sdk-macros", version = "0.2.0", optional = true }
+hipcheck-sdk-macros = { path = "../../library/hipcheck-sdk-macros", version = "0.2.1", optional = true }
 typify-macro = "0.3.0"
 url = { version = "2.5.4", features = ["serde"] }
-tracing = { version= "0.1", optional = true }
-tracing-subscriber = { version="0.3", features=["env-filter", "json"], optional = true }
-hipcheck-common = { version = "0.4.1", path = "../../library/hipcheck-common" }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "json",
+], optional = true }
+hipcheck-common = { version = "0.4.2", path = "../../library/hipcheck-common" }
 hipcheck-workspace-hack = { version = "0.1", path = "../../library/hipcheck-workspace-hack" }
 console = { version = "0.15.11", features = ["windows-console-colors"] }
 


### PR DESCRIPTION
See https://github.com/mitre/hipcheck/issues/1149