### PR TITLE
fix: Changes --type to --target in docs

### DIFF
--- a/site/content/docs/guide/cli/hc-check.md
+++ b/site/content/docs/guide/cli/hc-check.md
@@ -45,7 +45,7 @@ It is possible for a target specifier to be ambiguous. For example, Hipcheck
 accepts targets of the form `<package_name>[@<package_version>]`. In this case,
 it's not clear from the target specifier what package host this package is
 supposed to be hosted on. In these ambiguous cases, the user needs to specify
-the __target type__ with the `-t`/`--type` flag. The full list of current types
+the __target type__ with the `-t`/`--target` flag. The full list of current types
 is:
 
 - `maven`: A package on Maven Central

--- a/site/content/docs/guide/concepts/targets.md
+++ b/site/content/docs/guide/concepts/targets.md
@@ -87,13 +87,13 @@ expand that support to more platforms in the future.
 
 Packages from these hosts may be specified as package names, with optional
 versions. When specifying one of these targets, it is not sufficient to
-specify just the package name, you'll need to use the `-t`/`--type` flag to
+specify just the package name, you'll need to use the `-t`/`--target` flag to
 specify the package host. For example:
 
 ```sh
-$ hc check --type npm chalk@5.3.0
-$ hc check --type pypi numpy@2.0.0
-$ hc check --type maven commons-csv@1.11.0
+$ hc check --target npm chalk@5.3.0
+$ hc check --target pypi numpy@2.0.0
+$ hc check --target maven commons-csv@1.11.0
 ```
 
 Without specifying the platform, Hipcheck will be unable to determine


### PR DESCRIPTION
Resolves #1266 

Updates the documentation on the Hipcheck website to replace the deprecated `--type` flag with the correct `--target` flag.