### PR TITLE
feat: enhance affiliation analysis.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "strum 0.27.2",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/library/hipcheck-common/src/error.rs
+++ b/library/hipcheck-common/src/error.rs
@@ -4,8 +4,11 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// An unknown error occurred, the query is in an unspecified state
-	#[error("unknown error; query is in an unspecified state")]
+	#[error("unknown error")]
 	UnspecifiedQueryState,
+
+	#[error("the query is not supported for the target")]
+	QueryUnsupportedForTarget,
 
 	/// The `PluginEngine` received a message with the unexpected status `ReplyInProgress`
 	#[error("unexpected ReplyInProgress state for query")]

--- a/library/hipcheck-common/src/lib.rs
+++ b/library/hipcheck-common/src/lib.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
+#![allow(clippy::doc_lazy_continuation)]
 
+use anyhow::anyhow;
 use std::{result::Result as StdResult, str::FromStr};
 
 pub mod chunk;

--- a/plugins/activity/src/main.rs
+++ b/plugins/activity/src/main.rs
@@ -37,6 +37,10 @@ async fn activity(engine: &mut PluginEngine, target: Target) -> Result<String> {
 		})?;
 
 	let Value::String(date_string) = value else {
+		tracing::error!(
+			"Response from mitre/git/last_commit_date was not a string: {:?}",
+			value
+		);
 		return Err(Error::UnexpectedPluginQueryInputFormat);
 	};
 	let last_commit_date: Timestamp = date_string.parse().map_err(|e| {

--- a/plugins/affiliation/Cargo.toml
+++ b/plugins/affiliation/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt"] }
 hipcheck-workspace-hack = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 hipcheck-sdk = { workspace = true, features = ["macros", "mock_engine"] }

--- a/plugins/affiliation/src/affiliator.rs
+++ b/plugins/affiliation/src/affiliator.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+	enriched_contributor::EnrichedContributor,
 	org_spec::{Matcher, OrgSpec},
 	org_types::Mode,
 };
@@ -16,20 +17,25 @@ pub struct Affiliator<'haystack> {
 }
 
 impl<'haystack> Affiliator<'haystack> {
-	/// Check whether the given string is a match for the set of hosts, based on the mode.
-	///
-	/// If independent mode is on, you're looking for strings which do not match any of
-	/// the hosts.
-	///
-	/// If affiliated mode is on, you're looking for strings which do match one of the
-	/// hosts.
-	pub fn is_match(&self, s: &str) -> bool {
-		match self.mode {
-			Mode::Independent => !self.patterns.is_match(s),
-			Mode::Affiliated => self.patterns.is_match(s),
-			Mode::All => true,
-			Mode::None => false,
+	pub fn is_match(&self, contributor: &EnrichedContributor) -> bool {
+		if self.email_is_match(&contributor.git.email) {
+			return true;
 		}
+
+		if let Some(github_account) = &contributor.github {
+			if self.email_is_match(&github_account.email) {
+				return true;
+			}
+
+			for org in &github_account.github_orgs {
+				if let Some(org_email) = &org.email
+					&& self.email_is_match(org_email) {
+						return true;
+					}
+			}
+		}
+
+		false
 	}
 
 	/// Construct a new Affiliator from a given OrgSpec (built from an Orgs.kdl file).
@@ -40,5 +46,21 @@ impl<'haystack> Affiliator<'haystack> {
 		})?;
 		let mode = spec.mode();
 		Ok(Affiliator { patterns, mode })
+	}
+
+	/// Check whether the given string is a match for the set of hosts, based on the mode.
+	///
+	/// If independent mode is on, you're looking for strings which do not match any of
+	/// the hosts.
+	///
+	/// If affiliated mode is on, you're looking for strings which do match one of the
+	/// hosts.
+	pub fn email_is_match(&self, s: &str) -> bool {
+		match self.mode {
+			Mode::Independent => !self.patterns.is_match(s),
+			Mode::Affiliated => self.patterns.is_match(s),
+			Mode::All => true,
+			Mode::None => false,
+		}
 	}
 }

--- a/plugins/affiliation/src/enriched_contributor.rs
+++ b/plugins/affiliation/src/enriched_contributor.rs
@@ -1,0 +1,16 @@
+use crate::{
+	git::{Commit, GitIdentity},
+	github::GitHubCollaborator,
+};
+
+/// An "enriched contributor" combines basic Git data with any "extra" data
+/// we could identify from an associated GitHub account.
+#[derive(Debug)]
+pub struct EnrichedContributor {
+	/// The contributor's Git data (name and email)
+	pub git: GitIdentity,
+	/// The contributor's GitHub data (if present)
+	pub github: Option<GitHubCollaborator>,
+	/// The commits they worked on as author or committer.
+	pub commits: Vec<Commit>,
+}

--- a/plugins/affiliation/src/git.rs
+++ b/plugins/affiliation/src/git.rs
@@ -3,7 +3,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
-	collections::HashMap,
 	fmt::{self, Display, Formatter},
 	result::Result as StdResult,
 };
@@ -31,12 +30,12 @@ impl Display for Commit {
 #[derive(
 	Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Hash, PartialOrd, Ord, JsonSchema,
 )]
-pub struct Contributor {
+pub struct GitIdentity {
 	pub name: String,
 	pub email: String,
 }
 
-impl Display for Contributor {
+impl Display for GitIdentity {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "{} <{}>", self.name, self.email)
 	}
@@ -44,49 +43,20 @@ impl Display for Contributor {
 
 /// Temporary data structure for looking up the contributors of a commit
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema)]
-pub struct CommitContributorView {
+pub struct GitCommitContributors {
 	pub commit: Commit,
-	pub author: Contributor,
-	pub committer: Contributor,
+	pub author: GitIdentity,
+	pub committer: GitIdentity,
 }
 
-impl CommitContributorView {
+impl GitCommitContributors {
 	/// get the author of the commit
-	pub fn author(&self) -> &Contributor {
+	pub fn author(&self) -> &GitIdentity {
 		&self.author
 	}
 
 	/// get the committer of the commit
-	pub fn committer(&self) -> &Contributor {
+	pub fn committer(&self) -> &GitIdentity {
 		&self.committer
-	}
-}
-
-/// struct for counting number of contributions made by each contributor in the repo
-pub struct ContributorFrequencyMap<'a>(HashMap<&'a Contributor, u64>);
-
-impl<'a> ContributorFrequencyMap<'a> {
-	pub fn new(capacity: Option<usize>) -> Self {
-		match capacity {
-			Some(capacity) => Self(HashMap::with_capacity(capacity)),
-			None => Self(HashMap::new()),
-		}
-	}
-
-	/// Add an affiliated_contributor to the map, update frequency for affiliated_contributor
-	/// appropriately
-	///
-	/// If the contributor is not in the HashMap, then insert and set frequency to 1
-	/// Otherwise, increment frequency by 1
-	pub fn insert(&mut self, affiliated_contributor: &'a Contributor) {
-		self.0
-			.entry(affiliated_contributor)
-			.and_modify(|count| *count += 1)
-			.or_insert(1);
-	}
-
-	/// Retrieve a non-mutable handle to the internal HashMap
-	pub fn inner(&self) -> &HashMap<&'a Contributor, u64> {
-		&self.0
 	}
 }

--- a/plugins/affiliation/src/github.rs
+++ b/plugins/affiliation/src/github.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+/// Repository collaborator data pulled from the GitHub API.
+#[derive(Debug, Default, Deserialize, Clone)]
+pub struct GitHubCollaborator {
+	#[allow(unused)]
+	/// The user's username.
+	pub login: String,
+	/// The user's public email address.
+	pub email: String,
+	#[allow(unused)]
+	/// The user's employer, as pulled from their GitHub profile.
+	pub profile_employer: Option<String>,
+	/// The GitHub organizations the user belongs to.
+	pub github_orgs: Vec<GitHubOrg>,
+}
+
+/// A single organization on GitHub.
+#[derive(Debug, Deserialize, Clone)]
+pub struct GitHubOrg {
+	#[allow(unused)]
+	/// The display name of the organization, if present.
+	pub name: Option<String>,
+	#[allow(unused)]
+	/// The username of the organization.
+	pub login: String,
+	/// The organization's email, if present.
+	pub email: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GitHubRepoContributor {
+	/// The user's email.
+	pub email: Option<String>,
+
+	/// The user's username (GitHub calls them "logins").
+	pub login: Option<String>,
+}

--- a/plugins/affiliation/src/main.rs
+++ b/plugins/affiliation/src/main.rs
@@ -4,7 +4,9 @@
 
 mod affiliator;
 mod config;
+mod enriched_contributor;
 mod git;
+mod github;
 mod org_spec;
 mod org_types;
 mod util;
@@ -12,13 +14,15 @@ mod util;
 use crate::{
 	affiliator::Affiliator,
 	config::Config,
-	git::{CommitContributorView, ContributorFrequencyMap},
+	enriched_contributor::EnrichedContributor,
+	git::GitCommitContributors,
+	github::{GitHubCollaborator, GitHubRepoContributor},
 	org_spec::OrgSpec,
 	util::fs as file,
 };
 use clap::Parser;
 use hipcheck_sdk::{LogLevel, PluginConfig, prelude::*, types::Target};
-use std::{result::Result as StdResult, sync::OnceLock};
+use std::{collections::HashMap, ops::Not, result::Result as StdResult, sync::OnceLock};
 
 // We only keep a single org-spec in memory and just make it a global.
 pub static ORGSSPEC: OnceLock<OrgSpec> = OnceLock::new();
@@ -29,52 +33,170 @@ pub static ORGSSPEC: OnceLock<OrgSpec> = OnceLock::new();
 async fn affiliation(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>> {
 	tracing::info!("running affiliation query");
 
-	// Get the OrgSpec.
 	let org_spec = &ORGSSPEC.get().ok_or_else(|| {
 		tracing::error!("tried to access config before set by Hipcheck core!");
 		Error::UnspecifiedQueryState
 	})?;
 
-	// Get the commits for the source.
 	let repo = key.local;
 
-	// query the git plugin for a summary of all git contributors in the repo
-	let contributors_value = engine.query("mitre/git/contributor_summary", repo).await?;
-	let contributors: Vec<CommitContributorView> = serde_json::from_value(contributors_value)
-		.map_err(|e| {
+	let git_commit_contributors = engine.query("mitre/git/contributor_summary", &repo).await?;
+	let git_commit_contributors: Vec<GitCommitContributors> =
+		serde_json::from_value(git_commit_contributors).map_err(|e| {
 			tracing::error!("Error parsing output from mitre/git/contributor_summary: {e}");
 			Error::UnexpectedPluginQueryInputFormat
 		})?;
 
-	// Use the OrgSpec to build an Affiliator.
 	let affiliator = Affiliator::from_spec(org_spec).map_err(|e| {
 		tracing::error!("failed to build affiliation checker from org spec: {}", e);
 		Error::UnspecifiedQueryState
 	})?;
 
-	// attempt to reduce allocations by pre-allocating room for 500 unique contributors
-	let mut contributor_freq_map = ContributorFrequencyMap::new(Some(500));
-	contributors.iter().for_each(|contributor| {
-		contributor_freq_map.insert(contributor.author());
-		// prevent double counting a person if they are both the author and committer of a commit
-		if contributor.author() != contributor.committer() {
-			contributor_freq_map.insert(contributor.committer());
-		}
-	});
+	// If we have a GitHub repo on our hands...
+	let repo_collaborators = if let Some(
+		ref repo @ RemoteGitRepo {
+			known_remote: Some(KnownRemote::GitHub { .. }),
+			..
+		},
+	) = key.remote
+	{
+		let repo_collaborators = engine
+			.query("mitre/github/repo_collaborators", repo)
+			.await?;
+		let repo_collaborators: Vec<GitHubCollaborator> =
+			serde_json::from_value(repo_collaborators).map_err(|e| {
+				tracing::error!("Error parsing output from mitre/github/repo_collaborators: {e}");
+				Error::UnspecifiedQueryState
+			})?;
+		let repo_collaborators: HashMap<String, GitHubCollaborator> = repo_collaborators
+			.into_iter()
+			.map(|collaborator| (collaborator.email.clone(), collaborator))
+			.collect();
 
-	// by default initialize to false, only need to update if a contributor is affiliated
-	let mut affiliations = vec![false; contributor_freq_map.inner().keys().len()];
-	for (idx, (contributor, count)) in contributor_freq_map.inner().iter().enumerate() {
-		if affiliator.is_match(contributor.email.as_str()) {
+		repo_collaborators
+	} else {
+		HashMap::new()
+	};
+
+	let github_repo_contributors: HashMap<String, GitHubRepoContributor> = if let Some(
+		ref repo @ RemoteGitRepo {
+			known_remote: Some(KnownRemote::GitHub { .. }),
+			..
+		},
+	) = key.remote
+	{
+		let github_repo_contributors = engine.query("mitre/github/repo_contributors", repo).await?;
+		let github_repo_contributors: Vec<GitHubRepoContributor> =
+			serde_json::from_value(github_repo_contributors).map_err(|e| {
+				tracing::error!("Error parsing output from mitre/github/repo_contributors: {e}");
+				Error::UnspecifiedQueryState
+			})?;
+		github_repo_contributors
+			.into_iter()
+			.filter_map(|contributor| {
+				contributor
+					.email
+					.as_ref()
+					.map(|email| (email.clone(), contributor.clone()))
+			})
+			.collect()
+	} else {
+		HashMap::new()
+	};
+
+	// So now that we have repo collaborators, we ought to enrich the git contributors with that
+	// information if possible.
+	//
+	// Note that git_commit_contributors organizes per-commit, but what we basically want is to
+	// organize per-contributor. So we build up a HashMap of Git identities to the fully-enriched
+	// information, with the commits bundled up in that enriched structure.
+	let mut contributors: HashMap<String, EnrichedContributor> = HashMap::new();
+
+	for git_commit_contributor in git_commit_contributors {
+		let commit = git_commit_contributor.commit.clone();
+
+		// Add or update the commit author.
+		contributors
+			.entry(git_commit_contributor.author().email.trim().to_string())
+			.and_modify(|enriched| {
+				let new_commit = commit;
+				if enriched.commits.contains(&new_commit).not() {
+					enriched.commits.push(new_commit)
+				}
+			})
+			.or_insert({
+				let contributor = git_commit_contributor.clone();
+				let author = contributor.author.clone();
+
+				EnrichedContributor {
+					git: contributor.author,
+					github: repo_collaborators.get(&author.email).cloned(),
+					commits: vec![contributor.commit],
+				}
+			});
+
+		let commit = git_commit_contributor.commit.clone();
+
+		// Add or update the commit committer.
+		contributors
+			.entry(git_commit_contributor.committer().email.trim().to_string())
+			.and_modify(|enriched| {
+				let new_commit = commit.clone();
+				if enriched.commits.contains(&new_commit).not() {
+					enriched.commits.push(new_commit)
+				}
+			})
+			.or_insert({
+				let contributor = git_commit_contributor.clone();
+				let committer = contributor.committer.clone();
+
+				EnrichedContributor {
+					git: contributor.author,
+					github: repo_collaborators.get(&committer.email).cloned(),
+					commits: vec![contributor.commit],
+				}
+			});
+	}
+
+	for (email, enriched) in &mut contributors {
+		if let Some(github_repo_contributor) = github_repo_contributors.get(email)
+			&& let Some(email) = &github_repo_contributor.email
+				&& let Some(login) = &github_repo_contributor.login
+				&& enriched.github.is_none()
+			{
+				enriched.github = Some(GitHubCollaborator {
+					login: login.clone(),
+					email: email.clone(),
+					profile_employer: None,
+					github_orgs: vec![],
+				})
+			}
+	}
+
+	// TODO: Fix deduplication.
+
+	// Drop the mutability by rebinding.
+	let contributors = contributors;
+
+	let mut affiliations = vec![false; contributors.len()];
+	for (idx, contributor) in contributors.values().enumerate() {
+		if affiliator.is_match(contributor) {
+			let num_commits = contributor.commits.len();
+			let pluralized_commits = if num_commits == 1 {
+				"commit"
+			} else {
+				"commits"
+			};
 			let concern = format!(
-				"Contributor {} ({}) has count {}",
-				contributor.name, contributor.email, count
+				"Contributor {} ({}) wrote and/or committed {} {}",
+				contributor.git.name, contributor.git.email, num_commits, pluralized_commits
 			);
 			engine.record_concern(concern);
 			// SAFETY: affiliations has the same length as contributor_freq_map
 			*affiliations.get_mut(idx).unwrap() = true;
 		}
 	}
+
 	tracing::info!("completed affiliation query");
 	Ok(affiliations)
 }
@@ -165,7 +287,7 @@ async fn main() -> Result<()> {
 
 #[cfg(test)]
 mod test {
-	use super::git::{Commit, Contributor};
+	use super::git::{Commit, GitIdentity};
 	use super::*;
 	use hipcheck_sdk::types::LocalGitRepo;
 	use pathbuf::pathbuf;
@@ -199,29 +321,29 @@ mod test {
 			committed_on: Ok("2024-06-21T21:00:00Z".to_string()),
 		};
 
-		let contributor_1 = Contributor {
+		let contributor_1 = GitIdentity {
 			name: "John Smith".to_string(),
 			email: "jsmith@mitre.org".to_string(),
 		};
 
-		let contributor_2 = Contributor {
+		let contributor_2 = GitIdentity {
 			name: "Jane Doe".to_string(),
 			email: "jdoe@gmail.com".to_string(),
 		};
 
-		let commit_1_view = CommitContributorView {
+		let commit_1_view = GitCommitContributors {
 			commit: commit_1.clone(),
 			author: contributor_1.clone(),
 			committer: contributor_1.clone(),
 		};
 
-		let commit_2_view = CommitContributorView {
+		let commit_2_view = GitCommitContributors {
 			commit: commit_2.clone(),
 			author: contributor_2.clone(),
 			committer: contributor_1.clone(),
 		};
 
-		let commit_3_view = CommitContributorView {
+		let commit_3_view = GitCommitContributors {
 			commit: commit_3.clone(),
 			author: contributor_2.clone(),
 			committer: contributor_2.clone(),
@@ -260,20 +382,7 @@ mod test {
 		assert_eq!(num_affiliated, 1);
 		assert_eq!(
 			concerns[0],
-			"Contributor Jane Doe (jdoe@gmail.com) has count 2"
+			"Contributor Jane Doe (jdoe@gmail.com) wrote and/or committed 2 commits"
 		)
-	}
-
-	#[test]
-	fn test_affiliated_contributor_freq_map() {
-		let mut map = ContributorFrequencyMap::new(Some(2));
-		let contributor = Contributor {
-			name: "John Smith".to_owned(),
-			email: "john.smith@example.com".to_owned(),
-		};
-		map.insert(&contributor);
-		assert_eq!(*map.inner().get(&contributor).unwrap(), 1);
-		map.insert(&contributor);
-		assert_eq!(*map.inner().get(&contributor).unwrap(), 2);
 	}
 }

--- a/plugins/fuzz/src/main.rs
+++ b/plugins/fuzz/src/main.rs
@@ -10,10 +10,11 @@ use std::result::Result as StdResult;
 async fn fuzz(engine: &mut PluginEngine, key: Target) -> Result<Value> {
 	tracing::info!("running fuzz query");
 	if let Some(remote) = &key.remote {
-		let fuzz = engine.query("mitre/github", remote.clone()).await;
+		let fuzz = engine.query("mitre/github/has_fuzz", remote.clone()).await;
 		tracing::info!("completed fuzz query");
 		fuzz
 	} else {
+		tracing::error!("key target was not for a remote: '{:?}'", key);
 		Err(Error::UnexpectedPluginQueryInputFormat)
 	}
 }
@@ -93,7 +94,7 @@ mod test {
 		let known_remote = target.remote.as_ref().unwrap().clone();
 		let output = true;
 		let mut mock_reponses = MockResponses::new();
-		mock_reponses.insert("mitre/github", known_remote, Ok(output))?;
+		mock_reponses.insert("mitre/github/has_fuzz", known_remote, Ok(output))?;
 		Ok(mock_reponses)
 	}
 

--- a/plugins/github/src/github/graphql/custom_scalars.rs
+++ b/plugins/github/src/github/graphql/custom_scalars.rs
@@ -3,6 +3,3 @@
 //! Helper types used for GraphQL derives.
 //!
 //! These map scalar types from `types.graphql` to Rust types.
-
-#[allow(clippy::upper_case_acronyms)]
-pub type URI = url::Url;

--- a/plugins/github/src/github/graphql/mod.rs
+++ b/plugins/github/src/github/graphql/mod.rs
@@ -3,6 +3,7 @@
 //! Logic for interacting with the GitHub GraphQL API.
 
 mod custom_scalars;
+pub mod repo_collaborators;
 pub mod reviews;
 pub mod user_orgs;
 

--- a/plugins/github/src/github/graphql/repo_collaborators.rs
+++ b/plugins/github/src/github/graphql/repo_collaborators.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use self::user_orgs::{ResponseData, Variables};
+use self::repo_collaborators::{ResponseData, Variables};
 use crate::{github::graphql::GH_API_V4, tls::authenticated_agent::AuthenticatedAgent};
 use anyhow::{Result, anyhow};
 use graphql_client::{GraphQLQuery, QueryBody, Response};
@@ -12,48 +12,81 @@ use serde_json::{from_value as from_json_value, to_value as to_json_value};
 #[derive(GraphQLQuery)]
 #[graphql(
 	schema_path = "src/github/graphql/schemas/types.graphql",
-	query_path = "src/github/graphql/schemas/user_orgs.graphql",
+	query_path = "src/github/graphql/schemas/repo_collaborators.graphql",
 	response_derives = "Debug",
 	custom_scalars_module = "crate::github::graphql::custom_scalars"
 )]
-pub struct UserOrgs;
+pub struct RepoCollaborators;
 
 /// Get organization data for the target user.
-pub fn get_user_orgs(agent: &AuthenticatedAgent<'_>, login: &str) -> Result<UserOrgData> {
-	let query = UserOrgs::build_query(Variables {
-		login: login.to_owned(),
+pub fn get_repo_collaborators(
+	agent: &AuthenticatedAgent<'_>,
+	owner: &str,
+	name: &str,
+) -> Result<Vec<Collaborator>> {
+	let query = RepoCollaborators::build_query(Variables {
+		owner: owner.to_owned(),
+		name: name.to_owned(),
 	});
 
 	let body = make_request(agent, query)?;
 
-	let user = body
+	if let Some(errors) = body.errors {
+		for error in errors {
+			tracing::error!("mitre/github/repo_collaborators, error from GitHub API: {error}")
+		}
+	}
+
+	let repository = body
 		.data
 		.ok_or_else(|| anyhow!("missing response data from GitHub"))?
-		.user
-		.ok_or_else(|| anyhow!("user not found on GitHub"))?;
+		.repository
+		.ok_or_else(|| anyhow!("repository not found on GitHub"))?;
 
-	let profile_employer = user.company;
+	let Some(collaborators) = repository.collaborators else {
+		return Err(anyhow!("no collaborators for repository"));
+	};
 
-	let github_orgs = user
-		.organizations
-		.nodes
-		.unwrap_or_default()
+	let Some(collaborators) = collaborators.nodes else {
+		return Err(anyhow!("no collaborators for repository"));
+	};
+
+	let collaborators = collaborators
 		.into_iter()
-		.filter_map(|org| {
-			let org = org?;
+		.filter_map(|user| {
+			// Filter out invalid users.
+			let user = user?;
 
-			Some(GitHubOrg {
-				name: org.name,
-				login: org.login,
-				email: org.email,
+			let login = user.login;
+			let email = user.email;
+			let profile_employer = user.company;
+
+			let github_orgs = user
+				.organizations
+				.nodes
+				.unwrap_or_default()
+				.into_iter()
+				.filter_map(|org| {
+					let org = org?;
+
+					Some(GitHubOrg {
+						name: org.name,
+						login: org.login,
+						email: org.email,
+					})
+				})
+				.collect();
+
+			Some(Collaborator {
+				login,
+				email,
+				profile_employer,
+				github_orgs,
 			})
 		})
 		.collect();
 
-	Ok(UserOrgData {
-		profile_employer,
-		github_orgs,
-	})
+	Ok(collaborators)
 }
 
 /// Make a request to the GitHub API.
@@ -80,9 +113,13 @@ fn make_request(
 	}
 }
 
-/// User's organization membership data pulled from the GitHub API.
+/// Repository collaborator data pulled from the GitHub API.
 #[derive(Debug, Default, Serialize, JsonSchema)]
-pub struct UserOrgData {
+pub struct Collaborator {
+	/// The user's username.
+	pub login: String,
+	/// The user's public email address.
+	pub email: String,
 	/// The user's employer, as pulled from their GitHub profile.
 	pub profile_employer: Option<String>,
 	/// The GitHub organizations the user belongs to.
@@ -96,6 +133,6 @@ pub struct GitHubOrg {
 	pub name: Option<String>,
 	/// The username of the organization.
 	pub login: String,
-	/// The organization's email, if present.
+	/// The organization's public email, if present.
 	pub email: Option<String>,
 }

--- a/plugins/github/src/github/graphql/reviews.rs
+++ b/plugins/github/src/github/graphql/reviews.rs
@@ -122,6 +122,7 @@ fn get_cursor(body: &Response<ResponseData>) -> Cursor {
 /// Extract any PRs from the GitHub API response data.
 fn get_prs(body: Response<ResponseData>) -> Result<Vec<RawPull>> {
 	// Get the repo info from the response.
+
 	let prs = body
 		.data
 		.ok_or_else(|| anyhow!("missing response data from GitHub"))?

--- a/plugins/github/src/github/graphql/schemas/repo_collaborators.graphql
+++ b/plugins/github/src/github/graphql/schemas/repo_collaborators.graphql
@@ -1,0 +1,26 @@
+query RepoCollaborators($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+        # Want to include both direct (part of the owning org) and indirect collaborators.
+        collaborators(affiliation: ALL) {
+            nodes {
+                # The user's "login" (their username).
+                login
+                # The user's email address, which is guaranteed to be present.
+                email
+                # Company set in user's profile, if any.
+                company
+                # GitHub Organizations the user is a member of, if any, capped at 100.
+                organizations(
+                    first: 100
+                    orderBy: { direction: DESC, field: LOGIN }
+                ) {
+                    nodes {
+                        name
+                        login
+                        email
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/github/src/github/graphql/schemas/types.graphql
+++ b/plugins/github/src/github/graphql/schemas/types.graphql
@@ -37,6 +37,46 @@ A repository contains the content for a project.
 """
 type Repository {
     """
+    A list of collaborators associated with the repository.
+    """
+    collaborators(
+        """
+        Collaborators affiliation level with a repository.
+        """
+        affiliation: CollaboratorAffiliation
+
+        """
+        Returns the elements in the list that come after the specified cursor.
+        """
+        after: String
+
+        """
+        Returns the elements in the list that come before the specified cursor.
+        """
+        before: String
+
+        """
+        Returns the first _n_ elements from the list.
+        """
+        first: Int
+
+        """
+        Returns the last _n_ elements from the list.
+        """
+        last: Int
+
+        """
+        The login of one specific collaborator.
+        """
+        login: String
+
+        """
+        Filters users with query on user name and login
+        """
+        query: String
+    ): RepositoryCollaboratorConnection
+
+    """
     A list of pull requests that have been opened in the repository.
     """
     pullRequests(
@@ -56,9 +96,6 @@ type Repository {
         states: [PullRequestState!]
     ): PullRequestConnection!
 
-    # urlRequests(
-    #   url: URI
-    # ): PullRequestConnection!
     pullRequest(number: Int): PullRequest
 }
 
@@ -308,6 +345,16 @@ type User {
     company: String
 
     """
+    The user's publicly visible profile email.
+    """
+    email: String!
+
+    """
+    The username used to login.
+    """
+    login: String!
+
+    """
     A list of organizations the user belongs to.
     """
     organizations(
@@ -363,21 +410,6 @@ An account on GitHub, with one or more owners, that has repositories, members an
 """
 type Organization {
     """
-    A list of domains owned by the organization.
-    """
-    domains(
-        """
-        Returns the elements in the list that come after the specified cursor.
-        """
-        after: String
-
-        """
-        Returns the first _n_ elements from the list.
-        """
-        first: Int
-    ): VerifiableDomainConnection
-
-    """
     The organization's login name.
     """
     login: String!
@@ -386,41 +418,11 @@ type Organization {
     The organization's public profile name.
     """
     name: String
-}
-
-"""
-The connection type for VerifiableDomain.
-"""
-type VerifiableDomainConnection {
-    """
-    A list of nodes.
-    """
-    nodes: [VerifiableDomain]
 
     """
-    Information to aid in pagination.
+    The organization's public email.
     """
-    pageInfo: PageInfo!
-}
-
-"""
-A domain that can be verified or approved for an organization or an enterprise.
-"""
-type VerifiableDomain {
-    """
-    The unicode encoded domain.
-    """
-    domain: URI!
-
-    """
-    Whether or not the domain is approved.
-    """
-    isApproved: Boolean!
-
-    """
-    Whether or not the domain is verified.
-    """
-    isVerified: Boolean!
+    email: String
 }
 
 """
@@ -442,3 +444,39 @@ type PageInfo {
 An RFC 3986, RFC 3987, and RFC 6570 (level 4) compliant URI string.
 """
 scalar URI
+
+"""
+The connection type for User.
+"""
+type RepositoryCollaboratorConnection {
+    """
+    A list of edges.
+    """
+    edges: [RepositoryCollaboratorEdge]
+
+    """
+    A list of nodes.
+    """
+    nodes: [User]
+
+    """
+    Information to aid in pagination.
+    """
+    pageInfo: PageInfo!
+
+    """
+    Identifies the total count of items in the connection.
+    """
+    totalCount: Int!
+}
+
+"""
+Represents a user who is a collaborator of a repository.
+"""
+type RepositoryCollaboratorEdge {
+    """
+    A cursor for use in pagination.
+    """
+    cursor: String!
+    node: User!
+}

--- a/plugins/github/src/github/graphql/schemas/user_orgs.graphql
+++ b/plugins/github/src/github/graphql/schemas/user_orgs.graphql
@@ -7,14 +7,7 @@ query UserOrgs($login: String!) {
             nodes {
                 name
                 login
-                # Domains associated with an org, if any, capped at 100.
-                domains(first: 100) {
-                    nodes {
-                        domain
-                        isApproved
-                        isVerified
-                    }
-                }
+                email
             }
         }
     }

--- a/plugins/github/src/github/mod.rs
+++ b/plugins/github/src/github/mod.rs
@@ -6,10 +6,14 @@ pub mod rest;
 use crate::{
 	github::{
 		graphql::{
+			repo_collaborators::{Collaborator, get_repo_collaborators},
 			reviews::{GitHubPullRequest, get_reviews},
 			user_orgs::{UserOrgData, get_user_orgs},
 		},
-		rest::code_search::check_fuzzing,
+		rest::{
+			code_search::check_fuzzing,
+			repo_contributors::{Contributor, get_repo_contributors},
+		},
 	},
 	tls::authenticated_agent::AuthenticatedAgent,
 };
@@ -36,5 +40,13 @@ impl<'a> GitHub<'a> {
 
 	pub fn get_user_orgs(&self, user_login: &str) -> Result<UserOrgData> {
 		get_user_orgs(&self.agent, user_login)
+	}
+
+	pub fn get_repo_collaborators(&self, owner: &str, name: &str) -> Result<Vec<Collaborator>> {
+		get_repo_collaborators(&self.agent, owner, name)
+	}
+
+	pub fn get_repo_contributors(&self, owner: &str, name: &str) -> Result<Vec<Contributor>> {
+		get_repo_contributors(&self.agent, owner, name)
 	}
 }

--- a/plugins/github/src/github/rest/mod.rs
+++ b/plugins/github/src/github/rest/mod.rs
@@ -3,3 +3,4 @@
 //! Logic for interacting with the GitHub REST API.
 
 pub mod code_search;
+pub mod repo_contributors;

--- a/plugins/github/src/github/rest/repo_contributors.rs
+++ b/plugins/github/src/github/rest/repo_contributors.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tls::authenticated_agent::AuthenticatedAgent;
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Check if the given repo participates in OSS-Fuzz.
+pub fn get_repo_contributors(
+	agent: &AuthenticatedAgent<'_>,
+	owner: &str,
+	repo: &str,
+) -> Result<Vec<Contributor>> {
+	let endpoint = endpoint(owner, repo);
+
+	let contributors = agent
+		.get(&endpoint)
+		.call()?
+		.into_json::<Value>()
+		.map_err(|_| {
+			anyhow!(
+				"unable to get repository contributors for GitHub repo '{}/{}'",
+				owner,
+				repo
+			)
+		})?;
+
+	let contributors = serde_json::from_value(contributors)?;
+
+	Ok(contributors)
+}
+
+fn endpoint(owner: &str, repo: &str) -> String {
+	format!(
+		"https://api.github.com/repos/{}/{}/contributors",
+		owner, repo
+	)
+}
+
+/// Contributor to the repository from the GitHub API.
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct Contributor {
+	/// The number of contributions they've made to the repository.
+	///
+	/// (It's not clear how GitHub counts this)
+	contributions: i64,
+
+	/// What "type" of user they are for the repository.
+	///
+	/// The example in the GitHub Docs only shows "User" as a possible value.
+	/// I'm guessing this is a way of indicating who may be an administrator.
+	#[serde(rename = "type")]
+	contributor_type: String,
+
+	/// The user's email.
+	email: Option<String>,
+
+	/// The user's username (GitHub calls them "logins").
+	login: Option<String>,
+
+	/// The user's display name.
+	name: Option<String>,
+}

--- a/plugins/github/src/main.rs
+++ b/plugins/github/src/main.rs
@@ -10,7 +10,10 @@ use crate::{
 	config::CONFIG,
 	github::{
 		GitHub,
-		graphql::{reviews::GitHubPullRequest, user_orgs::UserOrgData},
+		graphql::{
+			repo_collaborators::Collaborator, reviews::GitHubPullRequest, user_orgs::UserOrgData,
+		},
+		rest::repo_contributors::Contributor,
 	},
 };
 use hipcheck_sdk::prelude::*;
@@ -39,7 +42,9 @@ impl Plugin for GitHubPlugin {
 	queries! {
 		pr_reviews,
 		has_fuzz,
-		user_orgs
+		repo_contributors,
+		user_orgs,
+		repo_collaborators
 	}
 }
 
@@ -63,6 +68,34 @@ async fn has_fuzz(_e: &mut PluginEngine, repo: RemoteGitRepo) -> Result<bool> {
 	let github = GitHub::new(token)?;
 	let fuzzing = github.check_fuzzing(repo.url.as_str())?;
 	Ok(fuzzing)
+}
+
+/// Get the contributors to a repository.
+#[query]
+async fn repo_contributors(_e: &mut PluginEngine, repo: RemoteGitRepo) -> Result<Vec<Contributor>> {
+	let Some(KnownRemote::GitHub { owner, repo }) = &repo.known_remote else {
+		return Err(Error::InvalidQueryTargetFormat);
+	};
+
+	let token = CONFIG.api_token()?;
+	let github = GitHub::new(token)?;
+	let contributors = github.get_repo_contributors(owner, repo)?;
+	Ok(contributors)
+}
+
+#[query]
+async fn repo_collaborators(
+	_e: &mut PluginEngine,
+	repo: RemoteGitRepo,
+) -> Result<Vec<Collaborator>> {
+	let Some(KnownRemote::GitHub { owner, repo }) = &repo.known_remote else {
+		return Err(Error::InvalidQueryTargetFormat);
+	};
+
+	let token = CONFIG.api_token()?;
+	let github = GitHub::new(token)?;
+	let contributors = github.get_repo_collaborators(owner, repo)?;
+	Ok(contributors)
 }
 
 /// Get the organizations to which a user belongs.

--- a/plugins/identity/src/main.rs
+++ b/plugins/identity/src/main.rs
@@ -89,8 +89,10 @@ async fn identity(engine: &mut PluginEngine, key: Target) -> Result<Vec<bool>> {
 			tracing::error!("failed to get last commits for identity metric: {}", e);
 			Error::UnspecifiedQueryState
 		})?;
-	let commits: Vec<Commit> =
-		serde_json::from_value(value).map_err(|_| Error::UnexpectedPluginQueryInputFormat)?;
+	let commits: Vec<Commit> = serde_json::from_value(value).map_err(|e| {
+		tracing::error!("Error parsing mitre/git/commits response: {e}");
+		Error::UnexpectedPluginQueryInputFormat
+	})?;
 	let mut res = vec![];
 	for c in commits {
 		let key = DetailedGitRepo {

--- a/plugins/npm/src/main.rs
+++ b/plugins/npm/src/main.rs
@@ -48,8 +48,8 @@ impl NpmDependencies {
 				Ok(NpmDependencies { language, deps })
 			}
 			Lang::Unknown => {
-				tracing::error!("can't identify a known language in the repository");
-				Err(Error::UnspecifiedQueryState)
+				tracing::warn!("can't identify a known language in the repository");
+				Err(Error::QueryUnsupportedForTarget)
 			}
 		}
 	}

--- a/sdk/rust/src/engine.rs
+++ b/sdk/rust/src/engine.rs
@@ -113,14 +113,18 @@ impl PluginEngine {
 			let mut results = Vec::with_capacity(input.len());
 			for i in input {
 				match self.mock_responses.0.get(&(target.clone(), i)) {
-					Some(res) => {
-						match res {
-							Ok(val) => results.push(val.clone()),
-							// TODO: since Error is not Clone, is there a better way to deal with this
-							Err(_) => return Err(Error::UnexpectedPluginQueryInputFormat),
+					Some(res) => match res {
+						Ok(val) => results.push(val.clone()),
+						Err(e) => {
+							tracing::error!("Error parsing mock_engine response: {e}");
+							return Err(Error::UnexpectedPluginQueryInputFormat);
 						}
+					},
+					None => {
+						return Err(Error::UnknownPluginQuery(
+							target.to_string().into_boxed_str(),
+						));
 					}
-					None => return Err(Error::UnknownPluginQuery),
 				}
 			}
 			Ok(results)
@@ -298,7 +302,13 @@ impl PluginEngine {
 			.filter_map(|x| if x.name == name { Some(x.inner) } else { None })
 			.next()
 			.or_else(|| plugin.default_query())
-			.ok_or_else(|| Error::UnknownPluginQuery)?;
+			.ok_or_else(|| {
+				if name.is_empty() {
+					Error::NoDefaultQuery
+				} else {
+					Error::UnknownPluginQuery(name.clone().into_boxed_str())
+				}
+			})?;
 
 		#[cfg(feature = "print-timings")]
 		let _0 = crate::benchmarking::print_scope_time!(format!("{}/{}", P::NAME, name));
@@ -326,10 +336,9 @@ impl PluginEngine {
 	where
 		P: Plugin,
 	{
-		use crate::error::Error::*;
 		if let Err(e) = self.handle_session_fallible(plugin).await {
 			let res_err_send = match e {
-				FailedToSendQueryFromSessionToServer(_) => {
+				Error::FailedToSendQueryFromSessionToServer(_) => {
 					tracing::error!("Failed to send message to Hipcheck core, analysis will hang.");
 					return;
 				}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -11,7 +11,7 @@ use tonic::Status as TonicStatus;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	/// An unknown error occurred, the query is in an unspecified state
-	#[error("unknown error; query is in an unspecified state")]
+	#[error("unknown error")]
 	UnspecifiedQueryState,
 
 	/// The `PluginEngine` received a message with the unexpected status `ReplyInProgress`
@@ -56,11 +56,17 @@ pub enum Error {
 	UnexpectedPluginQueryOutputFormat,
 
 	/// The `PluginEngine` received a request for an unknown query endpoint
-	#[error("could not determine which plugin query to run")]
-	UnknownPluginQuery,
+	#[error("could not determine which plugin query to run for '{0}'")]
+	UnknownPluginQuery(Box<str>),
 
 	#[error("invalid format for QueryTarget")]
 	InvalidQueryTargetFormat,
+
+	#[error("the plugin was called with a default query, but none is defined")]
+	NoDefaultQuery,
+
+	#[error("the query is unsupported for the target")]
+	QueryUnsupportedForTarget,
 
 	#[error(transparent)]
 	Unspecified { source: DynError },
@@ -78,6 +84,7 @@ impl From<hipcheck_common::error::Error> for Error {
 			MoreAfterQueryComplete { id } => Error::MoreAfterQueryComplete { id },
 			InvalidJsonInQueryKey(s) => Error::InvalidJsonInQueryKey(Box::new(s)),
 			InvalidJsonInQueryOutput(s) => Error::InvalidJsonInQueryOutput(Box::new(s)),
+			QueryUnsupportedForTarget => Error::QueryUnsupportedForTarget,
 		}
 	}
 }


### PR DESCRIPTION
This commit introduces a new enhanced form of affiliation analysis, which incorporates information from GitHub's API when we're able to connect a Git user to a GitHub user.