### PR TITLE
fix: broken 'rust-toolchain' GitHub Action

### DIFF
--- a/.github/workflows/hipcheck.yml
+++ b/.github/workflows/hipcheck.yml
@@ -59,7 +59,9 @@ jobs:
               - "xtask/**"
               - "sdk/rust/**"
               - "library/**"
-      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1 # stable
+      # This is a tag, not a commit, because that's how the Action determines
+      # what Rust toolchain you're using.
+      - uses: dtolnay/rust-toolchain@stable
         if: steps.filter.outputs.code == 'true'
       - uses: taiki-e/install-action@a761292ced99fc08cbae630a81f800d2d49b8bf4 # nextest
         if: steps.filter.outputs.code == 'true'


### PR DESCRIPTION
I'd amended all our GitHub Actions dependencies to use pinned hashes for specific commits, but it turns out that the "dtolnay/rust-toolchain" Action uses the target hash as the way to know what toolchain you want (I wish it wouldn't, and would instead use an argument like a normal GitHub Action, but alas). This reverts the change for stable so it will work again.