### PR TITLE
feat: support arm64 Linux for bin and Docker releases

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -46,7 +46,7 @@ jobs:
           context: .
           file: dist/Containerfile
           push: true
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           tags: mitre/hipcheck:latest,mitre/hipcheck:${{ steps.format-tag.outputs.replaced }}
 
   description:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,7 +113,14 @@ jobs:
         #
         # More info: https://github.com/actions/runner-images
         # See also: https://github.com/actions/partner-runner-images
-        os: [ubuntu-22.04, windows-2022, macos-14, macos-15-intel]
+        os:
+          [
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            windows-2022,
+            macos-14,
+            macos-15-intel,
+          ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
@@ -198,7 +205,14 @@ jobs:
         #
         # More info: https://github.com/actions/runner-images
         # See also: https://github.com/actions/partner-runner-images
-        os: [ubuntu-22.04, windows-2022, macos-14, macos-15-intel]
+        os:
+          [
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            windows-2022,
+            macos-14,
+            macos-15-intel,
+          ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.2"
+cargo-dist-version = "0.30.3"
 # CI backends to support
 ci = "github"
 # Which actions to run on pull requests
@@ -16,7 +16,7 @@ pr-run-mode = "plan"
 # Path that installers should place binaries in
 install-path = ["~/.local/bin", "~/.hipcheck/bin"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Whether to install an updater program
 install-updater = true
 # Build only the required packages, and individually
@@ -38,3 +38,7 @@ aarch64-apple-darwin = "macos-14"
 # compatible with 24.04, but if we built on 24.04 the glibc *would not* be
 # backwards-compatible.
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
+# For arm64, we're using one of GitHub's ARM-provided "partner images," which
+# matches the Ubuntu version used for x86 (for the same reasons we chose that
+# version), though the tools installed on it are not guaranteed to match.
+aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"


### PR DESCRIPTION
This adds support for arm64 Linux releases in both our pre-built binaries and for container images published to Docker Hub.

It uses the Arm-provided "partner images," and adds them to both our release automation and to CI to ensure we get regular testing against them with each PR.

Closes #1275 