### PR TITLE
chore: release Hipcheck 3.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "affiliation"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -330,7 +330,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "binary"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap",
  "content_inspector",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "churn"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dashmap",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -1291,7 +1291,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "github"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2217,7 +2217,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-common"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-kdl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hipcheck-workspace-hack",
  "kdl",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-macros"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "hipcheck-workspace-hack",
  "proc-macro2",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "console",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "hipcheck-sdk-macros"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "convert_case",
  "hipcheck-workspace-hack",
@@ -2646,7 +2646,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "hipcheck-sdk",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "linguist"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap",
  "hipcheck-kdl",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "npm"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "review"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "typo"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,11 +147,11 @@ glob = "0.3.3"
 gomod-rs = "0.1.1"
 graphql_client = "0.14.0"
 hex = "0.4.3"
-hipcheck-common = { version = "0.4.2", path = "library/hipcheck-common" }
-hipcheck-kdl = { version = "0.1.0", path = "library/hipcheck-kdl" }
-hipcheck-macros = { version = "0.3.5", path = "library/hipcheck-macros" }
-hipcheck-sdk = { version = "0.6.1", path = "sdk/rust" }
-hipcheck-sdk-macros = { version = "0.2.1", path = "library/hipcheck-sdk-macros" }
+hipcheck-common = { version = "0.5.0", path = "library/hipcheck-common" }
+hipcheck-kdl = { version = "0.2.0", path = "library/hipcheck-kdl" }
+hipcheck-macros = { version = "0.4.0", path = "library/hipcheck-macros" }
+hipcheck-sdk = { version = "0.7.0", path = "sdk/rust" }
+hipcheck-sdk-macros = { version = "0.3.0", path = "library/hipcheck-sdk-macros" }
 hipcheck-workspace-hack = { version = "0.1", path = "library/hipcheck-workspace-hack" }
 http = "1.3.1"
 indexmap = "2.12.0"

--- a/config/Hipcheck.kdl
+++ b/config/Hipcheck.kdl
@@ -1,12 +1,12 @@
 plugins {
-    plugin "mitre/activity" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/affiliation" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/binary" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/churn" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
-    plugin "mitre/fuzz" version="^0.3" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/review" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/activity" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/affiliation" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/binary" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/churn" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/fuzz" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/review" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
 }
 
 patch {

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -6,7 +6,7 @@ Automatically assess and score software packages for supply chain risk.
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"
-version = "3.14.0"
+version = "3.15.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://hipcheck.mitre.org"

--- a/hipcheck/src/policy/config_to_policy.rs
+++ b/hipcheck/src/policy/config_to_policy.rs
@@ -24,15 +24,15 @@ use std::{
 };
 use url::Url;
 
-const ACTIVITY_PLUGIN_VERSION: &str = "^0.5";
-const BINARY_PLUGIN_VERSION: &str = "^0.4";
-const FUZZ_PLUGIN_VERSION: &str = "^0.3";
-const IDENTITY_PLUGIN_VERSION: &str = "^0.5";
-const REVIEW_PLUGIN_VERSION: &str = "^0.4";
-const TYPO_PLUGIN_VERSION: &str = "^0.4";
-const AFFILIATION_PLUGIN_VERSION: &str = "^0.5";
-const CHURN_PLUGIN_VERSION: &str = "^0.5";
-const ENTROPY_PLUGIN_VERSION: &str = "^0.5";
+const ACTIVITY_PLUGIN_VERSION: &str = "^0.6";
+const BINARY_PLUGIN_VERSION: &str = "^0.5";
+const FUZZ_PLUGIN_VERSION: &str = "^0.4";
+const IDENTITY_PLUGIN_VERSION: &str = "^0.6";
+const REVIEW_PLUGIN_VERSION: &str = "^0.5";
+const TYPO_PLUGIN_VERSION: &str = "^0.5";
+const AFFILIATION_PLUGIN_VERSION: &str = "^0.6";
+const CHURN_PLUGIN_VERSION: &str = "^0.6";
+const ENTROPY_PLUGIN_VERSION: &str = "^0.6";
 
 struct Context {
 	path: PathBuf,

--- a/hipcheck/src/policy/test_example.kdl
+++ b/hipcheck/src/policy/test_example.kdl
@@ -1,13 +1,13 @@
 plugins {
-    plugin "mitre/activity" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
-    plugin "mitre/binary" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
-    plugin "mitre/fuzz" version="^0.3" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
-    plugin "mitre/identity" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
-    plugin "mitre/review" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
-    plugin "mitre/typo" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
-    plugin "mitre/affiliation" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
-    plugin "mitre/churn" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
-    plugin "mitre/entropy" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
+    plugin "mitre/activity" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/activity.kdl"
+    plugin "mitre/binary" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/binary.kdl"
+    plugin "mitre/fuzz" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/fuzz.kdl"
+    plugin "mitre/identity" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/identity.kdl"
+    plugin "mitre/review" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/review.kdl"
+    plugin "mitre/typo" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/typo.kdl"
+    plugin "mitre/affiliation" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/affiliation.kdl"
+    plugin "mitre/churn" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/churn.kdl"
+    plugin "mitre/entropy" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/entropy.kdl"
 }
 patch {
 	plugin "mitre/github" {

--- a/library/hipcheck-common/Cargo.toml
+++ b/library/hipcheck-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-common"
 description = "Common functionality for the Hipcheck gRPC protocol"
 repository = "https://github.com/mitre/hipcheck"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/library/hipcheck-kdl/Cargo.toml
+++ b/library/hipcheck-kdl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-kdl"
 description = "Common KDL functionality used throughout the Hipcheck project"
 repository = "https://github.com/mitre/hipcheck"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 edition = "2024"
 publish = false

--- a/library/hipcheck-macros/Cargo.toml
+++ b/library/hipcheck-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-macros"
 description = "Helper macros for the `hipcheck` crate."
 repository = "https://github.com/mitre/hipcheck"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/library/hipcheck-sdk-macros/Cargo.toml
+++ b/library/hipcheck-sdk-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hipcheck-sdk-macros"
 description = "Helper macros for the `hipcheck-sdk` crate."
 repository = "https://github.com/mitre/hipcheck"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/plugins/activity/Cargo.toml
+++ b/plugins/activity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "activity"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/activity/local-plugin.kdl
+++ b/plugins/activity/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/activity"
   on arch="x86_64-apple-darwin" "./target/debug/activity"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/activity"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/activity"
   on arch="x86_64-pc-windows-msvc" "./target/debug/activity.exe"
 }

--- a/plugins/activity/local-release-plugin.kdl
+++ b/plugins/activity/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/activity"
   on arch="x86_64-apple-darwin" "./target/release/activity"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/activity"
   on arch="x86_64-unknown-linux-gnu" "./target/release/activity"
   on arch="x86_64-pc-windows-msvc" "./target/release/activity.exe"
 }

--- a/plugins/activity/plugin.kdl
+++ b/plugins/activity/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "activity"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "activity"
   on arch="x86_64-apple-darwin" "activity"
+  on arch="aarch64-unknown-linux-gnu" "activity"
   on arch="x86_64-unknown-linux-gnu" "activity"
   on arch="x86_64-pc-windows-msvc" "activity.exe"
 }
 
 dependencies {
-  plugin "mitre/git" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "affiliation"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/affiliation/local-plugin.kdl
+++ b/plugins/affiliation/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/affiliation"
   on arch="x86_64-apple-darwin" "./target/debug/affiliation"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/affiliation"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/affiliation"
   on arch="x86_64-pc-windows-msvc" "./target/debug/affiliation.exe"
 }

--- a/plugins/affiliation/local-release-plugin.kdl
+++ b/plugins/affiliation/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/affiliation"
   on arch="x86_64-apple-darwin" "./target/release/affiliation"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/affiliation"
   on arch="x86_64-unknown-linux-gnu" "./target/release/affiliation"
   on arch="x86_64-pc-windows-msvc" "./target/release/affiliation.exe"
 }

--- a/plugins/affiliation/plugin.kdl
+++ b/plugins/affiliation/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "affiliation"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "affiliation"
   on arch="x86_64-apple-darwin" "affiliation"
+  on arch="aarch64-unknown-linux-gnu" "affiliation"
   on arch="x86_64-unknown-linux-gnu" "affiliation"
   on arch="x86_64-pc-windows-msvc" "affiliation.exe"
 }
 
 dependencies {
-  plugin "mitre/git" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/git" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/binary/Cargo.toml
+++ b/plugins/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/binary/local-plugin.kdl
+++ b/plugins/binary/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/binary"
   on arch="x86_64-apple-darwin" "./target/debug/binary"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/binary"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/binary"
   on arch="x86_64-pc-windows-msvc" "./target/debug/binary.exe"
 }

--- a/plugins/binary/local-release-plugin.kdl
+++ b/plugins/binary/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/binary"
   on arch="x86_64-apple-darwin" "./target/release/binary"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/binary"
   on arch="x86_64-unknown-linux-gnu" "./target/release/binary"
   on arch="x86_64-pc-windows-msvc" "./target/release/binary.exe"
 }

--- a/plugins/binary/plugin.kdl
+++ b/plugins/binary/plugin.kdl
@@ -1,11 +1,12 @@
 publisher "mitre"
 name "binary"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "binary"
   on arch="x86_64-apple-darwin" "binary"
+  on arch="aarch64-unknown-linux-gnu" "binary"
   on arch="x86_64-unknown-linux-gnu" "binary"
   on arch="x86_64-pc-windows-msvc" "binary.exe"
 }

--- a/plugins/churn/Cargo.toml
+++ b/plugins/churn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "churn"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/churn/local-plugin.kdl
+++ b/plugins/churn/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/churn"
   on arch="x86_64-apple-darwin" "./target/debug/churn"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/churn"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/churn"
   on arch="x86_64-pc-windows-msvc" "./target/debug/churn.exe"
 }

--- a/plugins/churn/local-release-plugin.kdl
+++ b/plugins/churn/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/churn"
   on arch="x86_64-apple-darwin" "./target/release/churn"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/churn"
   on arch="x86_64-unknown-linux-gnu" "./target/release/churn"
   on arch="x86_64-pc-windows-msvc" "./target/release/churn.exe"
 }

--- a/plugins/churn/plugin.kdl
+++ b/plugins/churn/plugin.kdl
@@ -1,16 +1,17 @@
 publisher "mitre"
 name "churn"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "churn"
   on arch="x86_64-apple-darwin" "churn"
+  on arch="aarch64-unknown-linux-gnu" "churn"
   on arch="x86_64-unknown-linux-gnu" "churn"
   on arch="x86_64-pc-windows-msvc" "churn.exe"
 }
 
 dependencies {
-  plugin "mitre/git" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
-  plugin "mitre/linguist" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
+  plugin "mitre/git" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/linguist" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
 }

--- a/plugins/entropy/Cargo.toml
+++ b/plugins/entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entropy"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/entropy/local-plugin.kdl
+++ b/plugins/entropy/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/entropy"
   on arch="x86_64-apple-darwin" "./target/debug/entropy"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/entropy"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/entropy"
   on arch="x86_64-pc-windows-msvc" "./target/debug/entropy.exe"
 }

--- a/plugins/entropy/local-release-plugin.kdl
+++ b/plugins/entropy/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/entropy"
   on arch="x86_64-apple-darwin" "./target/release/entropy"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/entropy"
   on arch="x86_64-unknown-linux-gnu" "./target/release/entropy"
   on arch="x86_64-pc-windows-msvc" "./target/release/entropy.exe"
 }

--- a/plugins/entropy/plugin.kdl
+++ b/plugins/entropy/plugin.kdl
@@ -1,16 +1,17 @@
 publisher "mitre"
 name "entropy"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "entropy"
   on arch="x86_64-apple-darwin" "entropy"
+  on arch="aarch64-unknown-linux-gnu" "entropy"
   on arch="x86_64-unknown-linux-gnu" "entropy"
   on arch="x86_64-pc-windows-msvc" "entropy.exe"
 }
 
 dependencies {
-  plugin "mitre/git" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
-  plugin "mitre/linguist" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
+  plugin "mitre/git" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+  plugin "mitre/linguist" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/linguist.kdl"
 }

--- a/plugins/fuzz/Cargo.toml
+++ b/plugins/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz"
-version = "0.3.2"
+version = "0.4.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/fuzz/local-plugin.kdl
+++ b/plugins/fuzz/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/fuzz"
   on arch="x86_64-apple-darwin" "./target/debug/fuzz"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/fuzz"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/fuzz"
   on arch="x86_64-pc-windows-msvc" "./target/debug/fuzz.exe"
 }

--- a/plugins/fuzz/local-release-plugin.kdl
+++ b/plugins/fuzz/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/fuzz"
   on arch="x86_64-apple-darwin" "./target/release/fuzz"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/fuzz"
   on arch="x86_64-unknown-linux-gnu" "./target/release/fuzz"
   on arch="x86_64-pc-windows-msvc" "./target/release/fuzz.exe"
 }

--- a/plugins/fuzz/plugin.kdl
+++ b/plugins/fuzz/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "fuzz"
-version "0.3.2"
+version "0.4.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "fuzz"
   on arch="x86_64-apple-darwin" "fuzz"
+  on arch="aarch64-unknown-linux-gnu" "fuzz"
   on arch="x86_64-unknown-linux-gnu" "fuzz"
   on arch="x86_64-pc-windows-msvc" "fuzz.exe"
 }
 
 dependencies {
-  plugin "mitre/github" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/git/Cargo.toml
+++ b/plugins/git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/git/local-plugin.kdl
+++ b/plugins/git/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/git"
   on arch="x86_64-apple-darwin" "./target/debug/git"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/git"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/git"
   on arch="x86_64-pc-windows-msvc" "./target/debug/git.exe"
 }

--- a/plugins/git/local-release-plugin.kdl
+++ b/plugins/git/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/git"
   on arch="x86_64-apple-darwin" "./target/release/git"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/git"
   on arch="x86_64-unknown-linux-gnu" "./target/release/git"
   on arch="x86_64-pc-windows-msvc" "./target/release/git.exe"
 }

--- a/plugins/git/plugin.kdl
+++ b/plugins/git/plugin.kdl
@@ -1,11 +1,12 @@
 publisher "mitre"
 name "git"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "git"
   on arch="x86_64-apple-darwin" "git"
+  on arch="aarch64-unknown-linux-gnu" "git"
   on arch="x86_64-unknown-linux-gnu" "git"
   on arch="x86_64-pc-windows-msvc" "git.exe"
 }

--- a/plugins/github/Cargo.toml
+++ b/plugins/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "github"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/github/local-plugin.kdl
+++ b/plugins/github/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/github"
   on arch="x86_64-apple-darwin" "./target/debug/github"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/github"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/github"
   on arch="x86_64-pc-windows-msvc" "./target/debug/github.exe"
 }

--- a/plugins/github/local-release-plugin.kdl
+++ b/plugins/github/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/github"
   on arch="x86_64-apple-darwin" "./target/release/github"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/github"
   on arch="x86_64-unknown-linux-gnu" "./target/release/github"
   on arch="x86_64-pc-windows-msvc" "./target/release/github.exe"
 }

--- a/plugins/github/plugin.kdl
+++ b/plugins/github/plugin.kdl
@@ -1,11 +1,12 @@
 publisher "mitre"
 name "github"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "github"
   on arch="x86_64-apple-darwin" "github"
+  on arch="aarch64-unknown-linux-gnu" "github"
   on arch="x86_64-unknown-linux-gnu" "github"
   on arch="x86_64-pc-windows-msvc" "github.exe"
 }

--- a/plugins/identity/Cargo.toml
+++ b/plugins/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity"
-version = "0.5.2"
+version = "0.6.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/identity/local-plugin.kdl
+++ b/plugins/identity/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
     on arch="aarch64-apple-darwin" "./target/debug/identity"
     on arch="x86_64-apple-darwin" "./target/debug/identity"
+    on arch="aarch64-unknown-linux-gnu" "./target/debug/identity"
     on arch="x86_64-unknown-linux-gnu" "./target/debug/identity"
     on arch="x86_64-pc-windows-msvc" "./target/debug/identity.exe"
 }

--- a/plugins/identity/local-release-plugin.kdl
+++ b/plugins/identity/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
     on arch="aarch64-apple-darwin" "./target/release/identity"
     on arch="x86_64-apple-darwin" "./target/release/identity"
+    on arch="aarch64-unknown-linux-gnu" "./target/release/identity"
     on arch="x86_64-unknown-linux-gnu" "./target/release/identity"
     on arch="x86_64-pc-windows-msvc" "./target/release/identity.exe"
 }

--- a/plugins/identity/plugin.kdl
+++ b/plugins/identity/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "identity"
-version "0.5.2"
+version "0.6.0"
 license "Apache-2.0"
 
 entrypoint {
     on arch="aarch64-apple-darwin" "identity"
     on arch="x86_64-apple-darwin" "identity"
+    on arch="aarch64-unknown-linux-gnu" "identity"
     on arch="x86_64-unknown-linux-gnu" "identity"
     on arch="x86_64-pc-windows-msvc" "identity.exe"
 }
 
 dependencies {
-    plugin "mitre/git" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
+    plugin "mitre/git" version="^0.6" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/git.kdl"
 }

--- a/plugins/linguist/Cargo.toml
+++ b/plugins/linguist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linguist"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/linguist/local-plugin.kdl
+++ b/plugins/linguist/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/linguist"
   on arch="x86_64-apple-darwin" "./target/debug/linguist"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/linguist"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/linguist"
   on arch="x86_64-pc-windows-msvc" "./target/debug/linguist.exe"
 }

--- a/plugins/linguist/local-release-plugin.kdl
+++ b/plugins/linguist/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/linguist"
   on arch="x86_64-apple-darwin" "./target/release/linguist"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/linguist"
   on arch="x86_64-unknown-linux-gnu" "./target/release/linguist"
   on arch="x86_64-pc-windows-msvc" "./target/release/linguist.exe"
 }

--- a/plugins/linguist/plugin.kdl
+++ b/plugins/linguist/plugin.kdl
@@ -1,11 +1,12 @@
 publisher "mitre"
 name "linguist"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "linguist"
   on arch="x86_64-apple-darwin" "linguist"
+  on arch="aarch64-unknown-linux-gnu" "linguist"
   on arch="x86_64-unknown-linux-gnu" "linguist"
   on arch="x86_64-pc-windows-msvc" "linguist.exe"
 }

--- a/plugins/npm/Cargo.toml
+++ b/plugins/npm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npm"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/npm/local-plugin.kdl
+++ b/plugins/npm/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/npm"
   on arch="x86_64-apple-darwin" "./target/debug/npm"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/npm"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/npm"
   on arch="x86_64-pc-windows-msvc" "./target/debug/npm.exe"
 }

--- a/plugins/npm/local-release-plugin.kdl
+++ b/plugins/npm/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/npm"
   on arch="x86_64-apple-darwin" "./target/release/npm"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/npm"
   on arch="x86_64-unknown-linux-gnu" "./target/release/npm"
   on arch="x86_64-pc-windows-msvc" "./target/release/npm.exe"
 }

--- a/plugins/npm/plugin.kdl
+++ b/plugins/npm/plugin.kdl
@@ -1,11 +1,12 @@
 publisher "mitre"
 name "npm"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "npm"
   on arch="x86_64-apple-darwin" "npm"
+  on arch="aarch64-unknown-linux-gnu" "npm"
   on arch="x86_64-unknown-linux-gnu" "npm"
   on arch="x86_64-pc-windows-msvc" "npm.exe"
 }

--- a/plugins/review/Cargo.toml
+++ b/plugins/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/review/local-plugin.kdl
+++ b/plugins/review/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/review"
   on arch="x86_64-apple-darwin" "./target/debug/review"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/review"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/review"
   on arch="x86_64-pc-windows-msvc" "./target/debug/review.exe"
 }

--- a/plugins/review/local-release-plugin.kdl
+++ b/plugins/review/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/review"
   on arch="x86_64-apple-darwin" "./target/release/review"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/review"
   on arch="x86_64-unknown-linux-gnu" "./target/release/review"
   on arch="x86_64-pc-windows-msvc" "./target/release/review.exe"
 }

--- a/plugins/review/plugin.kdl
+++ b/plugins/review/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "review"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "review"
   on arch="x86_64-apple-darwin" "review"
+  on arch="aarch64-unknown-linux-gnu" "review"
   on arch="x86_64-unknown-linux-gnu" "review"
   on arch="x86_64-pc-windows-msvc" "review.exe"
 }
 
 dependencies {
-  plugin "mitre/github" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
+  plugin "mitre/github" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/github.kdl"
 }

--- a/plugins/typo/Cargo.toml
+++ b/plugins/typo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typo"
-version = "0.4.2"
+version = "0.5.0"
 license = "Apache-2.0"
 edition = "2024"
 repository = "https://github.com/mitre/hipcheck"

--- a/plugins/typo/local-plugin.kdl
+++ b/plugins/typo/local-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/debug/typo"
   on arch="x86_64-apple-darwin" "./target/debug/typo"
+  on arch="aarch64-unknown-linux-gnu" "./target/debug/typo"
   on arch="x86_64-unknown-linux-gnu" "./target/debug/typo"
   on arch="x86_64-pc-windows-msvc" "./target/debug/typo.exe"
 }

--- a/plugins/typo/local-release-plugin.kdl
+++ b/plugins/typo/local-release-plugin.kdl
@@ -6,6 +6,7 @@ license "Apache-2.0"
 entrypoint {
   on arch="aarch64-apple-darwin" "./target/release/typo"
   on arch="x86_64-apple-darwin" "./target/release/typo"
+  on arch="aarch64-unknown-linux-gnu" "./target/release/typo"
   on arch="x86_64-unknown-linux-gnu" "./target/release/typo"
   on arch="x86_64-pc-windows-msvc" "./target/release/typo.exe"
 }

--- a/plugins/typo/plugin.kdl
+++ b/plugins/typo/plugin.kdl
@@ -1,15 +1,16 @@
 publisher "mitre"
 name "typo"
-version "0.4.2"
+version "0.5.0"
 license "Apache-2.0"
 
 entrypoint {
   on arch="aarch64-apple-darwin" "typo"
   on arch="x86_64-apple-darwin" "typo"
+  on arch="aarch64-unknown-linux-gnu" "typo"
   on arch="x86_64-unknown-linux-gnu" "typo"
   on arch="x86_64-pc-windows-msvc" "typo.exe"
 }
 
 dependencies {
-  plugin "mitre/npm" version="^0.4" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
+  plugin "mitre/npm" version="^0.5" manifest="https://hipcheck.mitre.org/dl/plugin/mitre/npm.kdl"
 }

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -4,7 +4,7 @@ description = "SDK for writing Hipcheck plugins in Rust"
 homepage = "https://hipcheck.mitre.org"
 repository = "https://github.com/mitre/hipcheck"
 license = "Apache-2.0"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
This bumps all appropriate versions across Cargo and Hipcheck plugin manifests. It also amends `config_to_policy` and its main test, so users of the legacy configuration file will continue to get an up-to-date policy file in the
transliteration process.

Once this is merged I can tag the releases and kickoff cargo-dist release builds.

---

DO NOT MERGE THIS until the announcement blog post (in a separate PR) has been reviewed and approved, but not merged).

After this, run `cargo xtask manifest` to update the download manifests.