### PR TITLE
fix: Adds .spdx.json as valid SPDX SBOM target

### DIFF
--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -888,7 +888,7 @@ impl ToTargetSeedKind for CheckSbomArgs {
 	fn to_target_seed_kind(&self) -> Result<TargetSeedKind> {
 		let path = PathBuf::from(&self.path);
 		if path.exists() {
-			if self.path.ends_with(".spdx") {
+			if self.path.ends_with(".spdx") || self.path.ends_with(".spdx.json") {
 				Ok(TargetSeedKind::Single(SingleTargetSeedKind::Sbom(Sbom {
 					path,
 					standard: SbomStandard::Spdx,

--- a/hipcheck/src/target/mod.rs
+++ b/hipcheck/src/target/mod.rs
@@ -90,6 +90,7 @@ impl TargetType {
 			Some((Repo, tgt.to_string()))
 		// Otherwise check if it has an SPDX or CycloneDX SBOM file extension
 		} else if tgt.ends_with(".spdx")
+			|| tgt.ends_with(".spdx.json")
 			|| tgt.ends_with("bom.json")
 			|| tgt.ends_with(".cdx.json")
 			|| tgt.ends_with("bom.xml")

--- a/hipcheck/src/target/pm.rs
+++ b/hipcheck/src/target/pm.rs
@@ -83,17 +83,18 @@ fn retrieve_maven_urls(pom: &str) -> Vec<String> {
 	loop {
 		let e = parser.next();
 		match e {
-			Ok(XmlEvent::StartElement { name, .. }) => {
-				if name.local_name == "connection" || name.local_name == "developerConnection" {
-					match parser.next() {
-						Ok(XmlEvent::Characters(s)) => {
-							urls.push(s);
-						}
-						Err(err) => {
-							println!("Error: {}", err);
-						}
-						_ => {}
+			Ok(XmlEvent::StartElement { name, .. })
+				if (name.local_name == "connection"
+					|| name.local_name == "developerConnection") =>
+			{
+				match parser.next() {
+					Ok(XmlEvent::Characters(s)) => {
+						urls.push(s);
 					}
+					Err(err) => {
+						println!("Error: {}", err);
+					}
+					_ => {}
 				}
 			}
 			Ok(XmlEvent::EndDocument) => {

--- a/plugins/churn/src/main.rs
+++ b/plugins/churn/src/main.rs
@@ -108,7 +108,7 @@ async fn commit_churns(
 
 	let source_files: HashSet<String> = psf_vec
 		.into_iter()
-		.zip(psf_bools.into_iter())
+		.zip(psf_bools)
 		.filter_map(|(p, b)| if b { Some(p) } else { None })
 		.map(|p| p.as_path().to_string_lossy().into_owned())
 		.collect();

--- a/plugins/entropy/src/main.rs
+++ b/plugins/entropy/src/main.rs
@@ -102,7 +102,7 @@ async fn commit_entropies(
 
 	let source_files: HashSet<String> = psf_vec
 		.into_iter()
-		.zip(psf_bools.into_iter())
+		.zip(psf_bools)
 		.filter_map(|(p, b)| if b { Some(p) } else { None })
 		.map(|p| p.as_path().to_string_lossy().into_owned())
 		.collect();


### PR DESCRIPTION
Resolves #1163 by adding `.spdx.json` as a supported file extension for SPDX SBOM targets.

Also makes some linting changes based on updates to the Rust `clippy` linter.