### PR TITLE
chore: break up "mitre/affiliation" structure

### DIFF
--- a/plugins/affiliation/src/affiliator.rs
+++ b/plugins/affiliation/src/affiliator.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	org_spec::{Matcher, OrgSpec},
+	org_types::Mode,
+};
+use hipcheck_sdk::prelude::*;
+
+/// A type which encapsulates checking whether a given string matches an org in the orgs file,
+/// based on the mode in question. If the mode is Independent, then you're looking for
+/// the strings that _don't match_ any of the hosts in the set. If the mode is Affiliated,
+/// you're looking for the strings that _match_ one of the hosts in the set.
+pub struct Affiliator<'haystack> {
+	patterns: Matcher<'haystack>,
+	mode: Mode,
+}
+
+impl<'haystack> Affiliator<'haystack> {
+	/// Check whether the given string is a match for the set of hosts, based on the mode.
+	///
+	/// If independent mode is on, you're looking for strings which do not match any of
+	/// the hosts.
+	///
+	/// If affiliated mode is on, you're looking for strings which do match one of the
+	/// hosts.
+	pub fn is_match(&self, s: &str) -> bool {
+		match self.mode {
+			Mode::Independent => !self.patterns.is_match(s),
+			Mode::Affiliated => self.patterns.is_match(s),
+			Mode::All => true,
+			Mode::None => false,
+		}
+	}
+
+	/// Construct a new Affiliator from a given OrgSpec (built from an Orgs.kdl file).
+	pub fn from_spec(spec: &'haystack OrgSpec) -> Result<Affiliator<'haystack>> {
+		let patterns = spec.patterns().map_err(|e| {
+			tracing::error!("failed to get patterns for org spec to check against {}", e);
+			Error::UnspecifiedQueryState
+		})?;
+		let mode = spec.mode();
+		Ok(Affiliator { patterns, mode })
+	}
+}

--- a/plugins/affiliation/src/config.rs
+++ b/plugins/affiliation/src/config.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use hipcheck_sdk::PluginConfig;
+use hipcheck_sdk::error::ConfigError;
+use hipcheck_sdk::macros::PluginConfig;
+use std::path::PathBuf;
+use std::result::Result as StdResult;
+
+/// Configuration for the affiliation plugin.
+#[derive(PluginConfig, Debug)]
+pub struct Config {
+	/// Path to the orgs file to use for defining matching behavior.
+	pub orgs_file: PathBuf,
+
+	/// The threshold of how many matches is too many.
+	pub count_threshold: Option<u64>,
+}

--- a/plugins/affiliation/src/git.rs
+++ b/plugins/affiliation/src/git.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{
+	collections::HashMap,
+	fmt::{self, Display, Formatter},
+	result::Result as StdResult,
+};
+
+/// Commits as understood in Hipcheck's data model.
+/// The `written_on` and `committed_on` datetime fields contain Strings that are created from `jiff:Timestamps`.
+/// Because `Timestamp` does not `impl JsonSchema`, we display the datetimes as Strings for passing out of this plugin.
+/// Other plugins that expect a `Timestamp`` should parse the provided Strings into `Timestamps` as needed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
+pub struct Commit {
+	pub hash: String,
+
+	pub written_on: StdResult<String, String>,
+
+	pub committed_on: StdResult<String, String>,
+}
+
+impl Display for Commit {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "{}", self.hash)
+	}
+}
+
+/// Authors or committers of a commit.
+#[derive(
+	Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Hash, PartialOrd, Ord, JsonSchema,
+)]
+pub struct Contributor {
+	pub name: String,
+	pub email: String,
+}
+
+impl Display for Contributor {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(f, "{} <{}>", self.name, self.email)
+	}
+}
+
+/// Temporary data structure for looking up the contributors of a commit
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema)]
+pub struct CommitContributorView {
+	pub commit: Commit,
+	pub author: Contributor,
+	pub committer: Contributor,
+}
+
+impl CommitContributorView {
+	/// get the author of the commit
+	pub fn author(&self) -> &Contributor {
+		&self.author
+	}
+
+	/// get the committer of the commit
+	pub fn committer(&self) -> &Contributor {
+		&self.committer
+	}
+}
+
+/// struct for counting number of contributions made by each contributor in the repo
+pub struct ContributorFrequencyMap<'a>(HashMap<&'a Contributor, u64>);
+
+impl<'a> ContributorFrequencyMap<'a> {
+	pub fn new(capacity: Option<usize>) -> Self {
+		match capacity {
+			Some(capacity) => Self(HashMap::with_capacity(capacity)),
+			None => Self(HashMap::new()),
+		}
+	}
+
+	/// Add an affiliated_contributor to the map, update frequency for affiliated_contributor
+	/// appropriately
+	///
+	/// If the contributor is not in the HashMap, then insert and set frequency to 1
+	/// Otherwise, increment frequency by 1
+	pub fn insert(&mut self, affiliated_contributor: &'a Contributor) {
+		self.0
+			.entry(affiliated_contributor)
+			.and_modify(|count| *count += 1)
+			.or_insert(1);
+	}
+
+	/// Retrieve a non-mutable handle to the internal HashMap
+	pub fn inner(&self) -> &HashMap<&'a Contributor, u64> {
+		&self.0
+	}
+}


### PR DESCRIPTION
We had a lot going on in a single file, which made it a bit difficult to follow when reading the code. This is hopefully a start to making it easier.