### PR TITLE
chore: Dependabot ignore workspace-hack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    exclude-paths:
+      - "library/hipcheck-workspace-hack/"


### PR DESCRIPTION
The workspace-hack crate's dependencies are set automatically based on dependencies used by other crates in the workspace, since the purpose of this crate is *only* to unify feature sets to improve build caching. So we don't need Dependabot to mess with them.